### PR TITLE
forward and backward policies

### DIFF
--- a/gflownet.py
+++ b/gflownet.py
@@ -1018,17 +1018,6 @@ class GFlowNetAgent:
             .pow(2)
             .mean()
         )
-        for p1, p2 in zip(
-            self.forward_policy.model.parameters(),
-            self.backward_policy.model.parameters(),
-        ):
-            if p1.data.ne(p2.data).sum() > 0:
-                # p1.data.ne(p2.data).sum() > 0:
-                print("\n")
-                print(p1.shape)
-                print(p2.shape)
-                print(p1)
-                print(p2)
         return loss, loss, loss
 
     def unpack_terminal_states(self, batch):
@@ -1347,7 +1336,6 @@ def make_opt(params, Z, args):
     """
     Set up the optimizer
     """
-    # params = list(params)
     params = params
     if not len(params):
         return None


### PR DESCRIPTION
i have tested the code. Below are the stats
With flowmatch loss, logq=-1 [[comet](https://www.comet.com/nikita-0209/gfn-grid/b3f493ed93c94988bd38935f724943e8?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step)]
With tb loss,
- shared_network for forward and backward policies =-0.89 [[comet](https://www.comet.com/nikita-0209/gfn-grid/a5284111131b4fb08358bb13551da069?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step)]
- individual mlpsfor forward and backward = 0.83 [[comet](https://www.comet.com/nikita-0209/gfn-grid/644f9c228d894bfd87079f3d0dc0a9bf?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step)]
- uniform backward policy and mlp  as forward policy = 0.85 [[comet](https://www.comet.com/nikita-0209/gfn-grid/c784f7ed92fa4c649bbead7662920217?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step)]

To Do:
1. add masks for parents and then update backward_sample()
2. do we need to save the backward mlp (if used)? I don't tthink so because just the forward is used in sampling.
3. Some combinations won't make sense. Like choosing backward policy as mlp when loss is flowmatch. Need to think about the best way to add this check. Perhaps the config files in hydra can help?