### PR TITLE
Suggested improvements to composition-sg-constraints PR

### DIFF
--- a/gflownet/utils/crystals/pyxtal_cache.py
+++ b/gflownet/utils/crystals/pyxtal_cache.py
@@ -1,8 +1,10 @@
+import numpy
 from pyxtal.symmetry import Group
 
 _pyxtal_space_group_cache = {}
 _pyxtal_check_compatible_cache = {}
 _pyxtal_space_group_free_wp_multiplicity = {}
+_pyxtal_space_group_wp_lowest_common_factor = {}
 
 
 def get_space_group(group_index):
@@ -120,3 +122,41 @@ def space_group_lowest_free_wp_multiplicity(group_index):
     # Store the result in cache before retuning it
     _pyxtal_space_group_free_wp_multiplicity[group_index] = multiplicity
     return multiplicity
+
+
+def space_group_wyckoff_gcd(group_index):
+    """
+    Returns the greatest common divisor of a space group's Wyckoff positions
+
+    This methods includes a lazy caching mechanism.
+
+    Args
+    ----
+    group_index : int
+        Index (starting at 1) of the space group
+
+    Returns
+    -------
+    gcd : int
+        Greatest common divisor of the group's wyckoff position.
+    """
+    # Check in the cache to see if the lowest common factor has previously
+    # been computed for this space group
+    if group_index in _pyxtal_space_group_wp_lowest_common_factor:
+        return _pyxtal_space_group_wp_lowest_common_factor[group_index]
+
+    # Obtain reference to the space group
+    space_group = get_space_group(group_index)
+
+    # Iterate over all of the space group's wyckoff positions from most
+    # specific to most general until a wyckoff position with a degree of
+    # freedom is found.
+    multiplicities = []
+    for wyckoff_idx in range(0, len(space_group.wyckoffs)):
+        wyckoff_position = space_group.get_wyckoff_position(wyckoff_idx)
+        multiplicities.append(wyckoff_position.multiplicity)
+    gcd = numpy.gcd.reduce(multiplicities)
+
+    # Store the result in cache before retuning it
+    _pyxtal_space_group_wp_lowest_common_factor[group_index] = gcd
+    return gcd

--- a/gflownet/utils/crystals/pyxtal_cache.py
+++ b/gflownet/utils/crystals/pyxtal_cache.py
@@ -1,0 +1,75 @@
+from pyxtal.symmetry import Group
+
+_pyxtal_space_group_cache = {}
+_pyxtal_check_compatible_cache = {}
+
+
+def get_space_group(group_index):
+    """
+    Returns a PyxTal Group object representing a crystal space group
+
+    This methods includes a lazy caching mechanism since the instantiation of
+    a pyxtal.symmetry.Group object is expensive.
+
+    Args
+    ----
+    group_index : int
+        Index (starting at 1) of the space group
+
+    Returns
+    -------
+    pyxtal.symmetry.Group
+        Requested space group
+    """
+    if group_index not in _pyxtal_space_group_cache:
+        _pyxtal_space_group_cache[group_index] = Group(group_index)
+    return _pyxtal_space_group_cache[group_index]
+
+
+def space_group_check_compatible(group_index, composition):
+    """
+    Determines if a given atom composition is compatible with a space group
+
+    This methods internally relies on pyxtal.symmetry.Group.check_compatible()
+    to determine if a composition and a space group are compatible but this
+    method includes a caching mechanism since the call to check_compatible()
+    is expensive.
+
+    Args
+    ----
+    group_index : int
+        Index (starting at 1) of the space group
+
+    composition : list of ints
+        Atom composition. Each element in the list corresponds to the number
+        of atoms of a distinct element in the crystal conventional cell
+
+    Returns
+    -------
+    is_compatible : bool
+        True if the composition and space group are compatible. False
+        otherwise.
+    """
+    # Get a tuple version of composition to ensure immutability and,
+    # therefore, allow dictionary indexing by composition. Ensure the elements
+    # in the tuple are sorted to improve cache hit rate since it doesn't
+    # affect the validity of a composition
+    t_composition = tuple(sorted(composition))
+
+    # Check in the cache to see if PyxTal has previously been called to
+    # validate this space group and composition
+    if group_index in _pyxtal_check_compatible_cache:
+        if t_composition in _pyxtal_check_compatible_cache[group_index]:
+            return _pyxtal_check_compatible_cache[group_index][t_composition]
+    else:
+        _pyxtal_check_compatible_cache[group_index] = {}
+
+    # Obtain the space group object
+    space_group = get_space_group(group_index)
+
+    # Perform compatibility check
+    is_compatible = space_group.check_compatible(composition)[0]
+
+    # Store result in cache before returning it
+    _pyxtal_check_compatible_cache[group_index][t_composition] = is_compatible
+    return is_compatible

--- a/gflownet/utils/crystals/pyxtal_cache.py
+++ b/gflownet/utils/crystals/pyxtal_cache.py
@@ -51,6 +51,12 @@ def space_group_check_compatible(group_index, composition):
         True if the composition and space group are compatible. False
         otherwise.
     """
+    # Remove from composition the number of atoms that are a multiple of the
+    # space group's most specific free wyckoff position. This improves the
+    # cache hit rate without affecting the validity of the composition
+    free_multiplicity = space_group_lowest_free_wp_multiplicity(group_index)
+    composition = [c for c in composition if c % free_multiplicity != 0]
+
     # Get a tuple version of composition to ensure immutability and,
     # therefore, allow dictionary indexing by composition. Ensure the elements
     # in the tuple are sorted to improve cache hit rate since it doesn't


### PR DESCRIPTION
Here are the changes to #148 that I am suggesting in this PR : 
- If the current state is deemed incompatible with the space group, then EOS is not marked as invalid to allow the GFN to end the trajectory ASAP since no actions it could take could bring it back into a valid state.
- Adding some code to mask actions that would lead to states incompatible with the space group
- Implement some utilitary fonctions to cache results from PyXtal's function because a lot of those are very very expensive to compute.

**Runtime**
I evaluated the same it takes to complete 10 trajectories, for the composition environment only and with its default hyperparameters, for every space group (2300 trajectories total). Since the cache mechanism means that the timings will change over time as the caches get larger, I repeated the process 40 times and produced here the total time, in seconds, for each attempt. 

1 - 6.4116950035095215
2 - 4.453245639801025
3 - 4.2290565967559814
4 - 4.128775358200073
5 - 4.059585094451904
6 - 3.9281723499298096
7 - 3.892940044403076
8 - 3.927881956100464
9 - 3.8759658336639404
10 - 3.8844809532165527
11 - 3.873915195465088
12 - 3.8338799476623535
13 - 3.86641788482666
14 - 3.880934953689575
15 - 3.833317279815674
16 - 3.8493034839630127
17 - 3.8233022689819336
18 - 3.824620246887207
19 - 3.823237895965576
20 - 3.7951202392578125
21 - 3.80896258354187
22 - 3.791884422302246
23 - 3.813082695007324
24 - 3.8194580078125
25 - 3.8226542472839355
26 - 3.8004648685455322
27 - 3.7659032344818115
28 - 3.81996488571167
29 - 3.812319040298462
30 - 3.824629068374634
31 - 3.821237802505493
32 - 3.8417959213256836
33 - 3.8055989742279053
34 - 3.800288677215576
35 - 3.8210251331329346
36 - 3.8367960453033447
37 - 3.8054256439208984
38 - 3.8340342044830322
39 - 3.808349609375
40 - 3.803480863571167

For reference, on the same compute node, running the same number of trajectories with the space group checks deactivated took 3.23 seconds. That's about 18% more runtime with the checks.

**Valid vs invalid samples**

On that 40th attempt, I looked at the number of valid samples that were generated for each space group to see if the increase was worth the additional runtime. The results are summarized in the bar graph below : 

- The figure shows results with the space group checks and without
- The vertical bar show how many of the 10 samples generated for each space group were considered valid by PyXtal's check_compatible(). The results without the space group checks are in blue. The results with the checks are in red. Since there is some alpha in this figure, the locations in purple show where the two methods overlap.
- The black dots indicate, for each individual space group, the ratio of time it takes to complete 1 trajectory with the checks vs 1 trajectory without the checks.

![image](https://github.com/alexhernandezgarcia/gflownet/assets/832811/4153f000-8b5f-483e-922c-6277c3a79e93)

Out of 2300 possible valid samples, generating samples without the space group checks give us ~386 valid samples from very few space groups. With the space group checks, it increases to 2270 (5.88x increase). There are three space groups (220, 228, 230) for which neither method produces valid samples. This is because the default hyperparameters of the composition environment are incompatible with these space groups.

Note : the samples are classified as valid/invalid using PyXtal's check_compatible() method. As discussed in the Slack channel, that method is not 100% reliable but it generally gives the right answer. 
