### PR TITLE
correct traj balance

### DIFF
--- a/gflownet.py
+++ b/gflownet.py
@@ -446,8 +446,6 @@ class GFlowNetAgent:
             print(f"\tMin score: {self.buffer.test['energies'].min()}")
             print(f"\tMax score: {self.buffer.test['energies'].max()}")
         # Model
-        # self.forward_policy = forward_policy("mlp")
-        # self.backward_policy = backward_policy("mlp", shared_weight = True)
         self.model = make_mlp(
             [self.env.obs_dim]
             + [args.gflownet.n_hid] * args.gflownet.n_layers
@@ -693,9 +691,7 @@ class GFlowNetAgent:
                                 tf(parents),
                                 tl(parents_a),
                                 env.done,
-                                tl(
-                                    [env.id] * len(parents)
-                                ),  # repeats that env id len(parents) number of times, no multiplication
+                                tl([env.id] * len(parents)),
                                 tl([env.n_actions - 1]),
                                 tb([mask]),
                             ]
@@ -1304,7 +1300,9 @@ def empirical_distribution_error(env, visited):
         hist[s] += 1
     Z = sum([hist[s] for s in states_term])
     estimated_density = tf([hist[s] / Z for s in states_term])
+    # L1 error
     l1 = abs(estimated_density - true_density).mean().item()
+    # KL divergence
     kl = (true_density * torch.log(estimated_density / true_density)).sum().item()
     return l1, kl
 

--- a/gflownet.py
+++ b/gflownet.py
@@ -446,6 +446,8 @@ class GFlowNetAgent:
             print(f"\tMin score: {self.buffer.test['energies'].min()}")
             print(f"\tMax score: {self.buffer.test['energies'].max()}")
         # Model
+        # self.forward_policy = forward_policy("mlp")
+        # self.backward_policy = backward_policy("mlp", shared_weight = True)
         self.model = make_mlp(
             [self.env.obs_dim]
             + [args.gflownet.n_hid] * args.gflownet.n_layers
@@ -491,6 +493,7 @@ class GFlowNetAgent:
 
     def parameters(self):
         return self.model.parameters()
+
 
     def forward_sample(self, envs, times, policy="model", model=None, temperature=1.0):
         """
@@ -1335,8 +1338,19 @@ if __name__ == "__main__":
     _, override_args = parser.parse_known_args()
     parser, args2config = add_args(parser)
     args = parser.parse_args()
+    # Begin Delete
+    args.yaml_config = "/home/mila/n/nikita.saxena/ActiveLearningPipeline/config/grid/default.yml"
+    args.workdir = "/home/mila/n/nikita.saxena/ActiveLearningPipeline/dummy"
+    args.overwrite_workdir = True
+    # End Delete
     config = get_config(args, override_args, args2config)
     config = process_config(config)
+    # Begin Delete
+    config.gflownet.comet.skip = True
+    config.gflownet.loss = "tb"
+    config.no_lightweight = True
+    # config.gflownet.
+    # End Delete
     print("Config file: " + config.yaml_config)
     if config.workdir is not None:
         print("Working dir: " + config.workdir)

--- a/gflownetenv.py
+++ b/gflownetenv.py
@@ -277,7 +277,7 @@ class GFlowNetEnv:
             state = self.state
         return False
 
-    def get_mask_invalid_actions(self, state=None, done=None):
+    def get_mask_invalid_actions(self, state=None, done=None, obs2state=None):
         """
         Returns a vector of length the action space + 1: True if forward action is invalid
         given the current state, False otherwise.
@@ -289,7 +289,7 @@ class GFlowNetEnv:
         mask = [False for _ in range(len(self.action_space) + 1)]
         return mask
 
-    def get_backward_mask(self, state=None, done=None, obs2state=False):
+    def get_backward_mask(self, state=None, done=None, obs2state=None):
         """
         Returns a vector of length the action space + 1: True if forward action is invalid
         given the current state, False otherwise.

--- a/gflownetenv.py
+++ b/gflownetenv.py
@@ -279,7 +279,19 @@ class GFlowNetEnv:
 
     def get_mask_invalid_actions(self, state=None, done=None):
         """
-        Returns a vector of length the action space + 1: True if action is invalid
+        Returns a vector of length the action space + 1: True if forward action is invalid
+        given the current state, False otherwise.
+        """
+        if state is None:
+            state = self.state
+        if done is None:
+            done = self.done
+        mask = [False for _ in range(len(self.action_space) + 1)]
+        return mask
+
+    def get_backward_mask(self, state=None, done=None, obs2state=False):
+        """
+        Returns a vector of length the action space + 1: True if forward action is invalid
         given the current state, False otherwise.
         """
         if state is None:

--- a/grid.py
+++ b/grid.py
@@ -95,9 +95,9 @@ class Grid(GFlowNetEnv):
             actions += actions_r
         return actions
 
-    def get_mask_invalid_actions(self, state=None, done=None):
+    def get_mask_invalid_actions(self, state=None, done=None, obs2state=False):
         """
-        Returns a vector of length the action space + 1: True if action is invalid
+        Returns a vector of length the action space + 1: True if forward action is invalid
         given the current state, False otherwise.
         """
         if state is None:
@@ -106,10 +106,35 @@ class Grid(GFlowNetEnv):
             done = self.done
         if done:
             return [True for _ in range(len(self.action_space) + 1)]
+        if obs2state == True:
+            state = self.obs2state(state.cpu().numpy())
         mask = [False for _ in range(len(self.action_space) + 1)]
         for idx, a in enumerate(self.action_space):
             for d in a:
                 if state[d] + 1 >= self.length:
+                    mask[idx] = True
+                    break
+        return mask
+
+    def get_backward_mask(self, state=None, done=None, obs2state=False):
+        """
+        Returns a vector of length the action space + 1: True if backward action is invalid
+        given the current state, False otherwise.
+        """
+        if state is None:
+            state = self.state.copy()
+        if done is None:
+            done = self.done
+        if done:
+            mask = [True for _ in range(len(self.action_space))]
+            mask.append(False)
+            return mask
+        if obs2state == True:
+            state = self.obs2state(state.cpu().numpy())
+        mask = [False for _ in range(len(self.action_space) + 1)]
+        for idx, a in enumerate(self.action_space):
+            for d in a:
+                if state[d] - 1 < 0:
                     mask[idx] = True
                     break
         return mask


### PR DESCRIPTION
We had missed out on including masks while computing the forward and backward log probs. It is necessary because taking into consideration the masks skews the distribution over actions such that a very less probability is assigned on the actions that aren't valid, and a higher probability is assigned to the valid actions
For example, for the terminal states, `done=True` so the only possible backward action is `2`, hence the log prob for this action must be 0, which is enforced by assigning high negative values to the other "possible" but invalid actions.
[[comet](https://www.comet.com/nikita-0209/gfn-grid/f5a969a6c90940adb40d0af7314760d7?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step)]

Remarks:
- This is not the cleanest version of code. As discussed in one of our meetings, we could incorporate a more sophisticated way of choosing the forward and backward masks.
- TODO: Implement backward masks for aptamers as well.