### PR TITLE
Remove batch class get_mask_invalid_actions_forward() calls

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -439,7 +439,9 @@ class GFlowNetAgent:
             envs, actions, valids = self.step(envs, actions, is_forward=True)
             # Add to batch
             t0_a_envs = time.time()
-            batch.add_to_batch(envs, actions, valids, train)
+            batch.add_to_batch(
+                envs, actions, valids, mask_invalid_actions_forward, train
+            )
             # Filter out finished trajectories
             envs = [env for env in envs if not env.done]
             t1_a_envs = time.time()

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -282,7 +282,7 @@ class GFlowNetAgent:
             mask_invalid_actions,
             temperature,
         )
-        return actions
+        return actions, mask_invalid_actions
 
     def step(
         self,
@@ -392,7 +392,7 @@ class GFlowNetAgent:
         while envs_offline:
             # Sample backward actions
             with torch.no_grad():
-                actions = self.sample_actions(
+                actions, _ = self.sample_actions(
                     envs_offline,
                     times,
                     sampling_method="policy",
@@ -416,7 +416,7 @@ class GFlowNetAgent:
             # Sample forward actions
             with torch.no_grad():
                 if train is False:
-                    actions = self.sample_actions(
+                    actions, mask_invalid_actions_forward = self.sample_actions(
                         envs,
                         times,
                         sampling_method="policy",
@@ -426,7 +426,7 @@ class GFlowNetAgent:
                         random_action_prob=self.random_action_prob,
                     )
                 else:
-                    actions = self.sample_actions(
+                    actions, mask_invalid_actions_forward = self.sample_actions(
                         envs,
                         times,
                         sampling_method="policy",


### PR DESCRIPTION
This PR aims to reduce the number of calls to the `get_mask_invalid_actions_forward()` method of environment classes. 

Currently, whenever the GFN takes an action on an environment, it involves computing a mask of invalid actions, sampling one of the non-invalid actions, and calling `Batch.add_to_batch()` which will compute the mask of invalid actions a second time. With this PR, the mask of invalid actions is computed only once and provided as an optional argument to `add_to_batch()`.

I tested on the Tetris environments (which, at larger env sizes, has its runtime completely dominated by calls to `get_mask_invalid_actions_forward()` ) with the following command : 
`python main.py user=$USER env=tetris proxy=tetris gflownet=trajectorybalance env.width=10 env.height=10 logger.do.online=False`

Without this PR : ~6.0 seconds/iteration
With this PR : ~4.1 seconds/iteration


