### PR TITLE
Boring PR to make Tree states 2D tensors

### DIFF
--- a/gflownet/envs/tree.py
+++ b/gflownet/envs/tree.py
@@ -200,7 +200,7 @@ class Tree(GFlowNetEnv):
         self.components = threshold_components
         self.beta_params_min = beta_params_min
         self.beta_params_max = beta_params_max
-        # Source will contain information about the current stage (on the 0-th position),
+        # Source will contain information about the current stage (on the last position),
         # and up to 2**max_depth - 1 nodes, each with Attribute.N attributes, for a total of
         # 1 + Attribute.N * (2**max_depth - 1) values. The root (0-th node) of the
         # source is initialized with a classifier.

--- a/gflownet/envs/tree.py
+++ b/gflownet/envs/tree.py
@@ -131,7 +131,7 @@ class Tree(GFlowNetEnv):
         1               2
     3       4       5       6
 
-    States are represented by a tensor with shape [n_nodes + 1, 5], where each row k-th
+    States are represented by a tensor with shape [n_nodes + 1, 5], where each k-th row
     corresponds to the attributes of the k-th node of the tree. The last row contains
     the information about the stage of the tree (see class Stage).
     """

--- a/gflownet/envs/tree.py
+++ b/gflownet/envs/tree.py
@@ -195,7 +195,7 @@ class Tree(GFlowNetEnv):
         # source is initialized with a classifier.
         self.n_nodes = 2**max_depth - 1
         self.source = torch.full((self.n_nodes + 1, Attribute.N), torch.nan)
-        self.source._set_stage(Stage.COMPLETE, self.source)
+        self._set_stage(Stage.COMPLETE, self.source)
         attributes_root = self.source[0]
         attributes_root[Attribute.TYPE] = NodeType.CLASSIFIER
         attributes_root[Attribute.FEATURE] = -1
@@ -862,7 +862,7 @@ class Tree(GFlowNetEnv):
 
                 # Revert stage (to "threshold": we skip "operator" because from it,
                 # finalizing splitting should be automatically executed).
-                parent = self._set_state(Stage.THRESHOLD, parent)
+                parent = self._set_stage(Stage.THRESHOLD, parent)
 
                 # Reset children attributes.
                 attributes_left[:] = torch.nan

--- a/gflownet/envs/tree.py
+++ b/gflownet/envs/tree.py
@@ -91,6 +91,8 @@ class ActionType:
 
 class Attribute:
     """
+    Contains indices of individual attributes in a state tensor.
+    
     Types of attributes defining each node of the tree:
 
         0 - node type (condition or classifier),

--- a/tests/gflownet/envs/test_tree.py
+++ b/tests/gflownet/envs/test_tree.py
@@ -69,15 +69,15 @@ def test__predict__has_expected_output(tree, x, output):
 
 
 def test__node_tree__has_expected_node_attributes(tree):
-    assert np.allclose(tree._get_attributes(0), [NodeType.CONDITION, 0, 0.5, -1, 0])
-    assert np.allclose(tree._get_attributes(1), [NodeType.CLASSIFIER, -1, -1, 0, 0])
-    assert np.allclose(tree._get_attributes(2), [NodeType.CONDITION, 1, 0.3, -1, 0])
-    assert torch.all(torch.isnan(tree._get_attributes(3)))
-    assert torch.all(torch.isnan(tree._get_attributes(4)))
-    assert np.allclose(tree._get_attributes(5), [NodeType.CLASSIFIER, -1, -1, 1, 0])
-    assert np.allclose(tree._get_attributes(6), [NodeType.CONDITION, 2, 0.7, -1, 0])
-    assert np.allclose(tree._get_attributes(13), [NodeType.CLASSIFIER, -1, -1, 0, 0])
-    assert np.allclose(tree._get_attributes(14), [NodeType.CLASSIFIER, -1, -1, 1, 0])
+    assert np.allclose(tree.state[0], [NodeType.CONDITION, 0, 0.5, -1, 0])
+    assert np.allclose(tree.state[1], [NodeType.CLASSIFIER, -1, -1, 0, 0])
+    assert np.allclose(tree.state[2], [NodeType.CONDITION, 1, 0.3, -1, 0])
+    assert torch.all(torch.isnan(tree.state[3]))
+    assert torch.all(torch.isnan(tree.state[4]))
+    assert np.allclose(tree.state[5], [NodeType.CLASSIFIER, -1, -1, 1, 0])
+    assert np.allclose(tree.state[6], [NodeType.CONDITION, 2, 0.7, -1, 0])
+    assert np.allclose(tree.state[13], [NodeType.CLASSIFIER, -1, -1, 0, 0])
+    assert np.allclose(tree.state[14], [NodeType.CLASSIFIER, -1, -1, 1, 0])
 
 
 @pytest.fixture
@@ -109,117 +109,45 @@ def state_action_are_in_parents(env, state, action):
     [
         (
             [
-                Stage.COMPLETE,
-                NodeType.CLASSIFIER,
-                -1,
-                -1,
-                0,
-                Status.INACTIVE,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
+                [NodeType.CLASSIFIER, -1, -1, 0, Status.INACTIVE],
+                [NAN, NAN, NAN, NAN, NAN],
+                [NAN, NAN, NAN, NAN, NAN],
+                [Stage.COMPLETE, NAN, NAN, NAN, NAN],
             ],
             (ActionType.PICK_LEAF, 0),
             [
-                Stage.LEAF,
-                NodeType.CONDITION,
-                -1,
-                -1,
-                -1,
-                Status.ACTIVE,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
+                [NodeType.CONDITION, -1, -1, -1, Status.ACTIVE],
+                [NAN, NAN, NAN, NAN, NAN],
+                [NAN, NAN, NAN, NAN, NAN],
+                [Stage.LEAF, NAN, NAN, NAN, NAN],
             ],
             (ActionType.PICK_FEATURE, 1),
             [
-                Stage.FEATURE,
-                NodeType.CONDITION,
-                1,
-                -1,
-                -1,
-                Status.ACTIVE,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
+                [NodeType.CONDITION, 1, -1, -1, Status.ACTIVE],
+                [NAN, NAN, NAN, NAN, NAN],
+                [NAN, NAN, NAN, NAN, NAN],
+                [Stage.FEATURE, NAN, NAN, NAN, NAN],
             ],
             (ActionType.PICK_THRESHOLD, 0.2),
             [
-                Stage.THRESHOLD,
-                NodeType.CONDITION,
-                1,
-                0.2,
-                -1,
-                Status.ACTIVE,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
-                NAN,
+                [NodeType.CONDITION, 1, 0.2, -1, Status.ACTIVE],
+                [NAN, NAN, NAN, NAN, NAN],
+                [NAN, NAN, NAN, NAN, NAN],
+                [Stage.THRESHOLD, NAN, NAN, NAN, NAN],
             ],
             (ActionType.PICK_OPERATOR, Operator.LT),
             [
-                Stage.COMPLETE,
-                NodeType.CONDITION,
-                1,
-                0.2,
-                -1,
-                Status.INACTIVE,
-                NodeType.CLASSIFIER,
-                -1,
-                -1,
-                0,
-                Status.INACTIVE,
-                NodeType.CLASSIFIER,
-                -1,
-                -1,
-                1,
-                Status.INACTIVE,
+                [NodeType.CONDITION, 1, 0.2, -1, Status.INACTIVE],
+                [NodeType.CLASSIFIER, -1, -1, 0, Status.INACTIVE],
+                [NodeType.CLASSIFIER, -1, -1, 1, Status.INACTIVE],
+                [Stage.COMPLETE, NAN, NAN, NAN, NAN],
             ],
             (-1, -1),
             [
-                Stage.COMPLETE,
-                NodeType.CONDITION,
-                1,
-                0.2,
-                -1,
-                Status.INACTIVE,
-                NodeType.CLASSIFIER,
-                -1,
-                -1,
-                0,
-                Status.INACTIVE,
-                NodeType.CLASSIFIER,
-                -1,
-                -1,
-                1,
-                Status.INACTIVE,
+                [NodeType.CONDITION, 1, 0.2, -1, Status.INACTIVE],
+                [NodeType.CLASSIFIER, -1, -1, 0, Status.INACTIVE],
+                [NodeType.CLASSIFIER, -1, -1, 1, Status.INACTIVE],
+                [Stage.COMPLETE, NAN, NAN, NAN, NAN],
             ],
         ),
     ],


### PR DESCRIPTION
This PR does what the title says plus other small things. Altogether:
- Make states a 2D tensor instead of 1D. Specifically:
  - Shape is n_nodes + 1 x n_attributes=5
  - k-th row has the attributes of k-th node
  - 0th element of the last row (`state[-1, 0])` contains the state's stage
- I have created getter and setter methods for the stage.
- I have created a class `Attribute` with constants to identify the index of each attribute. This helps me code and understand the code. I hope it's ok!
- I have made some methods receive the state as argument optionally (as many other methods in environments). Hope that's ok too!
- I have removed the methods that are not used any more (e.g. `_get_attributes()`)
  - Also, `N_ATTRIBUTES` -> `Attribute.N`
- I have updated the tests, which are easier to write and read with the 2D states.

### Tests
- [x] `python -m pytest tests/gflownet/envs/test_tree.py` :heavy_check_mark: 