### PR TITLE
First post-ICML cleanup of branch continuous

### DIFF
--- a/config/env/grid.yaml
+++ b/config/env/grid.yaml
@@ -21,6 +21,8 @@ buffer:
   train:
     type: all
     output_csv: grid_train.csv
+    output_pkl: grid_train.pkl
   test:
     type: all
     output_csv: grid_test.csv
+    output_pkl: grid_test.pkl

--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -578,6 +578,12 @@ class Buffer:
                 pickle.dump(dict_tt, f)
                 self.test_pkl = test.output_pkl
         else:
+            print("""
+            Important: test metrics will NOT be computed. In order to compute
+            test metrics the test configuration of the buffer should be complete and
+            feasible and an output pkl file should be defined in
+            env.buffer.test.output_pkl.
+            """)
             self.test_pkl = None
         # Compute buffer statistics
         if self.train is not None:

--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -10,6 +10,7 @@ import torch
 from torch.distributions import Categorical
 from torchtyping import TensorType
 import pickle
+from gflownet.utils.common import set_device, set_float_precision
 
 
 class GFlowNetEnv:
@@ -19,6 +20,8 @@ class GFlowNetEnv:
 
     def __init__(
         self,
+        device="cpu",
+        float_precision=32,
         env_id=None,
         reward_beta=1,
         reward_norm=1.0,
@@ -31,6 +34,11 @@ class GFlowNetEnv:
         proxy_state_format=None,
         **kwargs,
     ):
+        # Device
+        self.device = set_device(device)
+        # Float precision
+        self.float = set_float_precision(float_precision)
+        # Environment
         self.state = []
         self.done = False
         self.n_actions = 0
@@ -57,12 +65,6 @@ class GFlowNetEnv:
         assert self.reward_norm > 0
         assert self.reward_beta > 0
         assert self.min_reward > 0
-
-    def set_device(self, device):
-        self.device = device
-
-    def set_float_precision(self, dtype):
-        self.float = dtype
 
     def set_energies_stats(self, energies_stats):
         self.energies_stats = energies_stats

--- a/gflownet/envs/ctorus.py
+++ b/gflownet/envs/ctorus.py
@@ -30,43 +30,8 @@ class ContinuousTorus(HybridTorus):
        Fixed length of the trajectory.
     """
 
-    def __init__(
-        self,
-        n_dim=2,
-        length_traj=1,
-        policy_encoding_dim_per_angle=None,
-        fixed_distribution=dict,
-        random_distribution=dict,
-        vonmises_min_concentration=1e-3,
-        env_id=None,
-        reward_beta=1,
-        reward_norm=1.0,
-        reward_norm_std_mult=0,
-        reward_func="boltzmann",
-        denorm_proxy=False,
-        energies_stats=None,
-        proxy=None,
-        oracle=None,
-        **kwargs,
-    ):
-        super(ContinuousTorus, self).__init__(
-            n_dim=n_dim,
-            length_traj=length_traj,
-            policy_encoding_dim_per_angle=policy_encoding_dim_per_angle,
-            fixed_distribution=fixed_distribution,
-            random_distribution=random_distribution,
-            vonmises_min_concentration=vonmises_min_concentration,
-            env_id=env_id,
-            reward_beta=reward_beta,
-            reward_norm=reward_norm,
-            reward_norm_std_mult=reward_norm_std_mult,
-            reward_func=reward_func,
-            denorm_proxy=denorm_proxy,
-            energies_stats=energies_stats,
-            proxy=proxy,
-            oracle=oracle,
-            **kwargs,
-        )
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def get_actions_space(self):
         """

--- a/gflownet/envs/ctorusmixture.py
+++ b/gflownet/envs/ctorusmixture.py
@@ -30,45 +30,9 @@ class ContinuousTorusMixture(ContinuousTorus):
        Fixed length of the trajectory.
     """
 
-    def __init__(
-        self,
-        n_dim=2,
-        length_traj=1,
-        policy_encoding_dim_per_angle=None,
-        n_comp=3,
-        fixed_distribution=dict,
-        random_distribution=dict,
-        vonmises_min_concentration=1e-3,
-        env_id=None,
-        reward_beta=1,
-        reward_norm=1.0,
-        reward_norm_std_mult=0,
-        reward_func="boltzmann",
-        denorm_proxy=False,
-        energies_stats=None,
-        proxy=None,
-        oracle=None,
-        **kwargs,
-    ):
+    def __init__(self, n_comp=3, **kwargs):
         self.n_comp = n_comp
-        super(ContinuousTorusMixture, self).__init__(
-            n_dim=n_dim,
-            length_traj=length_traj,
-            policy_encoding_dim_per_angle=policy_encoding_dim_per_angle,
-            fixed_distribution=fixed_distribution,
-            random_distribution=random_distribution,
-            vonmises_min_concentration=vonmises_min_concentration,
-            env_id=env_id,
-            reward_beta=reward_beta,
-            reward_norm=reward_norm,
-            reward_norm_std_mult=reward_norm_std_mult,
-            reward_func=reward_func,
-            denorm_proxy=denorm_proxy,
-            energies_stats=energies_stats,
-            proxy=proxy,
-            oracle=oracle,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
     def get_policy_output(self, params: dict):
         """

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -79,6 +79,7 @@ class Grid(GFlowNetEnv):
             self.statebatch2proxy = self.statebatch2policy
         elif self.proxy_state_format == "oracle":
             self.statebatch2proxy = self.statebatch2oracle
+            self.statetorch2proxy = self.statetorch2oracle
 
     def get_actions_space(self):
         """
@@ -164,6 +165,19 @@ class Grid(GFlowNetEnv):
                 (len(states), self.n_dim, self.length)
             )
             * self.cells[None, :]
+        ).sum(axis=2)
+
+    def statetorch2oracle(
+        self, states: TensorType["batch", "state_dim"]
+    ) -> TensorType["batch", "state_oracle_dim"]:
+        """
+        Prepares a batch of states in torch "GFlowNet format" for the oracle.
+        """
+        return (
+            self.statetorch2policy(states).reshape(
+                (len(states), self.n_dim, self.length)
+            )
+            * torch.tensor(self.cells[None, :]).to(states)
         ).sum(axis=2)
 
     def state2policy(self, state: List = None) -> List:

--- a/gflownet/envs/htorus.py
+++ b/gflownet/envs/htorus.py
@@ -69,7 +69,7 @@ class HybridTorus(GFlowNetEnv):
         self.state2oracle = self.state2proxy
         self.statebatch2oracle = self.statebatch2proxy
         # Setup proxy
-        self.proxy.n_dim = self.n_dim
+        self.proxy.set_n_dim(self.n_dim)
 
     def get_actions_space(self):
         """

--- a/gflownet/envs/htorus.py
+++ b/gflownet/envs/htorus.py
@@ -42,29 +42,9 @@ class HybridTorus(GFlowNetEnv):
         fixed_distribution=dict,
         random_distribution=dict,
         vonmises_min_concentration=1e-3,
-        env_id=None,
-        reward_beta=1,
-        reward_norm=1.0,
-        reward_norm_std_mult=0,
-        reward_func="boltzmann",
-        denorm_proxy=False,
-        energies_stats=None,
-        proxy=None,
-        oracle=None,
         **kwargs,
     ):
-        super(HybridTorus, self).__init__(
-            env_id=env_id,
-            reward_beta=reward_beta,
-            reward_norm=reward_norm,
-            reward_norm_std_mult=reward_norm_std_mult,
-            reward_func=reward_func,
-            energies_stats=energies_stats,
-            denorm_proxy=denorm_proxy,
-            proxy=proxy,
-            oracle=oracle,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
         self.policy_encoding_dim_per_angle = policy_encoding_dim_per_angle
         self.continuous = True
         self.n_dim = n_dim

--- a/gflownet/envs/torus.py
+++ b/gflownet/envs/torus.py
@@ -63,6 +63,8 @@ class Torus(GFlowNetEnv):
         # Oracle
         self.state2oracle = self.state2proxy
         self.statebatch2oracle = self.statebatch2proxy
+        # Setup proxy
+        self.proxy.set_n_dim(self.n_dim)
 
     def get_actions_space(self):
         """

--- a/gflownet/envs/torus.py
+++ b/gflownet/envs/torus.py
@@ -41,29 +41,9 @@ class Torus(GFlowNetEnv):
         length_traj=1,
         min_step_len=1,
         max_step_len=1,
-        env_id=None,
-        reward_beta=1,
-        reward_norm=1.0,
-        reward_norm_std_mult=0,
-        reward_func="boltzmann",
-        denorm_proxy=False,
-        energies_stats=None,
-        proxy=None,
-        oracle=None,
         **kwargs,
     ):
-        super(Torus, self).__init__(
-            env_id,
-            reward_beta,
-            reward_norm,
-            reward_norm_std_mult,
-            reward_func,
-            energies_stats,
-            denorm_proxy,
-            proxy,
-            oracle,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
         self.continuous = True
         self.n_dim = n_dim
         self.eos = self.n_dim

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -60,7 +60,7 @@ class GFlowNetAgent:
         self.env.set_float_precision(self.float)
         self.mask_source = self._tbool([self.env.get_mask_invalid_actions_forward()])
         # Continuous environments
-        self.continuous = hasattr(self.env, "continuous") and self.env.continuous:
+        self.continuous = hasattr(self.env, "continuous") and self.env.continuous
         # Loss
         if optimizer.loss in ["flowmatch"]:
             self.loss = "flowmatch"

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -712,6 +712,13 @@ class GFlowNetAgent:
         # Train loop
         pbar = tqdm(range(1, self.n_train_steps + 1), disable=not self.logger.progress)
         for it in pbar:
+            # Test
+            if self.logger.do_test(it):
+                self.l1, self.kl, self.jsd, figs = self.test()
+                self.logger.log_test_metrics(
+                    self.l1, self.kl, self.jsd, it, self.use_context
+                )
+                self.logger.log_plots(figs, it, self.use_context)
             t0_iter = time.time()
             data = []
             for j in range(self.sttr):
@@ -772,13 +779,6 @@ class GFlowNetAgent:
                 it,
                 self.use_context,
             )
-            # Test
-            if self.logger.do_test(it):
-                self.l1, self.kl, self.jsd, figs = self.test()
-                self.logger.log_test_metrics(
-                    self.l1, self.kl, self.jsd, it, self.use_context
-                )
-                self.logger.log_plots(figs, it, self.use_context)
             # Save intermediate models
             self.logger.save_models(self.forward_policy, self.backward_policy, step=it)
 
@@ -894,7 +894,8 @@ class GFlowNetAgent:
             fig_kde_pred = self.env.plot_kde(kde_pred)
             fig_kde_true = self.env.plot_kde(kde_true)
         else:
-            fig_kde = None
+            fig_kde_pred = None
+            fig_kde_true = None
         return l1, kl, jsd, [fig_reward_samples, fig_kde_pred, fig_kde_true]
 
     def get_log_corr(self, times):

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 from scipy.special import logsumexp
 
 from gflownet.envs.base import Buffer
-from gflownet.utils.common import torch2np
+from gflownet.utils.common import set_device, set_float_precision, torch2np
 
 
 class GFlowNetAgent:
@@ -51,13 +51,11 @@ class GFlowNetAgent:
         # Seed
         self.rng = np.random.default_rng(seed)
         # Device
-        self.device = self._set_device(device)
+        self.device = set_device(device)
         # Float precision
-        self.float = self._set_float_precision(float_precision)
+        self.float = set_float_precision(float_precision)
         # Environment
         self.env = env
-        self.env.set_device(self.device)
-        self.env.set_float_precision(self.float)
         self.mask_source = self._tbool([self.env.get_mask_invalid_actions_forward()])
         # Continuous environments
         self.continuous = hasattr(self.env, "continuous") and self.env.continuous
@@ -172,22 +170,6 @@ class GFlowNetAgent:
         self.l1 = -1.0
         self.kl = -1.0
         self.jsd = -1.0
-
-    def _set_device(self, device: str):
-        if device.lower() == "cuda" and torch.cuda.is_available():
-            return torch.device("cuda")
-        else:
-            return torch.device("cpu")
-
-    def _set_float_precision(self, precision: int):
-        if precision == 16:
-            return torch.float16
-        elif precision == 32:
-            return torch.float32
-        elif precision == 64:
-            return torch.float64
-        else:
-            raise ValueError("Precision must be one of [16, 32, 64]")
 
     def _tfloat(self, x):
         return torch.tensor(x, dtype=self.float, device=self.device)

--- a/gflownet/proxy/base.py
+++ b/gflownet/proxy/base.py
@@ -4,20 +4,18 @@ Base class of GFlowNet proxies
 from abc import abstractmethod
 import numpy as np
 import numpy.typing as npt
+from gflownet.utils.common import set_device, set_float_precision
 
 
 class Proxy:
     """
     Generic proxy class
     """
-
-    @abstractmethod
-    def __init__(self, **kwargs):
-        """
-        kwargs:
-            for the acquisition, and model, the trained surrogate would be an input arg
-            but this wouldn't be so for the oracle
-        """
+    def __init__(self, device, float_precision, **kwargs):
+        # Device
+        self.device = set_device(device)
+        # Float precision
+        self.float = set_float_precision(float_precision)
 
     @abstractmethod
     def __call__(self, states: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:

--- a/gflownet/proxy/corners.py
+++ b/gflownet/proxy/corners.py
@@ -37,9 +37,9 @@ class Corners(Proxy):
                     torch.diag(
                         torch.tensordot(
                             torch.tensordot(
-                                (torch.abs(x) - self.mu_vec), self.cov_inv, dims=1
+                                (torch.abs(states) - self.mu_vec), self.cov_inv, dims=1
                             ),
-                            (torch.abs(x) - self.mu_vec).T,
+                            (torch.abs(states) - self.mu_vec).T,
                             dims=1,
                         )
                     )

--- a/gflownet/proxy/corners.py
+++ b/gflownet/proxy/corners.py
@@ -18,13 +18,16 @@ class Corners(Proxy):
 
     def setup(self):
         if self.sigma and self.mu and self.n_dim:
-            self.mu_vec = self.mu * torch.ones(self.n_dim, device=self.device, dtype=self.float)
-            cov = self.sigma * torch.eye(self.n_dim, device=self.device, dtype=self.float)
+            self.mu_vec = self.mu * torch.ones(
+                self.n_dim, device=self.device, dtype=self.float
+            )
+            cov = self.sigma * torch.eye(
+                self.n_dim, device=self.device, dtype=self.float
+            )
             cov_det = torch.linalg.det(cov)
             self.cov_inv = torch.linalg.inv(cov)
             self.mulnormal_norm = 1.0 / ((2 * torch.pi) ** 2 * cov_det) ** 0.5
-#             self.mulnormal = True
-            self.mulnormal = False
+            self.mulnormal = True
         else:
             self.mulnormal = False
         return self.mulnormal
@@ -49,7 +52,6 @@ class Corners(Proxy):
             return energies
 
         def _mulnormal_corners(x):
-            import ipdb; ipdb.set_trace()
             return (
                 -1.0
                 * self.mulnormal_norm
@@ -57,9 +59,12 @@ class Corners(Proxy):
                     -0.5
                     * (
                         torch.diag(
-                            torch.dot(
-                                torch.dot((torch.abs(x) - self.mu_vec), self.cov_inv),
+                            torch.tensordot(
+                                torch.tensordot(
+                                    (torch.abs(x) - self.mu_vec), self.cov_inv, dims=1
+                                ),
                                 (torch.abs(x) - self.mu_vec).T,
+                                dims=1,
                             )
                         )
                     )
@@ -67,10 +72,6 @@ class Corners(Proxy):
             )
 
         if self.mulnormal:
-            import ipdb; ipdb.set_trace()
             return _mulnormal_corners(states)
         else:
-            snp = states.cpu().numpy()
-            pnp =  np.asarray([_func_corners(state) for state in snp])
-            import ipdb; ipdb.set_trace()
             return np.asarray([_func_corners(state) for state in states])

--- a/gflownet/proxy/corners.py
+++ b/gflownet/proxy/corners.py
@@ -1,6 +1,7 @@
 from gflownet.proxy.base import Proxy
 import numpy as np
-import numpy.typing as npt
+import torch
+from torchtyping import TensorType
 
 
 class Corners(Proxy):
@@ -8,8 +9,8 @@ class Corners(Proxy):
     It is assumed that the state values will be in the range [-1.0, 1.0].
     """
 
-    def __init__(self, n_dim=None, mu=None, sigma=None):
-        super().__init__()
+    def __init__(self, n_dim=None, mu=None, sigma=None, **kwargs):
+        super().__init__(**kwargs)
         self.n_dim = n_dim
         self.mu = mu
         self.sigma = sigma
@@ -17,17 +18,18 @@ class Corners(Proxy):
 
     def setup(self):
         if self.sigma and self.mu and self.n_dim:
-            self.mu_vec = np.repeat(self.mu, self.n_dim)
-            self.cov = self.sigma * np.eye(self.n_dim)
-            self.cov_det = np.linalg.det(self.cov)
-            self.cov_inv = np.linalg.inv(self.cov)
-            self.mulnormal_norm = 1.0 / ((2 * np.pi) ** 2 * self.cov_det) ** 0.5
-            self.mulnormal = True
+            self.mu_vec = self.mu * torch.ones(self.n_dim, device=self.device, dtype=self.float)
+            cov = self.sigma * torch.eye(self.n_dim, device=self.device, dtype=self.float)
+            cov_det = torch.linalg.det(cov)
+            self.cov_inv = torch.linalg.inv(cov)
+            self.mulnormal_norm = 1.0 / ((2 * torch.pi) ** 2 * cov_det) ** 0.5
+#             self.mulnormal = True
+            self.mulnormal = False
         else:
             self.mulnormal = False
         return self.mulnormal
 
-    def __call__(self, states: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+    def __call__(self, states: TensorType["batch", "state_dim"]) -> TensorType["batch"]:
         """
         args:
             states: ndarray
@@ -47,16 +49,17 @@ class Corners(Proxy):
             return energies
 
         def _mulnormal_corners(x):
+            import ipdb; ipdb.set_trace()
             return (
                 -1.0
                 * self.mulnormal_norm
-                * np.exp(
+                * torch.exp(
                     -0.5
                     * (
-                        np.diag(
-                            np.dot(
-                                np.dot((np.abs(x) - self.mu_vec), self.cov_inv),
-                                (np.abs(x) - self.mu_vec).T,
+                        torch.diag(
+                            torch.dot(
+                                torch.dot((torch.abs(x) - self.mu_vec), self.cov_inv),
+                                (torch.abs(x) - self.mu_vec).T,
                             )
                         )
                     )
@@ -64,6 +67,10 @@ class Corners(Proxy):
             )
 
         if self.mulnormal:
+            import ipdb; ipdb.set_trace()
             return _mulnormal_corners(states)
         else:
+            snp = states.cpu().numpy()
+            pnp =  np.asarray([_func_corners(state) for state in snp])
+            import ipdb; ipdb.set_trace()
             return np.asarray([_func_corners(state) for state in states])

--- a/gflownet/proxy/torus.py
+++ b/gflownet/proxy/torus.py
@@ -10,6 +10,9 @@ class Torus(Proxy):
         self.alpha = alpha
         self.beta = beta
 
+    def set_n_dim(self, n_dim):
+        self.n_dim = n_dim
+
     @property
     def min(self):
         if self.normalize:

--- a/gflownet/proxy/torus.py
+++ b/gflownet/proxy/torus.py
@@ -4,8 +4,8 @@ from torchtyping import TensorType
 
 
 class Torus(Proxy):
-    def __init__(self, normalize, alpha=1.0, beta=1.0):
-        super().__init__()
+    def __init__(self, normalize, alpha=1.0, beta=1.0, **kwargs):
+        super().__init__(**kwargs)
         self.normalize = normalize
         self.alpha = alpha
         self.beta = beta

--- a/gflownet/utils/common.py
+++ b/gflownet/utils/common.py
@@ -1,6 +1,23 @@
 from collections.abc import MutableMapping
+import torch
 import numpy as np
 
+
+def set_device(device: str):
+    if device.lower() == "cuda" and torch.cuda.is_available():
+        return torch.device("cuda")
+    else:
+        return torch.device("cpu")
+
+def set_float_precision(precision: int):
+    if precision == 16:
+        return torch.float16
+    elif precision == 32:
+        return torch.float32
+    elif precision == 64:
+        return torch.float64
+    else:
+        raise ValueError("Precision must be one of [16, 32, 64]")
 
 def torch2np(x):
     if hasattr(x, "is_cuda") and x.is_cuda:

--- a/gflownet/utils/logger.py
+++ b/gflownet/utils/logger.py
@@ -153,6 +153,7 @@ class Logger:
 
     def log_plots(self, figs: list, step, use_context=True):
         if not self.do.online:
+            close_figs(figs)
             return
         keys = ["True reward and GFlowNet samples", "GFlowNet KDE Policy", "Reward KDE"]
         for key, fig in zip(keys, figs):
@@ -161,6 +162,11 @@ class Logger:
             if fig is not None:
                 figimg = self.wandb.Image(fig)
                 self.wandb.log({key: figimg}, step)
+                self.plt.close(fig)
+
+    def close_figs(figs: list):
+        for fig in figs:
+            if self.plt is not None and fig is not None:
                 self.plt.close(fig)
 
     def log_metrics(self, metrics: dict, step: int, use_context: bool = True):

--- a/gflownet/utils/logger.py
+++ b/gflownet/utils/logger.py
@@ -3,6 +3,7 @@ import numpy as np
 import torch
 from pathlib import Path
 from numpy import array
+import matplotlib.pyplot as plt
 
 
 class Logger:
@@ -41,16 +42,13 @@ class Logger:
             )
         if self.do.online:
             import wandb
-            import matplotlib.pyplot as plt
 
             self.wandb = wandb
-            self.plt = plt
             self.run = self.wandb.init(
                 config=config, project=project_name, name=run_name
             )
         else:
             self.wandb = None
-            self.plt = None
             self.run = None
         self.add_tags(tags)
         self.context = "0"
@@ -143,17 +141,17 @@ class Logger:
             return
         if use_context:
             key = self.context + "/" + key
-        fig = self.plt.figure()
-        self.plt.hist(value)
-        self.plt.title(key)
-        self.plt.ylabel("Frequency")
-        self.plt.xlabel(key)
+        fig = plt.figure()
+        plt.hist(value)
+        plt.title(key)
+        plt.ylabel("Frequency")
+        plt.xlabel(key)
         fig = self.wandb.Image(fig)
         self.wandb.log({key: fig}, step)
 
     def log_plots(self, figs: list, step, use_context=True):
         if not self.do.online:
-            close_figs(figs)
+            self.close_figs(figs)
             return
         keys = ["True reward and GFlowNet samples", "GFlowNet KDE Policy", "Reward KDE"]
         for key, fig in zip(keys, figs):
@@ -162,12 +160,12 @@ class Logger:
             if fig is not None:
                 figimg = self.wandb.Image(fig)
                 self.wandb.log({key: figimg}, step)
-                self.plt.close(fig)
+                plt.close(fig)
 
-    def close_figs(figs: list):
+    def close_figs(self, figs: list):
         for fig in figs:
-            if self.plt is not None and fig is not None:
-                self.plt.close(fig)
+            if fig is not None:
+                plt.close(fig)
 
     def log_metrics(self, metrics: dict, step: int, use_context: bool = True):
         if not self.do.online:

--- a/main.py
+++ b/main.py
@@ -30,9 +30,18 @@ def main(config):
     # Logger
     logger = hydra.utils.instantiate(config.logger, config, _recursive_=False)
     # The proxy is required in the env for scoring: might be an oracle or a model
-    proxy = hydra.utils.instantiate(config.proxy)
+    proxy = hydra.utils.instantiate(
+        config.proxy,
+        device=config.device,
+        float_precision=config.float_precision,
+    )
     # The proxy is passed to env and used for computing rewards
-    env = hydra.utils.instantiate(config.env, proxy=proxy)
+    env = hydra.utils.instantiate(
+        config.env,
+        proxy=proxy,
+        device=config.device,
+        float_precision=config.float_precision,
+    )
     gflownet = hydra.utils.instantiate(
         config.gflownet,
         device=config.device,


### PR DESCRIPTION
I have re-organised a bunch of things that were hanging from the ICML rush:
* The grid environment works again :tada: 
* The corners proxy is now fully in torch
* Device and float precision are managed globally by the classes instead of passing around the settings from class to class
* The above lead me to better code the inheritance of classes, including a simplification of what arguments are needed to be passed to each environment and proxy classes
* Re-organisation of the logging part, but more work is needed on this front, for instance adding the computation of the correlation (only when it should and can be computed) in `test()`
* Removed old code in `gflownet.py`

To soon be done (non-exhaustive):
* Backward sampling
* Make flowmatch loss work again
* Make sure that aptamers and molecule (@AlexandraVolokhova you can see my changes in the tori envs and do the same in the molecule) envs run well 