### PR TITLE
[FIX BUG] Fix bug in trajectory balance loss

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -638,7 +638,9 @@ class GFlowNetAgent:
         )
         # Shift state_id to [1, 2, ...]
         for tid in traj_id.unique():
-            state_id[traj_id == tid] -= state_id[traj_id == tid].min() + 1
+            state_id[traj_id == tid] = (
+                state_id[traj_id == tid] - state_id[traj_id == tid].min() + 1
+            )
         # Compute rewards
         rewards = self.env.reward_torchbatch(states, done)
         # Build parents forward masks from state masks


### PR DESCRIPTION
The [line](https://github.com/alexhernandezgarcia/gflownet/blob/main/gflownet/gflownet.py#L641)
```
state_id[traj_id == tid] -= state_id[traj_id == tid].min() + 1
```
was yielding negative `state_id` which in turn resulted in wrong masks, among other potential issues. Replaced for now with:
```
state_id[traj_id == tid] = state_id[traj_id == tid] - state_id[traj_id == tid].min() + 1
```

The new [Batch class](https://github.com/alexhernandezgarcia/gflownet/pull/111) should replace this. This is a temporary fix. 

Thanks @nikita-0209 for finding this!