### PR TITLE
Simplify obtention of forward and backward masks in trajectory balance loss

### DIFF
--- a/gflownet.py
+++ b/gflownet.py
@@ -829,7 +829,7 @@ class GFlowNetAgent:
 
         return loss, term_loss, flow_loss
 
-    def trajectorybalance_loss(self, it, batch):
+    def trajectorybalance_loss(self, it, batch, loginf=1000):
         """
         Computes the trajectory balance loss of a batch
 
@@ -852,6 +852,7 @@ class GFlowNetAgent:
         flow_loss : float
             Loss of the intermediate nodes only
         """
+        loginf = tf([loginf])
         # Unpack batch
         (
             states,
@@ -862,7 +863,7 @@ class GFlowNetAgent:
             done,
             path_id_parents,
             _,
-            _,
+            masks
         ) = zip(*batch)
         # Keep only parents in trajectory
         parents = [
@@ -870,7 +871,7 @@ class GFlowNetAgent:
         ]
         path_id = torch.cat([el[:1] for el in path_id_parents])
         # Concatenate lists of tensors
-        states, actions, rewards, parents, done = map(
+        states, actions, rewards, parents, done, masks = map(
             torch.cat,
             [
                 states,
@@ -878,9 +879,9 @@ class GFlowNetAgent:
                 rewards,
                 parents,
                 done,
+                masks,
             ],
         )
-        loginf = tf([1000])
         # Forward trajectories
         logits_parent = self.model(parents)[..., : len(self.env.action_space) + 1]
         mask_parents = tb(

--- a/gflownet.py
+++ b/gflownet.py
@@ -885,7 +885,6 @@ class GFlowNetAgent:
             ],
         )
         # Build forward masks from state masks
-        mask_source = masks[torch.where((state_id == 0) & (path_id == 0))]
         masks_f = torch.cat(
             [
                 masks[torch.where((state_id == sid - 1) & (path_id == pid))]

--- a/gflownet.py
+++ b/gflownet.py
@@ -372,7 +372,7 @@ class GFlowNetAgent:
             )
         else:
             raise NotImplemented
-        self.mask_source = tb(self.env.get_mask_invalid_actions())
+        self.mask_source = tb([self.env.get_mask_invalid_actions()])
         self.buffer = Buffer(self.env, replay_capacity=args.gflownet.replay_capacity)
         # Comet
         if (
@@ -895,12 +895,9 @@ class GFlowNetAgent:
             ]
         )
         # Forward trajectories
-        logits_parent = self.model(parents)[..., : len(self.env.action_space) + 1]
-        mask_parents = tb(
-            [self.env.get_mask_invalid_actions(parent, 0, True) for parent in parents]
-        )
-        logits_parent[mask_parents] = -loginf
-        logprobs_f = self.logsoftmax(logits_parent)[
+        logits_parents = self.model(parents)[..., : len(self.env.action_space) + 1]
+        logits_parents[masks_parents] = -loginf
+        logprobs_f = self.logsoftmax(logits_parents)[
             torch.arange(parents.shape[0]), actions
         ]
         sumlogprobs_f = tf(

--- a/gflownet.py
+++ b/gflownet.py
@@ -900,19 +900,19 @@ class GFlowNetAgent:
         for idx, pa in enumerate(parents_a):
             masks_b[idx, pa] = False
         # Forward trajectories
-        logits_parents = self.model(parents)[..., : len(self.env.action_space) + 1]
-        logits_parents[masks_f] = -loginf
-        logprobs_f = self.logsoftmax(logits_parents)[
-            torch.arange(logits_parents.shape[0]), actions
+        logits_f = self.model(parents)[..., : len(self.env.action_space) + 1]
+        logits_f[masks_f] = -loginf
+        logprobs_f = self.logsoftmax(logits_f)[
+            torch.arange(logits_f.shape[0]), actions
         ]
         sumlogprobs_f = tf(
             torch.zeros(len(torch.unique(path_id, sorted=True)))
         ).index_add_(0, path_id, logprobs_f)
         # Backward trajectories
-        logits_states = self.model(states)[..., len(self.env.action_space) + 1 :]
-        logits_states[masks_b] = -loginf
-        logprobs_b = self.logsoftmax(logits_states)[
-            torch.arange(states.shape[0]), actions
+        logits_b = self.model(states)[..., len(self.env.action_space) + 1 :]
+        logits_b[masks_b] = -loginf
+        logprobs_b = self.logsoftmax(logits_b)[
+            torch.arange(logits_b.shape[0]), actions
         ]
         sumlogprobs_b = tf(
             torch.zeros(len(torch.unique(path_id, sorted=True)))

--- a/gflownet.py
+++ b/gflownet.py
@@ -902,18 +902,14 @@ class GFlowNetAgent:
         # Forward trajectories
         logits_f = self.model(parents)[..., : len(self.env.action_space) + 1]
         logits_f[masks_f] = -loginf
-        logprobs_f = self.logsoftmax(logits_f)[
-            torch.arange(logits_f.shape[0]), actions
-        ]
+        logprobs_f = self.logsoftmax(logits_f)[torch.arange(logits_f.shape[0]), actions]
         sumlogprobs_f = tf(
             torch.zeros(len(torch.unique(path_id, sorted=True)))
         ).index_add_(0, path_id, logprobs_f)
         # Backward trajectories
         logits_b = self.model(states)[..., len(self.env.action_space) + 1 :]
         logits_b[masks_b] = -loginf
-        logprobs_b = self.logsoftmax(logits_b)[
-            torch.arange(logits_b.shape[0]), actions
-        ]
+        logprobs_b = self.logsoftmax(logits_b)[torch.arange(logits_b.shape[0]), actions]
         sumlogprobs_b = tf(
             torch.zeros(len(torch.unique(path_id, sorted=True)))
         ).index_add_(0, path_id, logprobs_b)

--- a/gflownetenv.py
+++ b/gflownetenv.py
@@ -277,10 +277,10 @@ class GFlowNetEnv:
             state = self.state
         return False
 
-    def get_mask_invalid_actions(self, state=None, done=None, obs2state=None):
+    def get_mask_invalid_actions(self, state=None, done=None):
         """
-        Returns a vector of length the action space + 1: True if forward action is invalid
-        given the current state, False otherwise.
+        Returns a vector of length the action space + 1: True if forward action is
+        invalid given the current state, False otherwise.
         """
         if state is None:
             state = self.state

--- a/grid.py
+++ b/grid.py
@@ -97,8 +97,8 @@ class Grid(GFlowNetEnv):
 
     def get_mask_invalid_actions(self, state=None, done=None, obs2state=False):
         """
-        Returns a vector of length the action space + 1: True if forward action is invalid
-        given the current state, False otherwise.
+        Returns a vector of length the action space + 1: True if forward action is
+        invalid given the current state, False otherwise.
         """
         if state is None:
             state = self.state.copy()
@@ -106,35 +106,10 @@ class Grid(GFlowNetEnv):
             done = self.done
         if done:
             return [True for _ in range(len(self.action_space) + 1)]
-        if obs2state == True:
-            state = self.obs2state(state.cpu().numpy())
         mask = [False for _ in range(len(self.action_space) + 1)]
         for idx, a in enumerate(self.action_space):
             for d in a:
                 if state[d] + 1 >= self.length:
-                    mask[idx] = True
-                    break
-        return mask
-
-    def get_backward_mask(self, state=None, done=None, obs2state=False):
-        """
-        Returns a vector of length the action space + 1: True if backward action is invalid
-        given the current state, False otherwise.
-        """
-        if state is None:
-            state = self.state.copy()
-        if done is None:
-            done = self.done
-        if done:
-            mask = [True for _ in range(len(self.action_space))]
-            mask.append(False)
-            return mask
-        if obs2state == True:
-            state = self.obs2state(state.cpu().numpy())
-        mask = [False for _ in range(len(self.action_space) + 1)]
-        for idx, a in enumerate(self.action_space):
-            for d in a:
-                if state[d] - 1 < 0:
                     mask[idx] = True
                     break
         return mask


### PR DESCRIPTION
The main goal of this PR is to avoid the re-computation of invalid masks for the forward and backward logits:
* The masks of the forward logits (for the parents) are obtained from the (states) masks already included in the batch.
* The masks of the backward logits (fo the states) are obtained from the parents actions already included in the batch.

I have removed the legacy code from the previous PR.