### PR TITLE
Update format of grid actions

### DIFF
--- a/config/env/grid.yaml
+++ b/config/env/grid.yaml
@@ -9,9 +9,10 @@ func: corners
 n_dim: 2
 # Number of cells per dimension
 length: 3
-# Minimum and maximum number of steps in the action space
-min_step_len: 1
-max_step_len: 1
+# Maximum number of steps in the action space
+max_increment: 1
+# Maximum number of dimensions that can be incremented by one action
+max_dim_per_action: 1
 # Mapping coordinates
 cell_min: -1
 cell_max: 1

--- a/config/env/grid.yaml
+++ b/config/env/grid.yaml
@@ -9,7 +9,7 @@ func: corners
 n_dim: 2
 # Number of cells per dimension
 length: 3
-# Maximum number of steps in the action space
+# Maximum increment per each dimension that can be done by one action
 max_increment: 1
 # Maximum number of dimensions that can be incremented by one action
 max_dim_per_action: 1

--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -110,7 +110,7 @@ class GFlowNetEnv:
     ) -> List:
         """
         Returns a list of length the action space with values:
-            - True if the forward action is invalid given the current state.
+            - True if the forward action is invalid from the current state.
             - False otherwise.
         For continuous or hybrid environments, this mask corresponds to the discrete
         part of the action space.
@@ -125,7 +125,7 @@ class GFlowNetEnv:
     ) -> List:
         """
         Returns a list of length the action space with values:
-            - True if the backward action is invalid given the current state.
+            - True if the backward action is invalid from the current state.
             - False otherwise.
         For continuous or hybrid environments, this mask corresponds to the discrete
         part of the action space.

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -80,10 +80,8 @@ class Grid(GFlowNetEnv):
     ) -> List:
         """
         Returns a list of length the action space with values:
-            - True if the forward action is invalid given the current state.
+            - True if the forward action is invalid from the current state.
             - False otherwise.
-        Returns a vector of length the action space + 1: True if forward action is
-        invalid given the current state, False otherwise.
         """
         if state is None:
             state = self.state.copy()

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -87,16 +87,14 @@ class Grid(GFlowNetEnv):
         represented by a vector of length n_dim where each index d indicates to
         increment to apply to dimension d of the hyper-grid.
         """
+        increments = [el for el in range(self.max_increment + 1)]
         actions = []
-        for incr in range(self.max_increment + 1):
-            for d in range(self.n_dim):
-                action = [0 for _ in range(self.n_dim)]
-                action[d] = incr
-                if (
-                    sum(action) != 0
-                    and len([el for el in action if el > 0]) <= self.max_dim_per_action
-                ):
-                    actions.append(tuple(action))
+        for action in itertools.product(increments, repeat=self.n_dim):
+            if (
+                sum(action) != 0
+                and len([el for el in action if el > 0]) <= self.max_dim_per_action
+            ):
+                actions.append(tuple(action))
         actions.append(self.eos)
         return actions
 

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -38,7 +38,8 @@ class Grid(GFlowNetEnv):
         Maximum increment of each dimension by the actions.
 
     max_dim_per_action : int
-        Maximum number of dimensions to increment per action.
+        Maximum number of dimensions to increment per action. If -1, then
+        max_dim_per_action is set to n_dim.
 
     cell_min : float
         Lower bound of the cells range
@@ -61,10 +62,12 @@ class Grid(GFlowNetEnv):
         assert n_dim > 0
         assert length > 1
         assert max_increment > 0
-        assert max_dim_per_action > 0
+        assert max_dim_per_action == -1 or max_dim_per_action > 0
         self.n_dim = n_dim
         self.length = length
         self.max_increment = max_increment
+        if max_dim_per_action == -1:
+            max_dim_per_action = self.n_dim
         self.max_dim_per_action = max_dim_per_action
         self.cells = np.linspace(cell_min, cell_max, length)
         # Source state: position 0 at all dimensions

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -59,12 +59,12 @@ class Grid(GFlowNetEnv):
     ):
         # Constants
         assert n_dim > 0
-        self.n_dim = n_dim
         assert length > 1
-        self.length = length
         assert max_increment > 0
-        self.max_increment = max_increment
         assert max_dim_per_action > 0
+        self.n_dim = n_dim
+        self.length = length
+        self.max_increment = max_increment
         self.max_dim_per_action = max_dim_per_action
         self.cells = np.linspace(cell_min, cell_max, length)
         # Source state: position 0 at all dimensions

--- a/tests/gflownet/envs/test_grid.py
+++ b/tests/gflownet/envs/test_grid.py
@@ -16,7 +16,7 @@ def env_extended_action_space_2d():
         n_dim=2,
         length=5,
         max_increment=2,
-        max_dim_per_action=2,
+        max_dim_per_action=-1,
         cell_min=-1.0,
         cell_max=1.0,
     )

--- a/tests/gflownet/envs/test_grid.py
+++ b/tests/gflownet/envs/test_grid.py
@@ -11,7 +11,19 @@ def env():
 
 
 @pytest.fixture
-def env_extended_action_space():
+def env_extended_action_space_2d():
+    return Grid(
+        n_dim=2,
+        length=5,
+        max_increment=2,
+        max_dim_per_action=2,
+        cell_min=-1.0,
+        cell_max=1.0,
+    )
+
+
+@pytest.fixture
+def env_extended_action_space_3d():
     return Grid(
         n_dim=3,
         length=5,
@@ -70,9 +82,23 @@ def test__statebatch2oracle__returns_expected(env, states, statebatch2oracle):
     assert torch.equal(torch.Tensor(statebatch2oracle), env.statebatch2oracle(states))
 
 
+@pytest.mark.parametrize(
+    "action_space",
+    [
+        [(0, 0), (1, 0), (2, 0), (0, 1), (1, 1), (2, 1), (0, 2), (1, 2), (2, 2)],
+    ],
+)
+def test__get_action_space__returns_expected(
+    env_extended_action_space_2d, action_space
+):
+    print(action_space)
+    print(set(env_extended_action_space_2d.action_space))
+    assert set(action_space) == set(env_extended_action_space_2d.action_space)
+
+
 def test__all_env_common(env):
     return common.test__all_env_common(env)
 
 
-def test__all_env_common(env_extended_action_space):
-    return common.test__all_env_common(env_extended_action_space)
+def test__all_env_common(env_extended_action_space_3d):
+    return common.test__all_env_common(env_extended_action_space_3d)

--- a/tests/gflownet/envs/test_grid.py
+++ b/tests/gflownet/envs/test_grid.py
@@ -11,6 +11,18 @@ def env():
 
 
 @pytest.fixture
+def env_extended_action_space():
+    return Grid(
+        n_dim=3,
+        length=5,
+        max_increment=2,
+        max_dim_per_action=3,
+        cell_min=-1.0,
+        cell_max=1.0,
+    )
+
+
+@pytest.fixture
 def env_default():
     return Grid()
 
@@ -60,3 +72,7 @@ def test__statebatch2oracle__returns_expected(env, states, statebatch2oracle):
 
 def test__all_env_common(env):
     return common.test__all_env_common(env)
+
+
+def test__all_env_common(env_extended_action_space):
+    return common.test__all_env_common(env_extended_action_space)


### PR DESCRIPTION
Note that the base branch is `tests-and-simplify-envs` because it is the most up to date with the grid environment although it has not been merged into continuous yet.

This PR updates the format of the actions in the grid environment. It used to be a tuple of dimension indices, with variable length, and for each element d, the dimension d would be incremented by 1. With the updated format, the action space is the increment to be applied to each dimension. For instance, (0, 0, 1) will increment dimension 2 by 1 and the action that goes from [1, 1, 1] to [2, 3, 1] is (1, 2, 0). This has a number of advantages related to the actions having fixed length, plus it is more intuitive.

Besides the main change about the update of the action format, the PR include the following minor changes:
* Extended docstring
* Change of variable name: `max_step_len` is now `max_increment`
* `min_step_len` has been removed assuming the minimum should be 1.
* `max_dim_per_action` has been introduced to control how many dimensions can be incremented at a time.
* self.eos is now an action (a tuple) instead of an index. This should be done in other environments too.
* Assertions in `__init__` for more robustness.
* The grid tests include an environment with _extended action space_ (`max_increment` larger than 1 and `max_dim_per_action` larger than 1)

- [X] `python -m pytest tests/gflownet/envs/test_grid.py`
- [X] black