### PR TITLE
Composition refactor

### DIFF
--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -339,17 +339,13 @@ class Composition(GFlowNetEnv):
             return self.state, action, False
         # If action is not eos, then perform action
         if action != self.eos:
-            atomic_number, num = action
-            idx = self.elem2idx[atomic_number]
+            element, num = action
+            idx = self.elem2idx[element]
             state_next = self.state[:]
             state_next[idx] = num
-            if sum(state_next) > self.max_atoms:
-                valid = False
-            else:
-                self.state = state_next
-                valid = True
-                self.n_actions += 1
-            return self.state, action, valid
+            self.state = state_next
+            self.n_actions += 1
+            return self.state, action, True
         # If action is eos, then perform eos
         else:
             if self.get_mask_invalid_actions_forward()[-1]:

--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -122,7 +122,7 @@ class Composition(GFlowNetEnv):
         return actions
 
     def get_max_traj_length(self):
-        return min(self.max_diff_elem, self.max_atoms // self.min_atom_i) + 1
+        return min(self.max_diff_elem, self.max_atoms // self.min_atom_i)
 
     def get_mask_invalid_actions_forward(self, state=None, done=None):
         """

--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -154,23 +154,29 @@ class Composition(GFlowNetEnv):
             mask[-1] = True
 
         for idx, (element, n) in enumerate(self.action_space[:-1]):
-            # compute how many additional atoms and elements need to be reserved
-            if element in unused_required_elements:
-                reserved_atoms = (n_unused_required_elements - 1) * self.min_atom_i
-                reserved_elements = n_unused_required_elements - 1
-            else:
-                reserved_atoms = n_unused_required_elements * self.min_atom_i
-                reserved_elements = n_unused_required_elements
-
             # cannot modify already set element
             if state[self.elem2idx[element]] > 0:
                 mask[idx] = True
+                continue
+
+            # compute how many additional atoms and elements need to be reserved
+            if element in unused_required_elements:
+                reserved_elements = n_unused_required_elements - 1
+            else:
+                reserved_elements = n_unused_required_elements
+            reserved_elements = max(
+                reserved_elements, self.min_diff_elem - n_used_elements - 1
+            )
+            reserved_atoms = reserved_elements * self.min_atom_i
+
             # cannot add atoms over the limit
-            elif n_used_atoms + n + reserved_atoms > self.max_atoms:
+            if n_used_atoms + n + reserved_atoms > self.max_atoms:
                 mask[idx] = True
+                continue
             # cannot add elements over the limit
-            elif n_used_elements + 1 + reserved_elements > self.max_diff_elem:
+            if n_used_elements + 1 + reserved_elements > self.max_diff_elem:
                 mask[idx] = True
+                continue
 
         return mask
 

--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -327,21 +327,13 @@ class Composition(GFlowNetEnv):
         # If done, return invalid
         if self.done:
             return self.state, action, False
-        # If only possible action is eos, then force eos
-        if sum(self.state) == self.max_atoms:
-            self.done = True
-            self.n_actions += 1
-            return self.state, self.eos, True
         # If action not found in action space raise an error
-        action_idx = None
-        for i, a in enumerate(self.action_space):
-            if a == action:
-                action_idx = i
-                break
-        if action_idx is None:
+        if action not in self.action_space:
             raise ValueError(
                 f"Tried to execute action {action} not present in action space."
             )
+        else:
+            action_idx = self.action_space.index(action)
         # If action is in invalid mask, exit immediately
         if self.get_mask_invalid_actions_forward()[action_idx]:
             return self.state, action, False

--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -122,7 +122,7 @@ class Composition(GFlowNetEnv):
         return actions
 
     def get_max_traj_length(self):
-        return self.max_atoms // self.min_atom_i
+        return min(self.max_diff_elem, self.max_atoms // self.min_atom_i) + 1
 
     def get_mask_invalid_actions_forward(self, state=None, done=None):
         """

--- a/tests/gflownet/envs/test_composition.py
+++ b/tests/gflownet/envs/test_composition.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import torch
 
@@ -290,6 +291,35 @@ def test__can_produce_neutral_charge__returns_expected_result(state, exp_result)
     )
 
     assert environment._can_produce_neutral_charge(state) == exp_result
+
+
+def test__get_mask_invalid_actions_forward__accounts_for_required_elements():
+    required_elements = [1, 2, 4, 5]
+    env = Composition(
+        elements=6, required_elements=required_elements, max_atom_i=1, max_diff_elem=4
+    )
+    mask = env.get_mask_invalid_actions_forward()
+
+    for (element, n), masked in zip(env.action_space, mask):
+        if element in required_elements:
+            assert not masked
+        else:
+            assert masked
+
+
+@pytest.mark.repeat(25)
+def test__required_elements_does_not_cause_environment_to_get_stuck():
+    required_elements = [1, 2, 3, 4, 5]
+    env = Composition(
+        elements=89, max_diff_elem=10, required_elements=required_elements
+    )
+
+    while not env.done:
+        mask = env.get_mask_invalid_actions_forward()
+        actions = [action for action, m in zip(env.action_space, mask) if not m]
+        assert len(actions) > 0
+        action = actions[np.random.choice(len(actions))]
+        env.step(action)
 
 
 def test__all_env_common(env):

--- a/tests/gflownet/envs/test_composition.py
+++ b/tests/gflownet/envs/test_composition.py
@@ -322,5 +322,24 @@ def test__required_elements_does_not_cause_environment_to_get_stuck():
         env.step(action)
 
 
+@pytest.mark.repeat(25)
+def test__insufficient_elements_left_does_not_cause_environment_to_get_stuck():
+    env = Composition(
+        elements=10,
+        min_diff_elem=5,
+        max_diff_elem=5,
+        max_atoms=25,
+        min_atom_i=4,
+        max_atom_i=10,
+    )
+
+    while not env.done:
+        mask = env.get_mask_invalid_actions_forward()
+        actions = [action for action, m in zip(env.action_space, mask) if not m]
+        assert len(actions) > 0
+        action = actions[np.random.choice(len(actions))]
+        env.step(action)
+
+
 def test__all_env_common(env):
     return common.test__all_env_common(env)


### PR DESCRIPTION
Changes to Composition environment's `get_mask_invalid_actions_forward` that take into account 1) required elements, and 2) atoms and elements that have to be reserved to meet minimum required values. Without these changes, environment could get stuck in some edge cases.

NOT INCLUDED: changes to neutral charge check, which was temporarily disabled - looking ahead and predicting from which states reaching neutral charge won't be possible is trickier than I hoped for...