### PR TITLE
Stoichiometry <-> Space group constraints

### DIFF
--- a/config/env/crystals/composition.yaml
+++ b/config/env/crystals/composition.yaml
@@ -12,6 +12,9 @@ min_atoms: 2
 max_atoms: 20
 min_atom_i: 1
 max_atom_i: 10
+space_group: null
+do_charge_check: False
+do_spacegroup_check: True
 # Buffer
 buffer:
   data_path: null

--- a/config/env/crystals/crystal.yaml
+++ b/config/env/crystals/crystal.yaml
@@ -13,6 +13,8 @@ lattice_parameters_kwargs:
   min_angle: 30.0
   max_angle: 150.0
   grid_size: 10
+# Stoichiometry <-> space group check
+do_stoichiometry_sg_check: False
 
 # Buffer
 buffer:

--- a/config/env/crystals/spacegroup.yaml
+++ b/config/env/crystals/spacegroup.yaml
@@ -4,6 +4,8 @@ defaults:
 _target_: gflownet.envs.crystals.spacegroup.SpaceGroup
 
 id: spacegroup
+# Stoichiometry
+n_atoms: null
 
 # Buffer
 buffer:

--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -231,7 +231,7 @@ class Composition(GFlowNetEnv):
         # Check if current state is compatible with space group
         if self.do_spacegroup_check and isinstance(self.space_group, int):
             n_atoms = [s for s in state if s > 0]
-            sg_compatible = all(Group(self.space_group).check_compatible(n_atoms))
+            sg_compatible = Group(self.space_group).check_compatible(n_atoms)[0]
         else:
             sg_compatible = True
 

--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -12,6 +12,12 @@ from torchtyping import TensorType
 
 from gflownet.envs.base import GFlowNetEnv
 from gflownet.utils.crystals.constants import ELEMENT_NAMES, OXIDATION_STATES
+from gflownet.utils.crystals.pyxtal_cache import (
+    get_space_group,
+    space_group_check_compatible,
+    space_group_lowest_free_wp_multiplicity,
+    space_group_wyckoff_gcd,
+)
 
 
 class Composition(GFlowNetEnv):
@@ -143,6 +149,86 @@ class Composition(GFlowNetEnv):
     def get_max_traj_length(self):
         return min(self.max_diff_elem, self.max_atoms // self.min_atom_i)
 
+    def _refine_compatibility_check(
+        self, state, mask_required_element, mask_unrequired_element
+    ):
+        """
+        Refines the masks (in-place) of required and unrequired elements by doing
+        compatibility checks between the space group and the number of atoms.
+
+        Args
+        ----
+        state : list
+            The state on which the masks are to be applied.
+
+        mask_required_element: list
+            Element-wise mask indicating invalid actions for required elements. This
+            masks indicates whether each individual actions is invalid or not for
+            elements that are required to be in the composition by the end of the
+            trajectory.
+
+        mask_unrequired_element: list
+            Element-wise mask indicating invalid actions for unrequired elements.
+            This masks indicates whether each individual actions is invalid or not for
+            elements that are not required to be in the composition by the end of the
+            trajectory.
+        """
+        space_group = get_space_group(self.space_group)
+        n_atoms = [s for s in state if s > 0]
+
+        # Get the greated common divisor of the group's wyckoff position.
+        # It cannot be valid to add a number of atoms that is not a
+        # multiple of this value
+        wyckoff_gcd = space_group_wyckoff_gcd(self.space_group)
+
+        # Get the multiplicity of the group's most specific wyckoff position with
+        # at least one degree of freedom
+        free_multiplicity = space_group_lowest_free_wp_multiplicity(self.space_group)
+
+        # Go through each action in the masks, validating them
+        # individually
+        for action_idx, nb_atoms_action in enumerate(
+            range(self.min_atom_i, self.max_atom_i + 1)
+        ):
+            if (
+                not mask_required_element[action_idx]
+                or not mask_unrequired_element[action_idx]
+            ):
+                # If the number of atoms added by this action is not a
+                # multiple of the greatest common divisor of the wyckoff
+                # positions' multiplicities, mark action as invalid
+                if nb_atoms_action % wyckoff_gcd != 0:
+                    mask_required_element[action_idx] = True
+                    mask_unrequired_element[action_idx] = True
+                    continue
+
+                # If the number of atoms added by this action is a
+                # multiple of a non-specific wyckoff position, nothing
+                # prevents it from being valid
+                if nb_atoms_action % free_multiplicity == 0:
+                    continue
+
+                # Checking validity by induction. If a composition is
+                # valid, adding a number of atoms is equal to the
+                # multiplicity of a non-specific position, then this
+                # action must also be valid.
+                if nb_atoms_action > free_multiplicity and (
+                    not mask_required_element[action_idx - free_multiplicity]
+                    or not mask_unrequired_element[action_idx - free_multiplicity]
+                ):
+                    continue
+
+                # If the composition resulting from this action is
+                # incompatible with the space group, mark action as
+                # invalid
+                n_atoms_post_action = n_atoms + [nb_atoms_action]
+                sg_compatible = space_group_check_compatible(
+                    self.space_group, n_atoms_post_action
+                )
+                if not sg_compatible:
+                    mask_required_element[action_idx] = True
+                    mask_unrequired_element[action_idx] = True
+
     def get_mask_invalid_actions_forward(self, state=None, done=None):
         """
         Returns a vector of length the action space + 1: True if forward action is
@@ -165,32 +251,62 @@ class Composition(GFlowNetEnv):
         n_unused_required_elements = len(unused_required_elements)
         n_used_atoms = sum(state)
 
+        if self.do_spacegroup_check and isinstance(self.space_group, int):
+            space_group = get_space_group(self.space_group)
+
+            # Determine, based on the space group's Wyckoff's positions, what
+            # is the min/max number of atoms of a given element that could be
+            # added.
+            most_specific_wp = space_group.get_wyckoff_position(-1)
+            min_atom_i = most_specific_wp.multiplicity
+
+            wyckoff_gcd = space_group_wyckoff_gcd(self.space_group)
+            max_atom_i = (self.max_atom_i // wyckoff_gcd) * wyckoff_gcd
+
+            # Determine if the current composition is compatible with the
+            # space group
+            n_atoms = [s for s in state if s > 0]
+            sg_compatible = space_group_check_compatible(self.space_group, n_atoms)
+        else:
+            # Don't impose additional constraints on the min/max number of
+            # atoms per element
+            min_atom_i = self.min_atom_i
+            max_atom_i = self.max_atom_i
+
+            # Assume the current composition is compatible with the space group
+            sg_compatible = True
+
         # Compute the min and max number of atoms to add to satisfy constraints
         nb_atoms_still_needed = max(0, self.min_atoms - n_used_atoms)
         nb_atoms_still_allowed = self.max_atoms - n_used_atoms
+
         # Compute the min and max number of elements to add to satisfy constraints
         nb_elems_still_needed = max(
             n_unused_required_elements, self.min_diff_elem - n_used_elements
         )
         nb_elems_still_allowed = self.max_diff_elem - n_used_elements
+
         # How many elements, other than the required elements, can still be added
         n_max_unrequired_elements_left = self.max_diff_elem - (
             n_used_elements + n_unused_required_elements
         )
+
         # What is the minimum number of atoms needed for a new required element in
         # order to reach the number of required atoms before we can't add new elements
         # anymore
         min_atoms_per_required_element = max(
-            nb_atoms_still_needed - (nb_elems_still_allowed - 1) * self.max_atom_i,
-            self.min_atom_i,
+            nb_atoms_still_needed - (nb_elems_still_allowed - 1) * max_atom_i,
+            min_atom_i,
         )
+
         # What is the maximum number of atoms allowed for a new required element in
         # order to be able to reach the number of required elements before we can't add
         # new atoms anymore
         max_atoms_per_required_element = min(
-            nb_atoms_still_allowed - (nb_elems_still_needed - 1) * self.min_atom_i,
-            self.max_atom_i,
+            nb_atoms_still_allowed - (nb_elems_still_needed - 1) * min_atom_i,
+            max_atom_i,
         )
+
         # Determine if there is a need to add unrequired elements to either reach the
         # number of required distinct elements or the number of required atoms
         unrequired_element_needed = (
@@ -198,14 +314,15 @@ class Composition(GFlowNetEnv):
             or max_atoms_per_required_element * n_unused_required_elements
             < nb_atoms_still_needed
         )
+
         # Determine if it is possible to add unrequired elements without going over the
         # maximum number of elements or atoms
         unrequired_element_allowed = (
             n_max_unrequired_elements_left > 0
-            and min_atoms_per_required_element * n_unused_required_elements
-            + self.min_atom_i
-            < self.max_atoms
+            and min_atoms_per_required_element * n_unused_required_elements + min_atom_i
+            < nb_atoms_still_allowed
         )
+
         # Compute the minimum and maximum number of atoms available for an unrequired
         # element
         if unrequired_element_needed:
@@ -217,23 +334,16 @@ class Composition(GFlowNetEnv):
             # Unrequired elements are optional so there is no minium amount to add for
             # them and the maximum is only as high as possible without preventing the
             # addition of the required elements later
-            min_atoms_per_unrequired_element = 0
+            min_atoms_per_unrequired_element = min_atom_i
             max_atoms_per_unrequired_element = min(
                 nb_atoms_still_allowed
                 - min_atoms_per_required_element * n_unused_required_elements,
-                self.max_atom_i,
+                max_atom_i,
             )
         else:
             # No unrequired elements can be added
             min_atoms_per_unrequired_element = 0
             max_atoms_per_unrequired_element = 0
-
-        # Check if current state is compatible with space group
-        if self.do_spacegroup_check and isinstance(self.space_group, int):
-            n_atoms = [s for s in state if s > 0]
-            sg_compatible = Group(self.space_group).check_compatible(n_atoms)[0]
-        else:
-            sg_compatible = True
 
         if n_used_atoms < self.min_atoms:
             mask[-1] = True
@@ -242,7 +352,9 @@ class Composition(GFlowNetEnv):
         if any(r not in used_elements for r in self.required_elements):
             mask[-1] = True
         if not sg_compatible:
-            mask[-1] = True
+            # The current composition is incompatible with the space group,
+            # we must allow EOS to end the trajectory.
+            mask[-1] = False
 
         # Obtain action mask for each category of element
         def get_element_mask(min_atoms, max_atoms):
@@ -257,6 +369,13 @@ class Composition(GFlowNetEnv):
         mask_unrequired_element = get_element_mask(
             min_atoms_per_unrequired_element, max_atoms_per_unrequired_element
         )
+
+        # If required, refine the masks by doing compatibility checks between
+        # the space group and the number of atoms
+        if self.do_spacegroup_check and isinstance(self.space_group, int):
+            self._refine_compatibility_check(
+                state, mask_required_element, mask_unrequired_element
+            )
 
         # Set action mask for each element
         nb_actions_per_element = self.max_atom_i - self.min_atom_i + 1

--- a/gflownet/envs/crystals/crystal.py
+++ b/gflownet/envs/crystals/crystal.py
@@ -53,7 +53,7 @@ class Crystal(GFlowNetEnv):
         composition_kwargs: Optional[Dict] = None,
         space_group_kwargs: Optional[Dict] = None,
         lattice_parameters_kwargs: Optional[Dict] = None,
-        do_stoichiometry_sg_check : bool = False,
+        do_stoichiometry_sg_check: bool = False,
         **kwargs,
     ):
         self.composition_kwargs = composition_kwargs or {}
@@ -348,9 +348,7 @@ class Crystal(GFlowNetEnv):
             if valid and executed_action == self.composition.eos:
                 self.stage = Stage.SPACE_GROUP
                 if self.do_stoichiometry_sg_check:
-                    self.space_group.set_n_atoms(
-                        self.composition.state
-                    )
+                    self.space_group.set_n_atoms(self.composition.state)
         elif self.stage == Stage.SPACE_GROUP:
             stage_group_action = self._depad_action(action, Stage.SPACE_GROUP)
             _, executed_action, valid = self.space_group.step(stage_group_action)

--- a/gflownet/envs/crystals/crystal.py
+++ b/gflownet/envs/crystals/crystal.py
@@ -53,11 +53,13 @@ class Crystal(GFlowNetEnv):
         composition_kwargs: Optional[Dict] = None,
         space_group_kwargs: Optional[Dict] = None,
         lattice_parameters_kwargs: Optional[Dict] = None,
+        do_stoichiometry_sg_check : bool = False,
         **kwargs,
     ):
         self.composition_kwargs = composition_kwargs or {}
         self.space_group_kwargs = space_group_kwargs or {}
         self.lattice_parameters_kwargs = lattice_parameters_kwargs or {}
+        self.do_stoichiometry_sg_check = do_stoichiometry_sg_check
 
         self.composition = Composition(**self.composition_kwargs)
         self.space_group = SpaceGroup(**self.space_group_kwargs)
@@ -345,6 +347,10 @@ class Crystal(GFlowNetEnv):
             _, executed_action, valid = self.composition.step(composition_action)
             if valid and executed_action == self.composition.eos:
                 self.stage = Stage.SPACE_GROUP
+                if self.do_stoichiometry_sg_check:
+                    self.space_group.set_n_atoms(
+                        self.composition.state
+                    )
         elif self.stage == Stage.SPACE_GROUP:
             stage_group_action = self._depad_action(action, Stage.SPACE_GROUP)
             _, executed_action, valid = self.space_group.step(stage_group_action)

--- a/gflownet/envs/crystals/crystal.py
+++ b/gflownet/envs/crystals/crystal.py
@@ -348,7 +348,9 @@ class Crystal(GFlowNetEnv):
             if valid and executed_action == self.composition.eos:
                 self.stage = Stage.SPACE_GROUP
                 if self.do_stoichiometry_sg_check:
-                    self.space_group.set_n_atoms(self.composition.state)
+                    self.space_group.set_n_atoms_compatibility_dict(
+                        self.composition.state
+                    )
         elif self.stage == Stage.SPACE_GROUP:
             stage_group_action = self._depad_action(action, Stage.SPACE_GROUP)
             _, executed_action, valid = self.space_group.step(stage_group_action)

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -82,10 +82,6 @@ class SpaceGroup(GFlowNetEnv):
             the space group. 0's are removed from the list. If None, composition/space
             group constraints are ignored.
         """
-        if n_atoms is not None:
-            self.n_atoms = [n for n in n_atoms if n > 0]
-        else:
-            self.n_atoms = None
         # Get dictionaries
         self.crystal_lattice_systems = _get_crystal_lattice_systems()
         self.point_symmetries = _get_point_symmetries()
@@ -93,12 +89,8 @@ class SpaceGroup(GFlowNetEnv):
         self.n_crystal_lattice_systems = len(self.crystal_lattice_systems)
         self.n_point_symmetries = len(self.point_symmetries)
         self.n_space_groups = len(self.space_groups)
-        # Get compatibility with stoichiometry
-        self.compatibility_stoichiometry_dict = (
-            SpaceGroup.get_compatibility_stoichiometry_dict(
-                self.n_atoms, self.space_groups.keys()
-            )
-        )
+        # Stoichiometry and compatibility dict
+        self.n_atoms, self.compatibility_stoichiometry_dict = self.set_n_atoms(n_atoms)
         # Define indices
         self.cls_idx, self.ps_idx, self.sg_idx = 0, 1, 2
         self.ref_state_factors = [1, 2]
@@ -566,6 +558,19 @@ class SpaceGroup(GFlowNetEnv):
         if state is None:
             state = self.state
         return sum([int(s > 0) * f for s, f in zip(state, self.ref_state_factors)])
+
+    def set_n_atoms(self, composition):
+        if composition is None:
+            self.n_atoms = None
+        else:
+            self.n_atoms = [n for n in composition if n > 0]
+        # Get compatibility with stoichiometry
+        self.compatibility_stoichiometry_dict = (
+            SpaceGroup.get_compatibility_stoichiometry_dict(
+                self.n_atoms, self.space_groups.keys()
+            )
+        )
+        return self.n_atoms, self.compatibility_stoichiometry_dict
 
     @staticmethod
     def get_compatibility_stoichiometry_dict(

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -603,7 +603,7 @@ class SpaceGroup(GFlowNetEnv):
             return {sg: True for sg in space_groups}
         assert all([n > 0 for n in n_atoms])
         assert all([sg > 0 and sg <= 230 for sg in space_groups])
-        return {sg: all(Group(sg).check_compatible(n_atoms)) for sg in space_groups}
+        return {sg: Group(sg).check_compatible(n_atoms)[0] for sg in space_groups}
 
     def get_all_terminating_states(
         self, apply_stoichiometry_constraints: Optional[bool] = True

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -794,10 +794,12 @@ class GFlowNetAgent:
             # Moving average of the loss for early stopping
             if loss_term_ema and loss_flow_ema:
                 loss_term_ema = (
-                    self.ema_alpha * losses[1].item() + (1.0 - self.ema_alpha) * loss_term_ema
+                    self.ema_alpha * losses[1].item()
+                    + (1.0 - self.ema_alpha) * loss_term_ema
                 )
                 loss_flow_ema = (
-                    self.ema_alpha * losses[2].item() + (1.0 - self.ema_alpha) * loss_flow_ema
+                    self.ema_alpha * losses[2].item()
+                    + (1.0 - self.ema_alpha) * loss_flow_ema
                 )
                 if (
                     loss_term_ema < self.early_stopping

--- a/gflownet/utils/crystals/build_lattice_dicts.py
+++ b/gflownet/utils/crystals/build_lattice_dicts.py
@@ -3,20 +3,23 @@ Reads a dictionary with crystal classes and their point groups, and a dictionary
 the point group of each space group, and outputs a dictionary containing both the point
 groups and space groups of each crystal class.
 """
-import numpy as np
 import sys
-import yaml
-from pymatgen.symmetry.groups import PointGroup, SpaceGroup, SymmetryGroup
-from pymatgen.symmetry.groups import sg_symbol_from_int_number
-
 from argparse import ArgumentParser
 
+import numpy as np
+import yaml
 from lattice_constants import (
     CRYSTAL_CLASSES_WIKIPEDIA,
     CRYSTAL_LATTICE_SYSTEMS,
     CRYSTAL_SYSTEMS,
     POINT_SYMMETRIES,
     RHOMBOHEDRAL_SPACE_GROUPS_WIKIPEDIA,
+)
+from pymatgen.symmetry.groups import (
+    PointGroup,
+    SpaceGroup,
+    SymmetryGroup,
+    sg_symbol_from_int_number,
 )
 
 N_SPACE_GROUPS = 230

--- a/gflownet/utils/crystals/pyxtal_cache.py
+++ b/gflownet/utils/crystals/pyxtal_cache.py
@@ -1,0 +1,162 @@
+import numpy
+from pyxtal.symmetry import Group
+
+_pyxtal_space_group_cache = {}
+_pyxtal_check_compatible_cache = {}
+_pyxtal_space_group_free_wp_multiplicity = {}
+_pyxtal_space_group_wp_lowest_common_factor = {}
+
+
+def get_space_group(group_index):
+    """
+    Returns a PyxTal Group object representing a crystal space group
+
+    This methods includes a lazy caching mechanism since the instantiation of
+    a pyxtal.symmetry.Group object is expensive.
+
+    Args
+    ----
+    group_index : int
+        Index (starting at 1) of the space group
+
+    Returns
+    -------
+    pyxtal.symmetry.Group
+        Requested space group
+    """
+    if group_index not in _pyxtal_space_group_cache:
+        _pyxtal_space_group_cache[group_index] = Group(group_index)
+    return _pyxtal_space_group_cache[group_index]
+
+
+def space_group_check_compatible(group_index, composition):
+    """
+    Determines if a given atom composition is compatible with a space group
+
+    This methods internally relies on pyxtal.symmetry.Group.check_compatible()
+    to determine if a composition and a space group are compatible but this
+    method includes a caching mechanism since the call to check_compatible()
+    is expensive.
+
+    Args
+    ----
+    group_index : int
+        Index (starting at 1) of the space group
+
+    composition : list of ints
+        Atom composition. Each element in the list corresponds to the number
+        of atoms of a distinct element in the crystal conventional cell
+
+    Returns
+    -------
+    is_compatible : bool
+        True if the composition and space group are compatible. False
+        otherwise.
+    """
+    # Remove from composition the number of atoms that are a multiple of the
+    # space group's most specific free wyckoff position. This improves the
+    # cache hit rate without affecting the validity of the composition
+    free_multiplicity = space_group_lowest_free_wp_multiplicity(group_index)
+    composition = [c for c in composition if c % free_multiplicity != 0]
+
+    # Get a tuple version of composition to ensure immutability and,
+    # therefore, allow dictionary indexing by composition. Ensure the elements
+    # in the tuple are sorted to improve cache hit rate since it doesn't
+    # affect the validity of a composition
+    t_composition = tuple(sorted(composition))
+
+    # Check in the cache to see if PyxTal has previously been called to
+    # validate this space group and composition
+    if group_index in _pyxtal_check_compatible_cache:
+        if t_composition in _pyxtal_check_compatible_cache[group_index]:
+            return _pyxtal_check_compatible_cache[group_index][t_composition]
+    else:
+        _pyxtal_check_compatible_cache[group_index] = {}
+
+    # Obtain the space group object
+    space_group = get_space_group(group_index)
+
+    # Perform compatibility check
+    is_compatible = space_group.check_compatible(composition)[0]
+
+    # Store result in cache before returning it
+    _pyxtal_check_compatible_cache[group_index][t_composition] = is_compatible
+    return is_compatible
+
+
+def space_group_lowest_free_wp_multiplicity(group_index):
+    """
+    Returns the multiplicity of a space group's most specific free WP.
+
+    This methods includes a lazy caching mechanism since the call to PyXtal
+    methods to determine if a Wyckoff position is fixed or free is expensive.
+
+    Args
+    ----
+    group_index : int
+        Index (starting at 1) of the space group
+
+    Returns
+    -------
+    multiplicity : int
+        Multiplicity of the most specific free wyckoff position.
+    """
+    # Check in the cache to see if the multiplicity has previously been
+    # computed for this space group
+    if group_index in _pyxtal_space_group_free_wp_multiplicity:
+        return _pyxtal_space_group_free_wp_multiplicity[group_index]
+
+    # Obtain reference to the space group
+    space_group = get_space_group(group_index)
+
+    # Iterate over all of the space group's wyckoff positions from most
+    # specific to most general until a wyckoff position with a degree of
+    # freedom is found.
+    multiplicity = None
+    for wyckoff_idx in range(1, len(space_group.wyckoffs) + 1):
+        wyckoff_position = space_group.get_wyckoff_position(-wyckoff_idx)
+        if wyckoff_position.get_dof() > 0:
+            multiplicity = wyckoff_position.multiplicity
+            break
+
+    # Store the result in cache before retuning it
+    _pyxtal_space_group_free_wp_multiplicity[group_index] = multiplicity
+    return multiplicity
+
+
+def space_group_wyckoff_gcd(group_index):
+    """
+    Returns the greatest common divisor of a space group's Wyckoff positions
+
+    This methods includes a lazy caching mechanism.
+
+    Args
+    ----
+    group_index : int
+        Index (starting at 1) of the space group
+
+    Returns
+    -------
+    gcd : int
+        Greatest common divisor of the group's wyckoff position.
+    """
+    # Check in the cache to see if the lowest common factor has previously
+    # been computed for this space group
+    if group_index in _pyxtal_space_group_wp_lowest_common_factor:
+        return _pyxtal_space_group_wp_lowest_common_factor[group_index]
+
+    # Obtain reference to the space group
+    space_group = get_space_group(group_index)
+
+    # Iterate over all of the space group's wyckoff positions from most
+    # specific to most general until a wyckoff position with a degree of
+    # freedom is found.
+    multiplicities = []
+    for wyckoff_idx in range(0, len(space_group.wyckoffs)):
+        wyckoff_position = space_group.get_wyckoff_position(wyckoff_idx)
+        multiplicities.append(wyckoff_position.multiplicity)
+    gcd = numpy.gcd.reduce(multiplicities)
+
+    # Store the result in cache before retuning it
+    _pyxtal_space_group_wp_lowest_common_factor[group_index] = gcd
+    return gcd

--- a/scripts/pyxtal/compatibility_sg_n_atoms.py
+++ b/scripts/pyxtal/compatibility_sg_n_atoms.py
@@ -1,0 +1,40 @@
+import itertools
+import time
+
+import numpy as np
+from pyxtal.symmetry import Group
+from tqdm import tqdm
+
+N_SYMMETRY_GROUPS = 230
+N_SPECIES = 5
+MAX_N_ATOMS = 10
+
+n_compatible = 0
+n_not_compatible = 0
+times = []
+for idx in tqdm(range(1, N_SYMMETRY_GROUPS + 1)):
+    sg = Group(idx)
+    times_sg = []
+    for n_atoms in itertools.product(range(1, MAX_N_ATOMS + 1), repeat=N_SPECIES):
+        time0 = time.time()
+        is_compatible, _ = sg.check_compatible(list(n_atoms))
+        times_sg.append(time.time() - time0)
+        if is_compatible is True:
+            n_compatible += 1
+        else:
+            n_not_compatible += 1
+    times.append((np.mean(times_sg), np.std(times_sg)))
+
+n_total = n_compatible + n_not_compatible
+pct_compatible = n_compatible / n_total * 100
+pct_not_compatible = n_not_compatible / n_total * 100
+print(f"Number compatible: {n_compatible}/{n_total} ({pct_compatible} %)")
+print(f"Number not compatible: {n_not_compatible}/{n_total} ({pct_not_compatible} %)")
+
+time_per_sg_mean = np.mean([t[0] for t in times]) * 1000
+time_per_sg_std = np.mean([t[1] for t in times]) * 1000
+n_iters_per_sg = n_total / N_SYMMETRY_GROUPS
+time_per_check_mean = time_per_sg_mean / n_iters_per_sg
+time_per_check_std = time_per_sg_std / n_iters_per_sg
+print(f"Mean (std) time per space group: {time_per_sg_mean} ms ({time_per_sg_std})")
+print(f"Mean (std) time per check: {time_per_check_mean} ms ({time_per_check_std})")

--- a/scripts/pyxtal/compatibility_sg_n_atoms.py
+++ b/scripts/pyxtal/compatibility_sg_n_atoms.py
@@ -1,3 +1,8 @@
+"""
+Calculates the compatibility between space groups and stoichiometries for all the
+combinations spanned by the N_SYMMETRY_GROUPS, N_SPECIES and MAX_N_ATOMS. The results
+are printed to stdout.
+"""
 import itertools
 import time
 
@@ -6,8 +11,8 @@ from pyxtal.symmetry import Group
 from tqdm import tqdm
 
 N_SYMMETRY_GROUPS = 230
-N_SPECIES = 5
-MAX_N_ATOMS = 10
+N_SPECIES = 3
+MAX_N_ATOMS = 20
 
 n_compatible = 0
 n_not_compatible = 0
@@ -15,7 +20,8 @@ times = []
 for idx in tqdm(range(1, N_SYMMETRY_GROUPS + 1)):
     sg = Group(idx)
     times_sg = []
-    for n_atoms in itertools.product(range(1, MAX_N_ATOMS + 1), repeat=N_SPECIES):
+    for n_atoms_withzeros in itertools.product(range(0, MAX_N_ATOMS + 1), repeat=N_SPECIES):
+        n_atoms = [n for n in n_atoms_withzeros if n > 0]
         time0 = time.time()
         is_compatible, _ = sg.check_compatible(list(n_atoms))
         times_sg.append(time.time() - time0)

--- a/scripts/pyxtal/compatibility_sg_n_atoms.py
+++ b/scripts/pyxtal/compatibility_sg_n_atoms.py
@@ -20,7 +20,9 @@ times = []
 for idx in tqdm(range(1, N_SYMMETRY_GROUPS + 1)):
     sg = Group(idx)
     times_sg = []
-    for n_atoms_withzeros in itertools.product(range(0, MAX_N_ATOMS + 1), repeat=N_SPECIES):
+    for n_atoms_withzeros in itertools.product(
+        range(0, MAX_N_ATOMS + 1), repeat=N_SPECIES
+    ):
         n_atoms = [n for n in n_atoms_withzeros if n > 0]
         time0 = time.time()
         is_compatible, _ = sg.check_compatible(list(n_atoms))

--- a/scripts/pyxtal/get_n_compatible_for_sg.py
+++ b/scripts/pyxtal/get_n_compatible_for_sg.py
@@ -1,0 +1,76 @@
+"""
+Calculates the compatibility between space group --space_group and all the stoichiometries
+spanned by the --max_n_atoms and --max_n_species. The results are written to a file in
+--output_dir.
+"""
+import itertools
+import time
+from argparse import ArgumentParser
+from pathlib import Path
+
+import numpy as np
+from pyxtal.symmetry import Group
+from tqdm import tqdm
+
+parser = ArgumentParser()
+parser.add_argument(
+    "--output_dir",
+    default="/home/mila/h/hernanga/crystal-gfn/data/crystals/compatibility_composition_spacegroup",
+    type=str,
+    help="Output directory",
+)
+parser.add_argument(
+    "--space_group",
+    default=1,
+    type=int,
+    help="Space group",
+)
+parser.add_argument(
+    "--max_n_species",
+    default=5,
+    type=int,
+    help="Maximum number of different elements",
+)
+parser.add_argument(
+    "--max_n_atoms",
+    default=20,
+    type=int,
+    help="Maximum number of atoms per species",
+)
+args = parser.parse_args()
+
+space_group = args.space_group
+assert space_group > 0 and space_group <= 230
+max_n_species = args.max_n_species
+assert max_n_species > 0 and max_n_species < 10
+max_n_atoms = args.max_n_atoms
+assert max_n_atoms > 0 and max_n_atoms < 50
+
+filename = f"sg-{space_group}_max_els-{max_n_species}_max_atoms-{max_n_atoms}.csv"
+f = open(Path(args.output_dir) / filename, "w")
+
+
+n_compatible = 0
+n_not_compatible = 0
+times = []
+sg = Group(space_group)
+for n_atoms_withzeros in tqdm(
+    itertools.product(range(0, max_n_atoms + 1), repeat=max_n_species)
+):
+    n_atoms = [n for n in n_atoms_withzeros if n > 0]
+    time0 = time.time()
+    is_compatible, _ = sg.check_compatible(list(n_atoms))
+    times.append(time.time() - time0)
+    if is_compatible is True:
+        n_compatible += 1
+    else:
+        n_not_compatible += 1
+
+n_total = n_compatible + n_not_compatible
+time_mean = np.mean(times)
+time_std = np.std(times)
+
+f.write("space_group,n_compatible,n_not_compatible,n_total,time_mean,time_std\n")
+f.write(
+    f"{space_group},{n_compatible},{n_not_compatible},{n_total},{time_mean},{time_std}\n"
+)

--- a/scripts/pyxtal/pyxtal_vs_pymatgen.py
+++ b/scripts/pyxtal/pyxtal_vs_pymatgen.py
@@ -1,0 +1,23 @@
+from argparse import ArgumentParser
+
+from pymatgen.symmetry.groups import (
+    PointGroup,
+    SpaceGroup,
+    SymmetryGroup,
+    sg_symbol_from_int_number,
+)
+from pyxtal.symmetry import Group
+
+N_SYMMETRY_GROUPS = 230
+
+for idx in range(1, N_SYMMETRY_GROUPS + 1):
+    sg_int = sg_symbol_from_int_number(idx)
+    sg_pymatgen = SpaceGroup(sg_int)
+    sg_pyxtal = Group(idx)
+    if sg_pymatgen.symbol != sg_pyxtal.symbol or sg_pyxtal.number != idx:
+        print(f"idx: {idx}")
+        print(f"sg_int: {sg_int}")
+        print(f"sg_pyxtal_number: {sg_pyxtal.number}")
+        print(f"pymatgen symbol: {sg_pymatgen.symbol}")
+        print(f"pyxtal symbol: {sg_pyxtal.symbol}")
+        print("---")

--- a/scripts/pyxtal/pyxtal_vs_pymatgen.py
+++ b/scripts/pyxtal/pyxtal_vs_pymatgen.py
@@ -1,3 +1,7 @@
+"""
+A simple script to determine which space group symbols are different in pyxtal and
+pymatgen.
+"""
 from argparse import ArgumentParser
 
 from pymatgen.symmetry.groups import (

--- a/tests/gflownet/envs/test_composition.py
+++ b/tests/gflownet/envs/test_composition.py
@@ -1,8 +1,8 @@
+import common
 import numpy as np
 import pytest
 import torch
 
-import common
 from gflownet.envs.crystals.composition import Composition
 
 
@@ -12,6 +12,17 @@ def env():
         elements=4,
         alphabet={1: "H", 2: "He", 3: "Li", 4: "Be"},
         oxidation_states={1: [-1, 0, 1], 2: [0], 3: [0, 1], 4: [0, 1, 2]},
+    )
+
+
+@pytest.fixture
+def env_with_spacegroup():
+    return Composition(
+        elements=4,
+        alphabet={1: "H", 2: "He", 3: "Li", 4: "Be"},
+        oxidation_states={1: [-1, 0, 1], 2: [0], 3: [0, 1], 4: [0, 1, 2]},
+        space_group=162,
+        do_spacegroup_check=True,
     )
 
 
@@ -326,7 +337,11 @@ def test__required_elements_does_not_cause_environment_to_get_stuck():
 def test__required_atoms_does_not_cause_environment_to_get_stuck():
     required_elements = []
     env = Composition(
-        elements=10, min_diff_elem=2, max_diff_elem=2, min_atoms=20, max_atoms=20,
+        elements=10,
+        min_diff_elem=2,
+        max_diff_elem=2,
+        min_atoms=20,
+        max_atoms=20,
     )
 
     while not env.done:
@@ -358,3 +373,7 @@ def test__insufficient_elements_left_does_not_cause_environment_to_get_stuck():
 
 def test__all_env_common(env):
     return common.test__all_env_common(env)
+
+
+def test__all_env_common__with_spacegroup_constraints(env_with_spacegroup):
+    return common.test__all_env_common(env_with_spacegroup)

--- a/tests/gflownet/envs/test_crystal.py
+++ b/tests/gflownet/envs/test_crystal.py
@@ -1,8 +1,8 @@
+import common
 import pytest
 import torch
 from torch import Tensor
 
-import common
 from gflownet.envs.crystals.crystal import Crystal, Stage
 from gflownet.envs.crystals.lattice_parameters import TRICLINIC
 
@@ -11,6 +11,15 @@ from gflownet.envs.crystals.lattice_parameters import TRICLINIC
 def env():
     return Crystal(
         composition_kwargs={"elements": 4}, lattice_parameters_kwargs={"grid_size": 10}
+    )
+
+
+@pytest.fixture
+def env_with_stoichiometry_sg_check():
+    return Crystal(
+        composition_kwargs={"elements": 4},
+        lattice_parameters_kwargs={"grid_size": 10},
+        do_stoichiometry_sg_check=True,
     )
 
 
@@ -361,3 +370,7 @@ def test__get_mask_invalid_actions_forward__masks_all_actions_from_different_sta
 
 def test__all_env_common(env):
     return common.test__all_env_common(env)
+
+
+def test__all_env_common(env_with_stoichiometry_sg_check):
+    return common.test__all_env_common(env_with_stoichiometry_sg_check)

--- a/tests/gflownet/envs/test_lattice_parameters.py
+++ b/tests/gflownet/envs/test_lattice_parameters.py
@@ -1,18 +1,17 @@
+import common
 import pytest
-
 import torch
 
-import common
 from gflownet.envs.crystals.lattice_parameters import (
     CUBIC,
     HEXAGONAL,
     LATTICE_SYSTEMS,
-    LatticeParameters,
     MONOCLINIC,
     ORTHORHOMBIC,
     RHOMBOHEDRAL,
     TETRAGONAL,
     TRICLINIC,
+    LatticeParameters,
 )
 
 

--- a/tests/gflownet/envs/test_spacegroup.py
+++ b/tests/gflownet/envs/test_spacegroup.py
@@ -7,6 +7,8 @@ from pyxtal.symmetry import Group
 
 from gflownet.envs.crystals.spacegroup import SpaceGroup
 
+N_ATOMS = [3, 7, 9]
+
 
 @pytest.fixture
 def env():
@@ -15,7 +17,7 @@ def env():
 
 @pytest.fixture
 def env_with_composition():
-    return SpaceGroup(n_atoms=[3, 7, 0, 9])
+    return SpaceGroup(n_atoms=N_ATOMS)
 
 
 def test__environment__initializes_properly():
@@ -203,19 +205,13 @@ def test__state2readable2state(env, state):
     )
 
 
-def test__env_with_composition__removes_zeros(env_with_composition):
-    assert all([n > 0 for n in env_with_composition.n_atoms])
-
-
 def test__env_with_composition__compatibility_dict_as_in_pyxtal(env_with_composition):
     for (
         sg,
         is_compatible,
-    ) in env_with_composition.compatibility_stoichiometry_dict.items():
+    ) in env_with_composition.n_atoms_compatibility_dict.items():
         sg_pyxtal = Group(sg)
-        assert (
-            sg_pyxtal.check_compatible(env_with_composition.n_atoms)[0] == is_compatible
-        )
+        assert sg_pyxtal.check_compatible(N_ATOMS)[0] == is_compatible
 
 
 def test__get_mask_invalid_actions_forward__incompatible_sg_are_invalid(
@@ -237,7 +233,7 @@ def test__get_mask_invalid_actions_forward__incompatible_sg_are_invalid(
         ref = env_with_composition.get_ref_index(state)
         for sg in range(1, env_with_composition.n_space_groups + 1):
             sg_pyxtal = Group(sg)
-            is_compatible = sg_pyxtal.check_compatible(env_with_composition.n_atoms)[0]
+            is_compatible = sg_pyxtal.check_compatible(N_ATOMS)[0]
             action = (env_with_composition.sg_idx, sg, ref)
             if not is_compatible:
                 assert mask_f[env_with_composition.action_space.index(action)] is True

--- a/tests/gflownet/envs/test_spacegroup.py
+++ b/tests/gflownet/envs/test_spacegroup.py
@@ -214,8 +214,7 @@ def test__env_with_composition__compatibility_dict_as_in_pyxtal(env_with_composi
     ) in env_with_composition.compatibility_stoichiometry_dict.items():
         sg_pyxtal = Group(sg)
         assert (
-            all(sg_pyxtal.check_compatible(env_with_composition.n_atoms))
-            == is_compatible
+            sg_pyxtal.check_compatible(env_with_composition.n_atoms)[0] == is_compatible
         )
 
 
@@ -238,9 +237,7 @@ def test__get_mask_invalid_actions_forward__incompatible_sg_are_invalid(
         ref = env_with_composition.get_ref_index(state)
         for sg in range(1, env_with_composition.n_space_groups + 1):
             sg_pyxtal = Group(sg)
-            is_compatible = all(
-                sg_pyxtal.check_compatible(env_with_composition.n_atoms)
-            )
+            is_compatible = sg_pyxtal.check_compatible(env_with_composition.n_atoms)[0]
             action = (env_with_composition.sg_idx, sg, ref)
             if not is_compatible:
                 assert mask_f[env_with_composition.action_space.index(action)] is True


### PR DESCRIPTION
## Summary

This PR incorporates constraints between the stoichiometry and the space group into the space group, composition and crystal environments. The constraints are computed via `pyxtal`, specifically the method `pyxtal.symmetry.Group.check_compatible()`, which checks whether a given stoichiometry (list of number of atoms per element) as argument is compatible with a space group (the class `Group`).

## Changes

### Space group environment

- A new argument `n_atoms` of the environment passes the stoichiometry information to the environment (can be `None` to make no checks).
- A dictionary `{space group number: is_compatible}` of compatibility is computed to determine which space groups are valid for the stoichiometry given by `n_atoms`: `self.compatibility_stoichiometry_dict`
- `self.compatibility_stoichiometry_dict` is used to further constrain the mask of forward invalid actions. 
- `self.compatibility_stoichiometry_dict` is also used to constrain `get_all_terminating_states()`.

I have implemented additional tests that make me moderately confident about the correctness of the implementation.

**Question**: are other methods impacted by the stoichiometry constraint?

### Composition environment

- A new `space_group` argument, together with `do_spacegroup_check`, pass the space group information to the environment and control whether doing the check or not.
- The space group is used to further constrain the mask of forward invalid actions. Specifically, the only constraint I have implemented is that if the current state is not compatible with the space group, then the EOS cannot be selected.

I have *not* implemented specific additional tests for the composition environment because we in the crystal environment we currently sample first the composition, without knowing the space group, therefore this constraint is currently not used in practice. I have only added a `common.test__all_env_common()` with an environment that has a space group and performs the check.

**Question**: can we _easily_ further constraint the forward masks?

**Question**: are other methods impacted by the stoichiometry constraint?

### Crystal environment

- A new `do_stoichiometry_sg_check` controls whether adding stoichiometry <-> space group constraints.
- It simply passes the composition to the space group environment after sampling the EOS action in the composition.

I have *not* implemented specific additional tests for the crystal environment (but probably we should!). I have only added a `common.test__all_env_common()` with an environment that has `do_stoichiometry_sg_check = True`.

### Other

- I have added a couple of playground scripts in `scripts/pyxtal`.
- There are a few changes unrelated to the goal of the PR from `black` and `isort`, for example in `gflownet/gflownet.py` and `gflownet/utils/crystals/build_lattice_dicts.py`.

## Insights about scope of constraints

I have run the script `scripts/pyxtal/compatibility_sg_n_atoms.py` to calculate the number of compatible stoichiometries for all space groups, by calculating all stoichiometries of 5 elements with up to 10 atoms each: 

Number compatible: 3,525,035/23,000,000 (15.3 %)
Number not compatible: 19,474,965/23,000,000 (84.7 %)

So the vast majority are not compatible, therefore we can expect these constraints to have a significant impact in at least reducing the training time.

## Checks

- [x] `python -m pytest tests/gflownet/envs/` :heavy_check_mark: 
- [x] `black .`
- [x] `isort --profile black .` 

## References

- [How PyXtal works](https://pyxtal.readthedocs.io/en/latest/Algorithm.html?highlight=lattice#how-pyxtal-works)
- [`pyxtal.symmetry module`](https://pyxtal.readthedocs.io/en/latest/pyxtal.symmetry.html?#pyxtal.symmetry.Group)