### PR TITLE
[WIP] Add forward-looking GFN loss

### DIFF
--- a/config/env/base.yaml
+++ b/config/env/base.yaml
@@ -13,6 +13,7 @@ reward_beta: 1.0
 reward_norm: 1.0
 # If > 0, reward_norm = reward_norm_std_mult * std(energies)
 reward_norm_std_mult: 0.0
+non_terminal_rewards: False
 proxy_state_format: oracle
 # Check if action valid with mask before step
 skip_mask_check: False

--- a/config/gflownet/forwardlooking.yaml
+++ b/config/gflownet/forwardlooking.yaml
@@ -1,0 +1,18 @@
+defaults:
+  - gflownet
+
+optimizer:
+  loss: forwardlooking
+  lr: 0.0001
+  lr_decay_period: 1000000
+  lr_decay_gamma: 0.5
+
+policy:
+  backward:
+    shared_weights: True
+    checkpoint: null
+    reload_ckpt: False
+  forward_flow:
+    shared_weights: True
+    checkpoint: null
+    reload_ckpt: False

--- a/config/gflownet/gflownet.yaml
+++ b/config/gflownet/gflownet.yaml
@@ -48,6 +48,7 @@ policy:
     checkpoint: null
     reload_ckpt: False
   backward: null
+  forward_flow: null
   ckpt_period: null
 num_empirical_loss: 200000
 oracle:

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -679,7 +679,7 @@ class GFlowNetAgent:
         masks_sf = batch.masks_invalid_actions_forward
         masks_b = batch.masks_invalid_actions_backward
         traj_ids = batch.env_ids
-        state_ids = batch.steps
+        state_ids = batch.n_actions
 
         # Ensure that the state_ids are indexed from 1 for any trajectory : [1, 2, ...].
         for tid in traj_ids.unique():

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -746,8 +746,8 @@ class GFlowNetAgent:
 
         # Compute loss for terminating nodes and for all other nodes
         with torch.no_grad():
-            term_loss = (per_node_loss * done).pow(2).sum() / (done.sum() + 1e-20)
-            flow_loss = (per_node_loss * torch.logical_not(done)).pow(2).sum() / (
+            term_loss = (per_node_loss * done).sum() / (done.sum() + 1e-20)
+            flow_loss = (per_node_loss * torch.logical_not(done)).sum() / (
                 torch.logical_not(done).sum() + 1e-20
             )
 

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -1011,6 +1011,82 @@ class Policy:
         )
 
 
+class ForwardFlow():
+
+    def __init__(self, config, env, device, float_precision, base=None):
+        # If config not provided, create a default config
+        if config is None:
+            config = OmegaConf.create()
+
+        # Device and float precision
+        self.device = device
+        self.float = float_precision
+
+        # Parameters of the internal neural network
+        self.state_dim = env.policy_input_dim
+        self.output_dim = 1
+        self.base = base
+
+        # Extract config values from config dict (use default values if not availables)
+        self.shared_weights = config.get("shared_weights", False)
+        self.n_hid = config.get("n_hid", None)
+        self.n_layers = config.get("n_layers", None)
+        self.tail = config.get("tail", [])
+
+        # Instantiate neural network
+        self.model = self.make_mlp(nn.LeakyReLU())
+        self.model.to(self.device)
+        self.is_model = True
+
+    def __call__(self, states):
+        return self.model(states)
+
+    def make_mlp(self, activation):
+        """
+        Defines an MLP with no top layer activation
+        If share_weight == True,
+            baseModel (the model with which weights are to be shared) must be provided
+        Args
+        ----
+        layers_dim : list
+            Dimensionality of each layer
+        activation : Activation
+            Activation function
+        """
+        if self.shared_weights == True and self.base is not None:
+            mlp = nn.Sequential(
+                self.base.model[:-1],
+                nn.Linear(
+                    self.base.model[-1].in_features, self.output_dim
+                ),
+            )
+            return mlp
+        elif self.shared_weights == False:
+            layers_dim = (
+                [self.state_dim] + [self.n_hid] * self.n_layers + [(self.output_dim)]
+            )
+            mlp = nn.Sequential(
+                *(
+                    sum(
+                        [
+                            [nn.Linear(idim, odim)]
+                            + ([activation] if n < len(layers_dim) - 2 else [])
+                            for n, (idim, odim) in enumerate(
+                                zip(layers_dim, layers_dim[1:])
+                            )
+                        ],
+                        [],
+                    )
+                    + self.tail
+                )
+            )
+            return mlp
+        else:
+            raise ValueError(
+                "Base Model must be provided when shared_weights is set to True"
+            )
+
+
 def make_opt(params, logZ, config):
     """
     Set up the optimizer

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -168,7 +168,9 @@ class GFlowNetAgent:
         if policy.forward_flow is None:
             self.forward_flow_policy = None
             if self.loss == "forward-looking":
-                raise ValueError("Using the forward-looking loss requires a forward-flow config")
+                raise ValueError(
+                    "Using the forward-looking loss requires a forward-flow config"
+                )
         else:
             self.forward_flow_policy = ForwardFlow(
                 policy.forward_flow,
@@ -182,7 +184,9 @@ class GFlowNetAgent:
                 and "checkpoint" in policy.forward_flow
                 and policy.forward_flow.checkpoint
             ):
-                self.logger.set_forward_flow_policy_ckpt_path(policy.forward_flow.checkpoint)
+                self.logger.set_forward_flow_policy_ckpt_path(
+                    policy.forward_flow.checkpoint
+                )
                 # TODO: re-write the logic and conditions to reload a model
                 if False:
                     self.forward_flow.load_state_dict(
@@ -232,9 +236,9 @@ class GFlowNetAgent:
             )
         elif self.loss == "forwardlooking":
             return (
-                list(self.forward_policy.model.parameters()) +
-                list(self.backward_policy.model.parameters()) +
-                list(self.forward_flow_policy.model.parameters())
+                list(self.forward_policy.model.parameters())
+                + list(self.backward_policy.model.parameters())
+                + list(self.forward_flow_policy.model.parameters())
             )
         else:
             raise ValueError("Backward Policy cannot be a nn in flowmatch.")
@@ -715,14 +719,18 @@ class GFlowNetAgent:
 
         # Compute rewards for all states and their parents
         rewards = batch.compute_rewards()
-        parent_rewards = self.env.reward_torchbatch(parents, done=torch.zeros_like(done))
+        parent_rewards = self.env.reward_torchbatch(
+            parents, done=torch.zeros_like(done)
+        )
 
         # Compute the energies associated with each reward. For rewards of 0 (undefined),
         # we set them to 1. This will make their energies equal to 0 which will make
         # the forward-looking loss equivalent to a detailed balance loss on environments
         # that have null rewards for non-terminal states.
         stable_rewards = rewards.eq(0) + rewards * rewards.ne(0)
-        stable_parent_rewards = parent_rewards.eq(0) + parent_rewards * parent_rewards.ne(0)
+        stable_parent_rewards = parent_rewards.eq(
+            0
+        ) + parent_rewards * parent_rewards.ne(0)
 
         state_energies = -torch.log(stable_rewards)
         parent_energies = -torch.log(stable_parent_rewards)
@@ -778,9 +786,7 @@ class GFlowNetAgent:
                         it * self.ttsr + j, data
                     )  # returns (opt loss, *metrics)
                 elif self.loss == "forwardlooking":
-                    losses, rewards = self.forwardlooking_loss(
-                        it * self.ttsr + j, data
-                    )
+                    losses, rewards = self.forwardlooking_loss(it * self.ttsr + j, data)
                 else:
                     print("Unknown loss!")
                 if not all([torch.isfinite(loss) for loss in losses]):
@@ -1165,8 +1171,7 @@ class Policy:
         )
 
 
-class ForwardFlow():
-
+class ForwardFlow:
     def __init__(self, config, env, device, float_precision, base=None):
         # If config not provided, create a default config
         if config is None:
@@ -1210,9 +1215,7 @@ class ForwardFlow():
         if self.shared_weights == True and self.base is not None:
             mlp = nn.Sequential(
                 self.base.model[:-1],
-                nn.Linear(
-                    self.base.model[-1].in_features, self.output_dim
-                ),
+                nn.Linear(self.base.model[-1].in_features, self.output_dim),
             )
             return mlp
         elif self.shared_weights == False:

--- a/gflownet/proxy/tetris.py
+++ b/gflownet/proxy/tetris.py
@@ -29,3 +29,72 @@ class Tetris(Proxy):
             return torch.sum(states, axis=(1, 2)) / self.norm
         else:
             raise ValueError
+
+
+class DensityTetris(Proxy):
+    """Tetris proxy with rewards based on density
+
+    In this proxy, the rewards are computed based on occupied_space / used_space with :
+    - occupied_space being the number of cells occupied by a Tetris piece
+    - used_space being the area of the smallest rectangle encompassing all Tetris pieces
+      present in the state.
+
+    The goal of this reward structure is to allow model that can use intermediate rewards to learn
+    to densely pack Tetris pieces together from the beginning instead of placing them far across the
+    board.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def setup(self, env=None):
+        if env:
+            self.height = env.height
+            self.width = env.width
+
+    def get_2d_state_density(self, state):
+        """
+        Compute the density of Tetris pieces in a 2D state tensor
+
+        This density is equal to ratio between the number of cells occupied by a Tetris piece and
+        the area of the smallest rectangle containing all the placed Tetris pieces.
+
+        Args
+        ----
+        state : tensor
+
+        Returns
+        -------
+        torch.tensor
+            Density of Tetris pieces in the state tensor (scalar)
+        """
+        # Compute the area used
+        rows_used = (state.sum(1) > 0).nonzero()
+        if len(rows_used) == 0:
+            nb_rows_used = torch.tensor(0)
+        else:
+            nb_rows_used = rows_used.max() - rows_used.min() + 1
+
+        cols_used = (state.sum(0) > 0).nonzero()
+        if len(cols_used) == 0:
+            nb_cols_used = torch.tensor(0)
+        else:
+            nb_cols_used = cols_used.max() - cols_used.min() + 1
+
+        area_used = nb_rows_used * nb_cols_used
+
+        # Compute the number of cells occupied by tetris pieces
+        area_occupied = state.sum()
+
+        # Compute the density of cells in the area used
+        return (area_occupied + 1e-6) / (area_used.float() + 1e-6)
+
+    def __call__(self, states: TensorType["batch", "state_dim"]) -> TensorType["batch"]:
+        if states.dim() == 2:
+            return self.get_2d_state_density(states)
+
+        elif states.dim() == 3:
+            density_per_sample = [self.get_2d_state_density(s) for s in states]
+            return torch.stack(density_per_sample)
+
+        else:
+            raise ValueError

--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -118,7 +118,7 @@ class Batch:
                     """
                     self.parents_all.append(parents)
                     self.parents_actions_all.append(parents_a)
-                if self.loss == "trajectorybalance":
+                if self.loss in ["trajectorybalance", "forwardlooking"]:
                     self.masks_invalid_actions_backward.append(
                         env.get_mask_invalid_actions_backward(
                             env.state, env.done, [action]
@@ -165,7 +165,7 @@ class Batch:
                     device=self.device,
                     float_type=self.float,
                 )
-            elif self.loss == "trajectorybalance":
+            elif self.loss in ["trajectorybalance", "forwardlooking"]:
                 self.masks_invalid_actions_backward = tbool(
                     self.masks_invalid_actions_backward, device=self.device
                 )
@@ -324,7 +324,7 @@ class Batch:
                 device=self.device,
                 float_type=self.float,
             )
-        elif self.loss == "trajectorybalance":
+        elif self.loss in ["trajectorybalance", "forwardlooking"]:
             assert self.trajectory_indices is not None
             parents_policy = torch.zeros_like(self.states_policy)
             parents = torch.zeros_like(self.states)

--- a/gflownet/utils/logger.py
+++ b/gflownet/utils/logger.py
@@ -127,6 +127,12 @@ class Logger:
         else:
             self.pb_ckpt_path = self.ckpts_dir / f"{ckpt_id}_"
 
+    def set_forward_flow_policy_ckpt_path(self, ckpt_id: str = None):
+        if ckpt_id is None:
+            self.ff_ckpt_path = None
+        else:
+            self.ff_ckpt_path = self.ckpts_dir / f"{ckpt_id}_"
+
     def progressbar_update(
         self, pbar, losses, rewards, jsd, step, use_context=True, n_mean=100
     ):


### PR DESCRIPTION
This PR adds the FL-GFN loss introduced in https://arxiv.org/abs/2302.01687

I've tested this PR on the grid environment : 

```
Flow matching : 
wandb: Run summary:
wandb: Jensen Shannon Div. 0.0081
wandb:             KL Div. 0.00853
wandb:            L1 error 0.01371
wandb:                Loss 0.0
wandb:    Loss (non-term.) 0.0
wandb:  Loss (terminating) 0.0
wandb:          batch_size 22
wandb:                logZ 0.0
wandb:                  lr 0.0001
wandb:             lr_logZ -1.0
wandb:           max_proxy -0.91197
wandb:          max_reward 0.91197
wandb:          mean_proxy -0.91197
wandb:         mean_reward 0.91197
wandb:     mean_seq_length 2.0
wandb:           min_proxy -0.91197

Trajectory Balance : 
wandb: Run summary:
wandb: Jensen Shannon Div. 0.0985
wandb:             KL Div. 0.0508
wandb:            L1 error 0.09333
wandb:                Loss 0.01254
wandb:    Loss (non-term.) 0.01254
wandb:  Loss (terminating) 0.01254
wandb:          batch_size 38
wandb:                logZ 2.15163
wandb:                  lr 0.0001
wandb:             lr_logZ 0.001
wandb:           max_proxy -0.00614
wandb:          max_reward 0.91197
wandb:          mean_proxy -0.73081
wandb:         mean_reward 0.73081
wandb:     mean_seq_length 2.0
wandb:           min_proxy -0.91197

Forward-looking
wandb: Run summary:
wandb: Jensen Shannon Div. 0.10812
wandb:             KL Div. 0.05787
wandb:            L1 error 0.09815
wandb:                Loss 1e-05
wandb:    Loss (non-term.) 0.0
wandb:  Loss (terminating) 0.0
wandb:          batch_size 46
wandb:                logZ 0.0
wandb:                  lr 0.0001
wandb:             lr_logZ -1.0
wandb:           max_proxy -0.91197
wandb:          max_reward 0.91197
wandb:          mean_proxy -0.91197
wandb:         mean_reward 0.91197
wandb:     mean_seq_length 2.0
wandb:           min_proxy -0.91197
```

And on ctorus : 

```
Trajectory Balance : 
wandb: Run summary:
wandb: Jensen Shannon Div. 0.32073
wandb:             KL Div. 0.00388
wandb:            L1 error 0.00123
wandb:                Loss 0.34674
wandb:    Loss (non-term.) 0.34674
wandb:  Loss (terminating) 0.34674
wandb:          batch_size 40
wandb:                logZ 2.00088
wandb:                  lr 0.0001
wandb:             lr_logZ 0.001
wandb:           max_proxy -0.02962
wandb:          max_reward 0.97297
wandb:          mean_proxy -0.56213
wandb:         mean_reward 0.56213
wandb:     mean_seq_length 3.0
wandb:           min_proxy -0.97297



Forward-looking
andb: Run summary:
wandb: Jensen Shannon Div. 0.34732
wandb:             KL Div. 0.00348
wandb:            L1 error 0.00131
wandb:                Loss 0.03494
wandb:    Loss (non-term.) 0.00847
wandb:  Loss (terminating) 0.00123
wandb:          batch_size 40
wandb:                logZ 0.0
wandb:                  lr 0.0001
wandb:             lr_logZ -1.0
wandb:           max_proxy -0.11296
wandb:          max_reward 0.92509
wandb:          mean_proxy -0.51573
wandb:         mean_reward 0.51573
wandb:     mean_seq_length 3.0
wandb:           min_proxy -0.92509
```

In both grid and ctorus, there are no intermediate rewards so the FL loss becomes equivalent to the detailed balance loss. And in both environments, it seems to perform roughly on par with TB.

I also tested the FL loss by adding the option for environments to give rewards for intermediary states and implementing a new proxy for the Tetris env. This new proxy provides intermediary rewards that indicate how efficiently the Tetris pieces have been packed so far by computing said reward based on the ratio between the number of "cells" occupied by Tetris pieces over the area of the smallest rectangle containing all the Tetris pieces placed so far.

With this new proxy, I compared TB and FL in the following setting : env.width=6 env.height=6 env.pieces=["O","J","L"] env.rotations=[0,180]. Looking at the curves for mean_reward, it seems like FL (grey) has an early advantage up to around 2500 iterations but then TB is able to catch up and possibly to a bit better.
Note : I added a tiny bit of smoothing in wandb (0.24) because otherwise the curves jump around to much that it's hard to tell anything.

![image](https://github.com/alexhernandezgarcia/gflownet/assets/832811/689aa3dc-8fab-440e-852e-0c36405c0014)
