### PR TITLE
Remove batch class mask calls - Follow up

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -261,10 +261,7 @@ class GFlowNetAgent:
                 )
         else:
             # Invalid action masks are provided, convert to pytorch tensors
-            mask_invalid_actions = tbool(
-                [m for m in mask_invalid_actions],
-                device=self.device,
-            )
+            mask_invalid_actions = tbool(mask_invalid_actions, device=self.device)
         # Build policy outputs
         policy_outputs = model.random_distribution(states)
         idx_norandom = (


### PR DESCRIPTION
New, and hopefully improved, version of #143.

In this version, `GFlowNet.sample_actions()` is modified such that : 
- After actions are taken on the environments, new actions masks are computed
- These masks are given to Batch.add_to_batch to avoid recomputation in the batch class
- These masks are given to Env.sample_actions() the next time actions are sampled on these environments.

I tested on the ctorus environment with the following command : 
`python main.py user=$USER +experiments=icml23/ctorus device=cpu env.reward_beta=1`
and validated that it runs and that it produces the exact same graphs of metrics (loss, ...) over iterations in WandB with and without the PR

I also tested on the Tetris environments with the following command :
`python main.py user=$USER env=tetris proxy=tetris gflownet=trajectorybalance env.width=10 env.height=10 logger.do.online=False`
Without this PR : ~7.2 seconds/iteration
With this PR : ~4.8 seconds/iteration