### PR TITLE
Improve implementation of exploration

### DIFF
--- a/config/env/ctorus.yaml
+++ b/config/env/ctorus.yaml
@@ -10,8 +10,13 @@ n_dim: 2
 # Fixed length of trajectories
 length_traj: 3
 # Parameters of the fixed policy output distribution
-vonmises_mean: 0.0
-vonmises_concentration: 0.5
+fixed_distribution:
+  vonmises_mean: 0.0
+  vonmises_concentration: 0.5
+# Parameters of the random policy output distribution
+random_distribution:
+  vonmises_mean: 0.0
+  vonmises_concentration: 0.001
 # Buffer
 buffer:
   data_path: null

--- a/config/env/htorus.yaml
+++ b/config/env/htorus.yaml
@@ -10,8 +10,13 @@ n_dim: 2
 # Fixed length of trajectories
 length_traj: 3
 # Parameters of the fixed policy output distribution
-vonmises_mean: 0.0
-vonmises_concentration: 0.5
+fixed_distribution:
+  vonmises_mean: 0.0
+  vonmises_concentration: 0.5
+# Parameters of the random policy output distribution
+random_distribution:
+  vonmises_mean: 0.0
+  vonmises_concentration: 0.001
 # Buffer
 buffer:
   data_path: null

--- a/gflownet/envs/aptamers.py
+++ b/gflownet/envs/aptamers.py
@@ -83,6 +83,7 @@ class AptamerSeq(GFlowNetEnv):
         self.action_space = self.get_actions_space()
         self.eos = len(self.action_space)
         self.fixed_policy_output = self.get_fixed_policy_output()
+        self.random_policy_output = self.get_fixed_policy_output()
         self.policy_output_dim = len(self.fixed_policy_output)
         self.policy_input_dim = len(self.state2policy())
         self.max_traj_len = self.get_max_traj_len()

--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -326,7 +326,6 @@ class GFlowNetEnv:
         sampling_method: str = "policy",
         mask_invalid_actions: TensorType["n_states", "policy_output_dim"] = None,
         temperature_logits: float = 1.0,
-        random_action_prob=0.0,
         loginf: float = 1000,
     ) -> Tuple[List[Tuple], TensorType["n_states"]]:
         """

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -72,6 +72,7 @@ class Grid(GFlowNetEnv):
         self.cells = np.linspace(cell_min, cell_max, length)
         self.action_space = self.get_actions_space()
         self.fixed_policy_output = self.get_fixed_policy_output()
+        self.random_policy_output = self.get_fixed_policy_output()
         self.policy_output_dim = len(self.fixed_policy_output)
         self.policy_input_dim = len(self.state2policy())
         if self.proxy_state_format == "ohe":

--- a/gflownet/envs/torus.py
+++ b/gflownet/envs/torus.py
@@ -76,6 +76,7 @@ class Torus(GFlowNetEnv):
         self.max_step_len = max_step_len
         self.action_space = self.get_actions_space()
         self.fixed_policy_output = self.get_fixed_policy_output()
+        self.random_policy_output = self.get_fixed_policy_output()
         self.policy_output_dim = len(self.fixed_policy_output)
         self.policy_input_dim = len(self.state2policy())
         self.angle_rad = 2 * np.pi / self.n_angles

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -305,20 +305,27 @@ class GFlowNetAgent:
             [env.get_mask_invalid_actions_forward() for env in envs]
         )
         # Build policy outputs
+        policy_outputs = model.random_distribution(states)
+        idx_norandom = (
+            Bernoulli(
+                (1 - random_action_prob) * torch.ones(len(states), device=self.device)
+            )
+            .sample()
+            .to(bool)
+        )
         if sampling_method == "policy":
-            policy_outputs = model(self._tfloat(self.env.statebatch2policy(states)))
+            policy_outputs[idx_norandom, :] = model(
+                self._tfloat(
+                    self.env.statebatch2policy(
+                        [s for s, do in zip(states, idx_norandom) if do]
+                    )
+                )
+            )
         elif sampling_method == "uniform":
             # TODO
             policy_outputs = None
         else:
             raise NotImplementedError
-        # Random actions
-        idx_random = (
-            Bernoulli(random_action_prob * torch.ones(len(states), device=self.device))
-            .sample()
-            .to(bool)
-        )
-        policy_outputs[idx_random, :] = self._tfloat(self.env.random_policy_output)
         # Sample actions from policy outputs
         actions, logprobs = self.env.sample_actions(
             policy_outputs,
@@ -1061,6 +1068,9 @@ class Policy:
         self.fixed_output = torch.tensor(env.fixed_policy_output).to(
             dtype=self.float, device=self.device
         )
+        self.random_output = torch.tensor(env.random_policy_output).to(
+            dtype=self.float, device=self.device
+        )
         self.output_dim = len(self.fixed_output)
         if "shared_weights" in config:
             self.shared_weights = config.shared_weights
@@ -1156,6 +1166,15 @@ class Policy:
         Args: states: tensor
         """
         return torch.tile(self.fixed_output, (len(states), 1)).to(
+            dtype=self.float, device=self.device
+        )
+
+    def random_distribution(self, states):
+        """
+        Returns the random distribution specified by the environment.
+        Args: states: tensor
+        """
+        return torch.tile(self.random_output, (len(states), 1)).to(
             dtype=self.float, device=self.device
         )
 

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -15,7 +15,7 @@ import pandas as pd
 import torch
 import torch.nn as nn
 import yaml
-from torch.distributions.categorical import Categorical
+from torch.distributions import Categorical, Bernoulli
 from tqdm import tqdm
 
 from gflownet.envs.base import Buffer
@@ -311,14 +311,17 @@ class GFlowNetAgent:
             # TODO
             policy_outputs = None
         else:
-            raise NotImplemented
+            raise NotImplementedError
+        # Random actions
+        bernoulli = Bernoulli(random_action_prob * torch.ones(len(states), device=self.device))
+        idx_random = bernoulli.sample().to(int)
+        policy_outputs[idx_random, :] = self._tfloat(self.env.random_policy_output)
         # Sample actions from policy outputs
         actions, logprobs = self.env.sample_actions(
             policy_outputs,
             sampling_method,
             mask_invalid_actions,
             temperature,
-            random_action_prob,
         )
         assert len(envs) == len(actions)
         # Execute actions

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -313,7 +313,11 @@ class GFlowNetAgent:
         else:
             raise NotImplementedError
         # Random actions
-        idx_random = Bernoulli(random_action_prob * torch.ones(len(states), device=self.device)).sample().to(int)
+        idx_random = (
+            Bernoulli(random_action_prob * torch.ones(len(states), device=self.device))
+            .sample()
+            .to(int)
+        )
         policy_outputs[idx_random, :] = self._tfloat(self.env.random_policy_output)
         # Sample actions from policy outputs
         actions, logprobs = self.env.sample_actions(

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -316,7 +316,7 @@ class GFlowNetAgent:
         idx_random = (
             Bernoulli(random_action_prob * torch.ones(len(states), device=self.device))
             .sample()
-            .to(int)
+            .to(bool)
         )
         policy_outputs[idx_random, :] = self._tfloat(self.env.random_policy_output)
         # Sample actions from policy outputs

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -313,8 +313,7 @@ class GFlowNetAgent:
         else:
             raise NotImplementedError
         # Random actions
-        bernoulli = Bernoulli(random_action_prob * torch.ones(len(states), device=self.device))
-        idx_random = bernoulli.sample().to(int)
+        idx_random = Bernoulli(random_action_prob * torch.ones(len(states), device=self.device)).sample().to(int)
         policy_outputs[idx_random, :] = self._tfloat(self.env.random_policy_output)
         # Sample actions from policy outputs
         actions, logprobs = self.env.sample_actions(


### PR DESCRIPTION
* Environments must define a `random_policy_output` vector
* Before calling `sample_actions()` (in the `GFlowNetAgent`), the policy output vector of each element in the batch is changed to `random_policy_output` with probability `random_action_prob` (by sampling from a Bernoulli distribution)
* Efficient implementation by first determining the non-random indices and calling the model only for those.