### PR TITLE
Changes in step() function of environments

### DIFF
--- a/src/gflownet/envs/base.py
+++ b/src/gflownet/envs/base.py
@@ -248,19 +248,22 @@ class GFlowNetEnv:
             path_list, actions = self.get_paths(path_list, actions)
         return path_list, actions
 
-    def step(self, action):
+    def step(self, action_idx):
         """
         Executes step given an action.
 
         Args
         ----
-        a : int (tensor)
+        action_idx : int
             Index of action in the action space. a == eos indicates "stop action"
 
         Returns
         -------
         self.state : list
             The sequence after executing the action
+
+        action_idx : int
+            Action index
 
         valid : bool
             False, if the action is not allowed for the current state, e.g. stop at the

--- a/src/gflownet/gflownet.py
+++ b/src/gflownet/gflownet.py
@@ -283,7 +283,9 @@ class GFlowNetAgent:
         times["actions_model"] += t1_a_model - t0_a_model
         assert len(envs) == len(actions)
         # Execute actions
-        _, actions, valids = zip(*[env.step(action) for env, action in zip(envs, actions)])
+        _, actions, valids = zip(
+            *[env.step(action) for env, action in zip(envs, actions)]
+        )
         return envs, actions, valids
 
     def backward_sample(

--- a/src/gflownet/gflownet.py
+++ b/src/gflownet/gflownet.py
@@ -275,15 +275,15 @@ class GFlowNetAgent:
         if self.mask_invalid_actions:
             action_logits[mask_invalid_actions] = -1000
         if all(torch.isfinite(action_logits).flatten()):
-            actions = Categorical(logits=action_logits).sample()
+            actions = Categorical(logits=action_logits).sample().tolist()
         else:
             if self.debug:
                 raise ValueError("Action could not be sampled from model!")
         t1_a_model = time.time()
         times["actions_model"] += t1_a_model - t0_a_model
-        assert len(envs) == actions.shape[0]
+        assert len(envs) == len(actions)
         # Execute actions
-        _, _, valids = zip(*[env.step(action) for env, action in zip(envs, actions)])
+        _, actions, valids = zip(*[env.step(action) for env, action in zip(envs, actions)])
         return envs, actions, valids
 
     def backward_sample(
@@ -434,6 +434,7 @@ class GFlowNetAgent:
                 if valid:
                     parents, parents_a = env.get_parents()
                     mask = env.get_mask_invalid_actions()
+                    assert action in parents_a
                     if train:
                         batch.append(
                             [


### PR DESCRIPTION
This PR simplifies a bit the handling of the action inside the step() function and solves a potential issue in the case the action is changed within step(). Main changes are:

* The argument of the step function (now called `action_idx`) is an `int` instead of a tensor.
* The returned action (`action_idx`) is thus also an int, instead of a list
* `action_idx` explicitly refers to the index in the action space
* When `step()` is called (from `forward_sample()`), now the actions (indices) are retrieved (instead of `_`) to handle the possibility of the action being changed in `step()` (which should not occur if the invalid actions mask are used and work well)
* New assertion for extra security