### PR TITLE
Compute EMAs outside of pytorch

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -794,10 +794,10 @@ class GFlowNetAgent:
             # Moving average of the loss for early stopping
             if loss_term_ema and loss_flow_ema:
                 loss_term_ema = (
-                    self.ema_alpha * losses[1] + (1.0 - self.ema_alpha) * loss_term_ema
+                    self.ema_alpha * losses[1].item() + (1.0 - self.ema_alpha) * loss_term_ema
                 )
                 loss_flow_ema = (
-                    self.ema_alpha * losses[2] + (1.0 - self.ema_alpha) * loss_flow_ema
+                    self.ema_alpha * losses[2].item() + (1.0 - self.ema_alpha) * loss_flow_ema
                 )
                 if (
                     loss_term_ema < self.early_stopping
@@ -805,8 +805,9 @@ class GFlowNetAgent:
                 ):
                     break
             else:
-                loss_term_ema = losses[1]
-                loss_flow_ema = losses[2]
+                loss_term_ema = losses[1].item()
+                loss_flow_ema = losses[2].item()
+
             # Log times
             t1_iter = time.time()
             times.update({"iter": t1_iter - t0_iter})


### PR DESCRIPTION
This PR fixes a memory leak issue that occured in the code.

Basically, the GFlowNet computes a running average of loss for the terminal and the non-terminal states. The issue is that this computation was done with pytorch tensors and without any detach. The result is that the whole pytorch computational graph is maintained in memory (because pytorch wants us to be able to take gradients on those EMAs) and grows very fast with every iteration.

I've modified the code to perform this computation outside of pytorch and validated that this fixes the issue. The figure below shows the memory consumption over time for experiments with the Dave Proxy on its own branch : 

![image](https://github.com/alexhernandezgarcia/gflownet/assets/832811/7f61478c-7347-4907-b78f-3898620555f6)

From the graph, we see that the fix in this PR almost entirely fixes the issue. There is still some memory leak due to the main buffer that grows over training but it is much smaller in scale.

I've also tested the fix on the main branch with the ctorus environment and found the same result : fast increase in memory consumption without the fix, very small increase in memory consumption (most likely the main buffer) with the fix.
