### PR TITLE
Cleanup analinedipeptide

### DIFF
--- a/config/env/alaninedipeptide_mixture.yaml
+++ b/config/env/alaninedipeptide_mixture.yaml
@@ -3,7 +3,8 @@ defaults:
 
 _target_: gflownet.envs.alaninedipeptide_mixture.AlanineDipeptideMixture
 
-path_to_dataset: ${user.data.alanine_dipeptide}
+path_to_dataset: './data/alanine_dipeptide_conformers_1.npy'
+url_to_dataset: 'https://drive.google.com/uc?id=1r1KRGcpBhR3xaS8yt2i64dfMnJGgNj4C'
 id: alaninedipeptide
 policy_encoding_dim_per_angle: null
 # Fixed length of trajectories

--- a/config/experiments/icml23/molecule_mixture.yaml
+++ b/config/experiments/icml23/molecule_mixture.yaml
@@ -11,7 +11,7 @@ defaults:
 env:
   length_traj: 10
   policy_encoding_dim_per_angle: 10
-  n_comp: 3
+  n_comp: 5
   vonmises_min_concentration: 4
 
 # GFlowNet hyperparameters
@@ -19,21 +19,22 @@ gflownet:
   random_action_prob: 0.1
   optimizer:
     batch_size: 100
-    lr: 0.001
+    lr: 0.00001
     z_dim: 16
-    lr_z_mult: 50
-    n_train_steps: 20000
+    lr_z_mult: 1000
+    n_train_steps: 40000
+    lr_decay_period: 1000000
   policy:
     forward:
       type: mlp
-      n_hid: 128
-      n_layers: 2
+      n_hid: 512
+      n_layers: 5
       checkpoint: forward
     backward:
       type: mlp
-      n_hid: 128
-      n_layers: 2
-      shared_weights: True
+      n_hid: 512
+      n_layers: 5
+      shared_weights: False
       checkpoint: backward
 
 # WandB

--- a/config/proxy/molecule.yaml
+++ b/config/proxy/molecule.yaml
@@ -1,3 +1,4 @@
 _target_: gflownet.proxy.molecule.MoleculeEnergyProxy
 
-path_to_model: '/home/mila/a/alexandra.volokhova/projects/gflownet/data/random_forest_reward_100.pkl'
+path_to_model: './data/random_forest_reward_100.pkl'
+url_to_model: 'https://drive.google.com/uc?id=1OpQNC8WWIsMh8K4olfSaQRFlj3emYThF'

--- a/config/user/sasha.yaml
+++ b/config/user/sasha.yaml
@@ -1,4 +1,2 @@
 logdir:
   root: /network/scratch/a/alexandra.volokhova/logs/gflownet
-data:
-  alanine_dipeptide: /home/mila/a/alexandra.volokhova/projects/gflownet/data/alanine_dipeptide_conformers_1.npy

--- a/gflownet/envs/alaninedipeptide.py
+++ b/gflownet/envs/alaninedipeptide.py
@@ -18,6 +18,7 @@ class AlanineDipeptide(ContinuousTorus):
     def __init__(
         self,
         path_to_dataset,
+        url_to_dataset,
         length_traj=1,
         fixed_distribution=dict,
         random_distribution=dict,
@@ -34,7 +35,7 @@ class AlanineDipeptide(ContinuousTorus):
         policy_encoding_dim_per_angle=None,
         **kwargs,
     ):
-        self.atom_positions_dataset = AtomPositionsDataset(path_to_dataset)
+        self.atom_positions_dataset = AtomPositionsDataset(path_to_dataset, url_to_dataset)
         atom_positions = self.atom_positions_dataset.sample()
         self.conformer = ConformerBase(
             atom_positions, constants.ad_smiles, constants.ad_free_tas

--- a/gflownet/envs/alaninedipeptide_mixture.py
+++ b/gflownet/envs/alaninedipeptide_mixture.py
@@ -19,6 +19,7 @@ class AlanineDipeptideMixture(ContinuousTorusMixture):
     def __init__(
         self,
         path_to_dataset,
+        url_to_dataset,
         length_traj=1,
         fixed_distribution=dict,
         random_distribution=dict,
@@ -36,7 +37,8 @@ class AlanineDipeptideMixture(ContinuousTorusMixture):
         n_comp=3,
         **kwargs,
     ):
-        self.atom_positions_dataset = AtomPositionsDataset(path_to_dataset)
+        
+        self.atom_positions_dataset = AtomPositionsDataset(path_to_dataset, url_to_dataset)
         atom_positions = self.atom_positions_dataset.sample()
         self.conformer = ConformerBase(
             atom_positions, constants.ad_smiles, constants.ad_free_tas

--- a/gflownet/proxy/molecule.py
+++ b/gflownet/proxy/molecule.py
@@ -3,21 +3,18 @@ import numpy.typing as npt
 import pickle
 import torch
 
-from xtb.interface import Calculator, Param, XTBException
-from xtb.libxtb import VERBOSITY_MUTED
-
-
-from gflownet.proxy.base import Proxy
 from sklearn.ensemble import RandomForestRegressor
 
+from gflownet.proxy.base import Proxy
+from gflownet.utils.common import download_file_if_not_exists
 
 class MoleculeEnergyProxy(Proxy):
-    def __init__(self, path_to_model=None, **kwargs):
+    def __init__(self, path_to_model, url_to_model, **kwargs):
         super().__init__(**kwargs)
         self.min = -np.log(105)
-        if path_to_model is not None:
-            with open(path_to_model, 'rb') as inp:
-                self.model = pickle.load(inp)
+        path_to_model = download_file_if_not_exists(path_to_model, url_to_model)
+        with open(path_to_model, 'rb') as inp:
+            self.model = pickle.load(inp)
     
     def set_device(self, device):
         self.device = device

--- a/gflownet/utils/common.py
+++ b/gflownet/utils/common.py
@@ -1,7 +1,10 @@
-from collections.abc import MutableMapping
-import torch
+import gdown
 import numpy as np
+import torch
 
+from collections.abc import MutableMapping
+from hydra.utils import get_original_cwd
+from pathlib import Path
 
 def set_device(device: str):
     if device.lower() == "cuda" and torch.cuda.is_available():
@@ -42,3 +45,18 @@ def handle_logdir():
             print(f"logdir {config.logdir} already exists! - Ending run...")
     else:
         print(f"working directory not defined - Ending run...")
+
+def download_file_if_not_exists(path: str, url: str):
+    """
+    Download a file from google drive if path doestn't exist.
+    url should be in the format: https://drive.google.com/uc?id=FILE_ID
+    """
+    path = Path(path)
+    if not path.is_absolute():
+        # to avoid storing downloaded files with the logs, prefix is set to the original working dir
+        prefix = get_original_cwd()
+        path = Path(prefix) / path
+    if not path.exists():
+        path.absolute().parent.mkdir(parents=True, exist_ok=True)
+        gdown.download(url, str(path.absolute()), quiet=False)
+    return path

--- a/gflownet/utils/molecule/atom_positions_dataset.py
+++ b/gflownet/utils/molecule/atom_positions_dataset.py
@@ -1,8 +1,10 @@
 import numpy as np
 
+from gflownet.utils.common import download_file_if_not_exists
 
 class AtomPositionsDataset:
-    def __init__(self, path_to_data):
+    def __init__(self, path_to_data, url_to_data):
+        path_to_data = download_file_if_not_exists(path_to_data, url_to_data)
         self.positions = np.load(path_to_data)
 
     def __getitem__(self, i):

--- a/setup_conformer.sh
+++ b/setup_conformer.sh
@@ -18,8 +18,8 @@ python -m pip install pyg-lib torch-scatter torch-sparse torch-cluster torch-spl
 python -m pip install dgl-cu102 dglgo -f https://data.dgl.ai/wheels/repo.html
 # Requirements to run
 python -m pip install numpy pandas hydra-core tqdm torchtyping six xtb scikit-learn
-# Conditional requirements to run
-python -m pip install wandb matplotlib plotly
+# Conditional requirements
+python -m pip install wandb matplotlib plotly gdown
 # Dev packages
 # python -m pip install black flake8 isort pylint ipdb jupyter
 

--- a/setup_gflownet.sh
+++ b/setup_gflownet.sh
@@ -15,7 +15,7 @@ python -m pip install --upgrade pip
 python -m pip install torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
 # Requirements to run
 python -m pip install numpy pandas hydra-core tqdm torchtyping scikit-learn
-# Conditional requirements to run
+# Conditional requirements
 python -m pip install wandb matplotlib plotly
 # Dev packages
 # python -m pip install black flake8 isort pylint ipdb jupyter


### PR DESCRIPTION
Two changes:
1. I added automatic downloading of the pretrained proxy model and of a small dataset needed for defining conformer. I put the downloading function in `utils.common` because it can be potentially helpful for other environments. It uses [gdown](https://github.com/wkentaro/gdown) library, so you will need to install it.
2. Updated parameters in `experiments/icml23/molecule_mixture` according to the paper

@michalkoziarski now you should be able to run the icml experiment with molecule just via `python main.py +experiments=icml23/molecule_mixture user=your_user`