### PR TITLE
Revert "Remove batch class get_mask_invalid_actions_forward() calls"

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -282,7 +282,7 @@ class GFlowNetAgent:
             mask_invalid_actions,
             temperature,
         )
-        return actions, mask_invalid_actions
+        return actions
 
     def step(
         self,
@@ -392,7 +392,7 @@ class GFlowNetAgent:
         while envs_offline:
             # Sample backward actions
             with torch.no_grad():
-                actions, _ = self.sample_actions(
+                actions = self.sample_actions(
                     envs_offline,
                     times,
                     sampling_method="policy",
@@ -416,7 +416,7 @@ class GFlowNetAgent:
             # Sample forward actions
             with torch.no_grad():
                 if train is False:
-                    actions, mask_invalid_actions_forward = self.sample_actions(
+                    actions = self.sample_actions(
                         envs,
                         times,
                         sampling_method="policy",
@@ -426,7 +426,7 @@ class GFlowNetAgent:
                         random_action_prob=self.random_action_prob,
                     )
                 else:
-                    actions, mask_invalid_actions_forward = self.sample_actions(
+                    actions = self.sample_actions(
                         envs,
                         times,
                         sampling_method="policy",
@@ -439,9 +439,7 @@ class GFlowNetAgent:
             envs, actions, valids = self.step(envs, actions, is_forward=True)
             # Add to batch
             t0_a_envs = time.time()
-            batch.add_to_batch(
-                envs, actions, valids, mask_invalid_actions_forward, train
-            )
+            batch.add_to_batch(envs, actions, valids, train)
             # Filter out finished trajectories
             envs = [env for env in envs if not env.done]
             t1_a_envs = time.time()

--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -73,7 +73,6 @@ class Batch:
         envs: List[GFlowNetEnv],
         actions: List[Tuple],
         valids: List[bool],
-        masks_invalid_actions_forward: Optional[List[List[bool]]] = None,
         train: Optional[bool] = True,
     ):
         """
@@ -93,31 +92,10 @@ class Batch:
 
         valids : list
             A list of boolean values indicated whether the actions were valid.
-
-        masks_invalid_actions_forward : list
-            A list of masks indicating, among all the actions that could have been
-            selected for all environments, which ones were invalid. Optional, will be
-            computed if not provided.
-
-        train : bool
-            A boolean value indicating whether the data to add to the batch will be used
-            for training. Optional, default is True.
         """
         if self.is_processed:
             raise Exception("Cannot append to the processed batch")
-
-        # Sample masks of invalid actions if required and none are provided
-        if masks_invalid_actions_forward is None:
-            if train:
-                masks_invalid_actions_forward = [
-                    env.get_mask_invalid_actions_forward() for env in envs
-                ]
-            else:
-                masks_invalid_actions_forward = [None] * len(envs)
-
-        # Add data samples to the batch
-        for sample_data in zip(envs, actions, valids, masks_invalid_actions_forward):
-            env, action, valid, mask_forward = sample_data
+        for env, action, valid in zip(envs, actions, valids):
             self.envs.update({env.id: env})
             if not valid:
                 continue
@@ -127,8 +105,9 @@ class Batch:
                 self.env_ids.append(env.id)
                 self.done.append(env.done)
                 self.n_actions.append(env.n_actions)
-                self.masks_invalid_actions_forward.append(mask_forward)
-
+                self.masks_invalid_actions_forward.append(
+                    env.get_mask_invalid_actions_forward()
+                )
                 if self.loss == "flowmatch":
                     parents, parents_a = env.get_parents(action=action)
                     assert (


### PR DESCRIPTION
Reverts alexhernandezgarcia/gflownet#143

The PR removes the call to `get_mask_invalid_actions_forward()` inside the Batch class by using instead the masks computed when sampling the actions.

But that's not correct. The reason is that the masks used when sampling the actions for transitions between (say) t -> t+1. So those masks correspond to states at t. However, then steps are taken and we obtain the states at t+1, which is what needs to be added to the batch. And we need to store the masks of states at t+1 but we are now passing instead the masks of states at t.
That's why the masks were recomputed. 

This doesn't mean we cannot make the code more efficient, but it has to be the other way around: the batch computes the masks of states at t, then we re-use them to sample transitions t -> t+1. Let's do this in a new PR.