### PR TITLE
Change loginf = -1000 by torch.inf and simplify part of flow matching loss

### DIFF
--- a/gflownet/envs/ctorus.py
+++ b/gflownet/envs/ctorus.py
@@ -149,7 +149,6 @@ class ContinuousTorus(HybridTorus):
         sampling_method: str = "policy",
         mask_invalid_actions: TensorType["n_states", "1"] = None,
         temperature_logits: float = 1.0,
-        loginf: float = 1000,
     ) -> Tuple[List[Tuple], TensorType["n_states"]]:
         """
         Samples a batch of actions from a batch of policy outputs.
@@ -202,7 +201,6 @@ class ContinuousTorus(HybridTorus):
         actions: TensorType["n_states", "n_dim"],
         states_target: TensorType["n_states", "policy_input_dim"],
         mask_invalid_actions: TensorType["n_states", "1"] = None,
-        loginf: float = 1000,
     ) -> TensorType["batch_size"]:
         """
         Computes log probabilities of actions given policy outputs and actions.

--- a/gflownet/envs/htorus.py
+++ b/gflownet/envs/htorus.py
@@ -344,7 +344,6 @@ class HybridTorus(GFlowNetEnv):
         sampling_method: str = "policy",
         mask_invalid_actions: TensorType["n_states", "n_dim"] = None,
         temperature_logits: float = 1.0,
-        loginf: float = 1000,
     ) -> Tuple[List[Tuple], TensorType["n_states"]]:
         """
         Samples a batch of actions from a batch of policy outputs.
@@ -359,7 +358,7 @@ class HybridTorus(GFlowNetEnv):
             logits_dims = policy_outputs[:, 0 :: self.n_params_per_dim]
             logits_dims /= temperature_logits
         if mask_invalid_actions is not None:
-            logits_dims[mask_invalid_actions] = -loginf
+            logits_dims[mask_invalid_actions] = -torch.inf
         dimensions = Categorical(logits=logits_dims).sample()
         logprobs_dim = self.logsoftmax(logits_dims)[ns_range, dimensions]
         # Sample angle increments
@@ -404,7 +403,6 @@ class HybridTorus(GFlowNetEnv):
         actions: TensorType["n_states", 2],
         states_target: TensorType["n_states", "policy_input_dim"],
         mask_invalid_actions: TensorType["batch_size", "policy_output_dim"] = None,
-        loginf: float = 1000,
     ) -> TensorType["batch_size"]:
         """
         Computes log probabilities of actions given policy outputs and actions.
@@ -418,7 +416,7 @@ class HybridTorus(GFlowNetEnv):
         # Dimensions
         logits_dims = policy_outputs[:, 0 :: self.n_params_per_dim]
         if mask_invalid_actions is not None:
-            logits_dims[mask_invalid_actions] = -loginf
+            logits_dims[mask_invalid_actions] = -torch.inf
         logprobs_dim = self.logsoftmax(logits_dims)[ns_range, dimensions]
         # Angle increments
         # Cases where p(angle) should be computed (nofix):

--- a/gflownet/envs/plane.py
+++ b/gflownet/envs/plane.py
@@ -283,7 +283,6 @@ class Plane(GFlowNetEnv):
         mask_invalid_actions: TensorType["n_states", "policy_output_dim"] = None,
         temperature_logits: float = 1.0,
         random_action_prob=0.0,
-        loginf: float = 1000,
     ) -> Tuple[List[Tuple], TensorType["n_states"]]:
         """
         Samples a batch of actions from a batch of policy outputs.
@@ -304,7 +303,7 @@ class Plane(GFlowNetEnv):
             logits_dims = policy_outputs[:, 0::3]
             logits_dims /= temperature_logits
         if mask_invalid_actions is not None:
-            logits_dims[mask_invalid_actions] = -loginf
+            logits_dims[mask_invalid_actions] = -torch.inf
         dimensions = Categorical(logits=logits_dims).sample()
         logprobs_dim = self.logsoftmax(logits_dims)[ns_range, dimensions]
         # Sample steps
@@ -339,7 +338,6 @@ class Plane(GFlowNetEnv):
         actions: TensorType["n_states", 2],
         states_target: TensorType["n_states", "policy_input_dim"],
         mask_invalid_actions: TensorType["batch_size", "policy_output_dim"] = None,
-        loginf: float = 1000,
     ) -> TensorType["batch_size"]:
         """
         Computes log probabilities of actions given policy outputs and actions.
@@ -353,7 +351,7 @@ class Plane(GFlowNetEnv):
         # Dimensions
         logits_dims = policy_outputs[:, 0::3]
         if mask_invalid_actions is not None:
-            logits_dims[mask_invalid_actions] = -loginf
+            logits_dims[mask_invalid_actions] = -torch.inf
         logprobs_dim = self.logsoftmax(logits_dims)[ns_range, dimensions]
         # Steps
         ns_range_noeos = ns_range[dimensions != self.eos]


### PR DESCRIPTION
### Context

The current code uses the value -1000 in place of -infinity for, for example, the logits of invalid actions. However, there is no reason to not use -infinity instead and actually this may cause problems if for some reason the logits of valid actions become close or even lower than -1000. 

### Changes

This PR replaces the -1000 (via the `loginf` variable) by `torch.inf`. This actually simplifies the code a bit, since `loginf` was an argument of a few methods, without really being used (the default 1000 was used).

Furthermore, I have taken the opportunity to simplify the last part of the calculation of the flow matching loss, since simply replacing -1000 by -infinity would have made the code crash due to nan losses. Now, the flow matching loss is computed as the combination of the loss on the terminating states and the loss on the intermediate states. This is more readable, potentially slightly faster (although some quick tests show no noticeable difference), and it will be easy to add an option to weight differently the contribution of each loss (terminating vs. intermediate states).

### Sanity checks

- [10x10 grid FM wandb report](https://wandb.ai//alexhg/Sanity%20checks/reports/Sanity-check-loginf-to-torch-inf-10x10-grid---Vmlldzo0Nzc2MzU5)
- [continuous torus wandb report](https://wandb.ai//alexhg/Sanity%20checks/reports/Sanity-check-loginf-to-torch-inf-cont-torus---Vmlldzo0Nzc2MzUz)

---

@carriepl I believe this should resolve the issues you observed training with the tetris environment, but I have not been able to reproduce the problem. 