### PR TITLE
Generic env method to sample random terminating states

### DIFF
--- a/config/env/base.yaml
+++ b/config/env/base.yaml
@@ -18,6 +18,8 @@ proxy_state_format: oracle
 skip_mask_check: False
 # Whether the environment has conditioning variables
 conditional: False
+# Whether the environment is continuous
+continuous: False
 # Buffer
 buffer:
   replay_capacity: 10

--- a/config/experiments/icml23/ctorus.yaml
+++ b/config/experiments/icml23/ctorus.yaml
@@ -26,7 +26,8 @@ proxy:
 gflownet:
   random_action_prob: 0.1
   optimizer:
-    batch_size: 100
+    batch_size:
+      forward: 100
     lr: 0.00001
     z_dim: 16
     lr_z_mult: 1000

--- a/config/gflownet/gflownet.yaml
+++ b/config/gflownet/gflownet.yaml
@@ -19,8 +19,11 @@ optimizer:
   adam_beta2: 0.999
   # Momentum for SGD
   sgd_momentum: 0.9
-  # Mini-batch size
-  batch_size: 10
+  # Number of trajectories of each kind
+  batch_size:
+    forward: 10
+    train: 0
+    replay: 0
   # Train to sample ratio
   train_to_sample_ratio: 1
   # Number of training iterations

--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -498,20 +498,32 @@ class GFlowNetEnv:
         Samples n terminating states by using the random policy of the environment
         (calling self.trajectory_random()).
 
+        Note that this method is general for all environments but it may be suboptimal
+        in terms of efficiency. In particular, 1) it samples full trajectories in order
+        to get terminating states, 2) if unique is True, it needs to compare each newly
+        sampled state with all the previously sampled states. If
+        get_uniform_terminating_states is available, it may be preferred, or for some
+        environments, a custom get_random_terminating_states may be straightforward to
+        implement in a much more efficient way.
+
         Args
         ----
         n_states : int
             The number of terminating states to sample.
 
         unique : bool
-            Whether samples should be unique.
+            Whether samples should be unique. True by default.
 
         max_attempts : int
             The maximum number of attempts, to prevent the method from getting stuck
             trying to obtain n_states different samples if unique is True. 100000 by
             default, therefore if more than 100000 are requested, max_attempts should
-            be increased
-            accordingly.
+            be increased accordingly.
+
+        Returns
+        -------
+        states : list
+            A list of randomly sampled terminating states.
         """
         if unique is False:
             max_attempts = n_states + 1

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -379,7 +379,9 @@ class Grid(GFlowNetEnv):
         )
         return all_x.tolist()
 
-    def get_uniform_terminating_states(self, n_states: int, seed: int) -> List[List]:
+    def get_uniform_terminating_states(
+        self, n_states: int, seed: int = None
+    ) -> List[List]:
         rng = np.random.default_rng(seed)
         states = rng.integers(low=0, high=self.length, size=(n_states, self.n_dim))
         return states.tolist()

--- a/gflownet/envs/htorus.py
+++ b/gflownet/envs/htorus.py
@@ -58,7 +58,6 @@ class HybridTorus(GFlowNetEnv):
         assert n_dim > 0
         assert length_traj > 0
         assert n_comp > 0
-        self.continuous = True
         self.n_dim = n_dim
         self.length_traj = length_traj
         self.policy_encoding_dim_per_angle = policy_encoding_dim_per_angle
@@ -83,6 +82,7 @@ class HybridTorus(GFlowNetEnv):
             random_distribution=random_distribution,
             **kwargs,
         )
+        self.continuous = True
 
     def get_action_space(self):
         """

--- a/gflownet/envs/spacegroup.py
+++ b/gflownet/envs/spacegroup.py
@@ -5,12 +5,12 @@ import itertools
 import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
-import numpy as np
 import torch
 from torch import Tensor
 from torchtyping import TensorType
 
 from gflownet.envs.base import GFlowNetEnv
+from gflownet.utils.common import tfloat
 from gflownet.utils.crystals.constants import (
     CRYSTAL_CLASSES,
     CRYSTAL_SYSTEMS,
@@ -56,6 +56,10 @@ class SpaceGroup(GFlowNetEnv):
         # Source state: index 0 (empty) for all three properties (crystal system index,
         # point symmetry index, space group)
         self.source = [0 for _ in range(3)]
+        # Conversions
+        self.state2proxy = self.state2oracle
+        self.statebatch2proxy = self.statebatch2oracle
+        self.statetorch2proxy = self.statetorch2oracle
         # Base class init
         super().__init__(**kwargs)
 
@@ -166,7 +170,7 @@ class SpaceGroup(GFlowNetEnv):
             raise ValueError(
                 "The space group must have been set in order to call the oracle"
             )
-        return torch.Tensor(state[self.sg_idx], device=self.device, dtype=self.float)
+        return tfloat(state[self.sg_idx], device=self.device, float_type=self.float)
 
     def statebatch2oracle(
         self, states: List[List]
@@ -185,7 +189,7 @@ class SpaceGroup(GFlowNetEnv):
         oracle_state : Tensor
         """
         return self.statetorch2oracle(
-            torch.Tensor(states, device=self.device, dtype=self.float)
+            tfloat(states, device=self.device, float_type=self.float)
         )
 
     def statetorch2oracle(
@@ -204,7 +208,7 @@ class SpaceGroup(GFlowNetEnv):
         ----
         oracle_state : Tensor
         """
-        return torch.unsqueeze(states[:, self.sg_idx])
+        return torch.unsqueeze(states[:, self.sg_idx], dim=1)
 
     def state2readable(self, state=None):
         """

--- a/gflownet/envs/tetris.py
+++ b/gflownet/envs/tetris.py
@@ -11,6 +11,7 @@ import torch
 from torchtyping import TensorType
 
 from gflownet.envs.base import GFlowNetEnv
+from gflownet.utils.common import set_device, tint
 
 PIECES = {
     "I": [1, [[1], [1], [1], [1]]],
@@ -65,6 +66,8 @@ class Tetris(GFlowNetEnv):
     ):
         assert all([p in ["I", "J", "L", "O", "S", "T", "Z"] for p in pieces])
         assert all([r in [0, 90, 180, 270] for r in rotations])
+        self.device = set_device(kwargs["device"])
+        self.int = torch.int16
         self.width = width
         self.height = height
         self.pieces = pieces
@@ -75,8 +78,8 @@ class Tetris(GFlowNetEnv):
         # Helper functions and dicts
         self.piece2idx = lambda letter: PIECES[letter][0]
         self.idx2piece = {v[0]: k for k, v in PIECES.items()}
-        self.piece2mat = lambda letter: torch.tensor(
-            PIECES[letter][1], dtype=torch.int16
+        self.piece2mat = lambda letter: tint(
+            PIECES[letter][1], int_type=self.int, device=self.device
         )
         self.rot2idx = {0: 0, 90: 1, 180: 2, 270: 3}
         # Check width and height compatibility
@@ -90,7 +93,9 @@ class Tetris(GFlowNetEnv):
         assert all([self.height >= h for h in widths])
         assert all([self.width >= w for w in widths])
         # Source state: empty board
-        self.source = torch.zeros((self.height, self.width), dtype=torch.int16)
+        self.source = torch.zeros(
+            (self.height, self.width), dtype=self.int, device=self.device
+        )
         # End-of-sequence action: all -1
         self.eos = (-1, -1, -1)
         # Conversions
@@ -334,7 +339,7 @@ class Tetris(GFlowNetEnv):
         if isinstance(state, tuple):
             readable = str(np.stack(state))
         else:
-            readable = str(state.numpy())
+            readable = str(state.cpu().numpy())
         readable = readable.replace("[[", "[").replace("]]", "]").replace("\n ", "\n")
         return readable
 
@@ -353,8 +358,10 @@ class Tetris(GFlowNetEnv):
             row = row.replace("[ ", "[")
             # Process
             state.append(
-                torch.tensor(
-                    [int(el) for el in row.strip("[]").split(" ")], dtype=torch.int16
+                tint(
+                    [int(el) for el in row.strip("[]").split(" ")],
+                    int_type=self.int,
+                    device=self.device,
                 )
             )
         return torch.stack(state)
@@ -459,7 +466,7 @@ class Tetris(GFlowNetEnv):
 
     # TODO
     def get_max_traj_length(self):
-        return 1e9
+        return int(1e9)
 
     def _piece_can_be_lifted(self, board, piece_idx):
         """
@@ -522,7 +529,7 @@ class Tetris(GFlowNetEnv):
             return min_idx
 
     def get_uniform_terminating_states(
-        self, n_states: int, seed: int, n_factor_max: int = 10
+        self, n_states: int, seed: int = None, n_factor_max: int = 10
     ) -> List[List]:
         rng = np.random.default_rng(seed)
         n_iter_max = n_states * n_factor_max

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -5,22 +5,19 @@ TODO:
 """
 import copy
 import pickle
-import sys
 import time
 from collections import defaultdict
-from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
-import pandas as pd
 import torch
 import torch.nn as nn
-import yaml
 from omegaconf import OmegaConf
 from scipy.special import logsumexp
-from torch.distributions import Bernoulli, Categorical
+from torch.distributions import Bernoulli
 from tqdm import tqdm
 
+from gflownet.envs.base import GFlowNetEnv
 from gflownet.utils.batch import Batch
 from gflownet.utils.buffer import Buffer
 from gflownet.utils.common import (
@@ -28,8 +25,6 @@ from gflownet.utils.common import (
     set_float_precision,
     tbool,
     tfloat,
-    tint,
-    tlong,
     torch2np,
 )
 
@@ -65,9 +60,6 @@ class GFlowNetAgent:
         self.float = set_float_precision(float_precision)
         # Environment
         self.env = env
-        self.mask_source = tbool(
-            [self.env.get_mask_invalid_actions_forward()], device=self.device
-        )
         # Continuous environments
         self.continuous = hasattr(self.env, "continuous") and self.env.continuous
         if self.continuous and optimizer.loss in ["flowmatch", "flowmatching"]:
@@ -191,7 +183,7 @@ class GFlowNetAgent:
         self.jsd = -1.0
 
     def parameters(self):
-        if self.backward_policy.is_model == False:
+        if self.backward_policy.is_model is False:
             return list(self.forward_policy.model.parameters())
         elif self.loss == "trajectorybalance":
             return list(self.forward_policy.model.parameters()) + list(
@@ -202,66 +194,127 @@ class GFlowNetAgent:
 
     def sample_actions(
         self,
-        envs,
-        times,
-        sampling_method="policy",
-        model=None,
-        is_forward: bool = True,
-        temperature=1.0,
-        random_action_prob=0.0,
-        mask_invalid_actions=None,
-    ):
+        envs: List[GFlowNetEnv],
+        batch: Optional[Batch] = None,
+        sampling_method: Optional[str] = "policy",
+        backward: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        random_action_prob: Optional[float] = 0.0,
+        no_random: Optional[bool] = True,
+        times: Optional[dict] = None,
+    ) -> List[Tuple]:
         """
-        Samples one action on each environment of a list.
+        Samples one action on each environment of the list envs, according to the
+        sampling method specify by sampling_method.
+
+        With probability 1 - random_action_prob, actions will be sampled from the
+        self.forward_policy or self.backward_policy, depending on backward. The rest
+        are sampled according to the random policy of the environment
+        (model.random_distribution).
+
+        If a batch is provided (and self.mask_invalid_actions) is True, the masks are
+        retrieved from the batch. Otherwise they are computed from the environments.
 
         Args
         ----
         envs : list of GFlowNetEnv or derived
             A list of instances of the environment
 
-        times : dict
-            Dictionary to store times
+        batch_forward : Batch
+            A batch from which obtain required variables (e.g. masks) to avoid
+            recomputing them.
 
         sampling_method : string
-            - model: uses current forward to obtain the sampling probabilities.
-            - uniform: samples uniformly from the action space.
+            - policy: uses current forward to obtain the sampling probabilities.
+            - random: samples purely from a random policy, that is
+                - random_action_prob = 1.0
+              regardless of the value passed as arguments.
 
-        model : torch model
-            Model to use as policy if sampling_method="policy"
-
-        is_forward : bool
-            True if sampling is forward. False if backward.
+        backward : bool
+            True if sampling is backward. False (forward) by default.
 
         temperature : float
-            Temperature to adjust the logits by logits /= temperature
+            Temperature to adjust the logits by logits /= temperature. If None,
+            self.temperature_logits is used.
 
-        mask_invalid_actions : list or None
-            List of invalid action masks for the environments in env. Optional, will be
-            computed if not provided.
+        random_action_prob : float
+            Probability of sampling random actions. If None, self.random_action_prob is used.
+
+        no_random : bool
+            If True, the samples will strictly be on-policy, that is
+                - temperature = 1.0
+                - random_action_prob = 0.0
+            regardless of the values passed as arguments.
+
+        times : dict
+            Dictionary to store times. Currently not implemented.
+
+        Returns
+        -------
+        actions : list of tuples
+            The sampled actions, one for each environment in envs.
         """
+        # Preliminaries
+        if sampling_method == "random":
+            assert (
+                no_random is False
+            ), "sampling_method random and no_random True is ambiguous"
+            random_action_prob = 1.0
+            temperature = 1.0
+        elif no_random is True:
+            temperature = 1.0
+            random_action_prob = 0.0
+        else:
+            if temperature is not None:
+                temperature = self.temperature_logits
+            if random_action_prob is not None:
+                random_action_prob = self.random_action_prob
+        if backward:
+            # TODO: backward sampling with FM?
+            model = self.backward_policy
+        else:
+            model = self.forward_policy
+
         # TODO: implement backward sampling from forward policy as in old
         # backward_sample.
-        if sampling_method == "random":
-            random_action_prob = 1.0
         if not isinstance(envs, list):
             envs = [envs]
         # Build states and masks
         states = [env.state for env in envs]
-        if mask_invalid_actions is None:
-            # Invalid actions masks are not provided, they need to be computed
-            if is_forward:
-                mask_invalid_actions = tbool(
-                    [env.get_mask_invalid_actions_forward() for env in envs],
-                    device=self.device,
-                )
+
+        # Retrieve masks from the batch (batch.get_item("mask_*") computes the mask if
+        # it is not available and stores it to the batch)
+        # TODO: make get_mask_ method with the ugly code below
+        if self.mask_invalid_actions is True:
+            if batch is not None:
+                if backward:
+                    mask_invalid_actions = tbool(
+                        [
+                            batch.get_item("mask_backward", env, backward=True)
+                            for env in envs
+                        ],
+                        device=self.device,
+                    )
+                else:
+                    mask_invalid_actions = tbool(
+                        [batch.get_item("mask_forward", env) for env in envs],
+                        device=self.device,
+                    )
+            # Compute masks since a batch was not provided
             else:
-                mask_invalid_actions = tbool(
-                    [env.get_mask_invalid_actions_backward() for env in envs],
-                    device=self.device,
-                )
+                if backward:
+                    mask_invalid_actions = tbool(
+                        [env.get_mask_invalid_actions_backward() for env in envs],
+                        device=self.device,
+                    )
+                else:
+                    mask_invalid_actions = tbool(
+                        [env.get_mask_invalid_actions_forward() for env in envs],
+                        device=self.device,
+                    )
         else:
-            # Invalid action masks are provided, convert to pytorch tensors
-            mask_invalid_actions = tbool(mask_invalid_actions, device=self.device)
+            mask_invalid_actions = None
+
         # Build policy outputs
         policy_outputs = model.random_distribution(states)
         idx_norandom = (
@@ -271,8 +324,9 @@ class GFlowNetAgent:
             .sample()
             .to(bool)
         )
-        # Check for at least one non-random action
+        # Get policy outputs from model
         if sampling_method == "policy":
+            # Check for at least one non-random action
             if idx_norandom.sum() > 0:
                 policy_outputs[idx_norandom, :] = model(
                     tfloat(
@@ -285,7 +339,9 @@ class GFlowNetAgent:
                 )
         else:
             raise NotImplementedError
+
         # Sample actions from policy outputs
+        # TODO: consider adding logprobs to batch
         actions, logprobs = self.env.sample_actions(
             policy_outputs,
             sampling_method,
@@ -296,12 +352,14 @@ class GFlowNetAgent:
 
     def step(
         self,
-        envs: List,
+        envs: List[GFlowNetEnv],
         actions: List[Tuple],
-        is_forward: bool = True,
+        backward: bool = False,
     ):
         """
-        Executes the actions of a list on the environments of a list.
+        Executes the actions on the environments envs, one by one. This method simply
+        calls env.step(action) or env.step_backwards(action) for each (env, action)
+        pair, depending on thhe value of backward.
 
         Args
         ----
@@ -311,178 +369,145 @@ class GFlowNetAgent:
         actions : list
             A list of actions to be executed on each env of envs.
 
-        is_forward : bool
-            True if sampling is forward. False if backward.
-
-        temperature : float
-            Temperature to adjust the logits by logits /= temperature
+        backward : bool
+            True if sampling is backward. False (forward) by default.
         """
         assert len(envs) == len(actions)
         if not isinstance(envs, list):
             envs = [envs]
-        if is_forward:
+        if backward:
+            _, actions, valids = zip(
+                *[env.step_backwards(action) for env, action in zip(envs, actions)]
+            )
+        else:
             _, actions, valids = zip(
                 *[env.step(action) for env, action in zip(envs, actions)]
             )
-        else:
-            valids = []
-            for env, action in zip(envs, actions):
-                parents, parents_a = env.get_parents(action=action)
-                if action in parents_a:
-                    state_next = parents[parents_a.index(action)]
-                    env.set_state(state_next, done=False)
-                    env.n_actions -= 1
-                    valids.append(True)
-                else:
-                    valids.append(False)
         return envs, actions, valids
 
     # @profile
+    @torch.no_grad()
+    # TODO: extract code from while loop to avoid replication
     def sample_batch(
-        self, envs, n_samples=None, train=True, model=None, progress=False
+        self,
+        n_forward: int = 0,
+        n_train: int = 0,
+        n_replay: int = 0,
+        train=True,
+        progress=False,
     ):
         """
-        Builds a batch of data
-
-        if train == True:
-            Each item in the batch is a list of 7 elements (all tensors):
-                - [0] the state
-                - [1] the action
-                - [2] all parents of the state, parents
-                - [3] actions that lead to the state from each parent, parents_a
-                - [4] done [True, False]
-                - [5] traj id: identifies each trajectory
-                - [6] state id: identifies each state within a traj
-                - [7] mask_f: invalid forward actions from that state are 1
-                - [8] mask_b: invalid backward actions from that state are 1
-        else:
-            Each item in the batch is a list of 1 element:
-                - [0] the states (state)
-
-        Args
-        ----
+        TODO: extend docstring.
+        Builds a batch of data by sampling online and/or offline trajectories.
         """
+        # PRELIMINARIES: Prepare Batch and environments
         times = {
             "all": 0.0,
             "forward_actions": 0.0,
-            "backward_actions": 0.0,
+            "train_actions": 0.0,
+            "replay_actions": 0.0,
             "actions_envs": 0.0,
-            "rewards": 0.0,
         }
         t0_all = time.time()
-        batch = Batch(loss=self.loss, device=self.device, float_type=self.float)
-        if isinstance(envs, list):
-            envs = [env.reset(idx) for idx, env in enumerate(envs)]
-        elif n_samples is not None and n_samples > 0:
-            envs = [self.env.copy().reset(idx) for idx in range(n_samples)]
-        else:
-            return None, None
-        # Offline trajectories
-        if train:
-            n_empirical = int(self.pct_offline * len(envs))
-        else:
-            n_empirical = 0
-        if n_empirical > 0 and self.buffer.train_pkl is not None:
+        batch = Batch(env=self.env, device=self.device, float_type=self.float)
+
+        # ON-POLICY FORWARD trajectories
+        t0_forward = time.time()
+        envs = [self.env.copy().reset(idx) for idx in range(n_forward)]
+        batch_forward = Batch(env=self.env, device=self.device, float_type=self.float)
+        while envs:
+            # Sample actions
+            t0_a_envs = time.time()
+            actions = self.sample_actions(
+                envs,
+                batch_forward,
+                no_random=not train,
+                times=times,
+            )
+            times["actions_envs"] += time.time() - t0_a_envs
+            # Update environments with sampled actions
+            envs, actions, valids = self.step(envs, actions)
+            # Add to batch
+            batch_forward.add_to_batch(envs, actions, valids, train=train)
+            # Filter out finished trajectories
+            envs = [env for env in envs if not env.done]
+        times["forward_actions"] = time.time() - t0_forward
+
+        # TRAIN BACKWARD trajectories
+        t0_train = time.time()
+        envs = [self.env.copy().reset(idx) for idx in range(n_train)]
+        batch_train = Batch(env=self.env, device=self.device, float_type=self.float)
+        if n_train > 0 and self.buffer.train_pkl is not None:
             with open(self.buffer.train_pkl, "rb") as f:
                 dict_tr = pickle.load(f)
                 # TODO: implement other sampling options besides permutation
+                # TODO: this converts to numpy
                 x_tr = self.rng.permutation(dict_tr["x"])
-            envs_offline = []
             actions = []
             valids = []
-            for idx in range(n_empirical):
-                env = envs[idx]
-                env = env.set_state(x_tr[idx].tolist(), done=True)
-                env.n_actions = env.get_max_traj_length()
-                envs_offline.append(env)
-                actions.append(env.eos)
-                valids.append(True)
-        else:
-            envs_offline = []
-        while envs_offline:
+            for idx, env in enumerate(envs):
+                env.set_state(x_tr[idx], done=True)
+        while envs:
             # Sample backward actions
-            with torch.no_grad():
-                actions = self.sample_actions(
-                    envs_offline,
-                    times,
-                    sampling_method="policy",
-                    model=self.backward_policy,
-                    is_forward=False,
-                    temperature=self.temperature_logits,
-                    random_action_prob=self.random_action_prob,
-                )
-            # Add to batch
-            batch.add_to_batch(envs_offline, actions, valids, train=True)
-            # Update environments with sampled actions
-            envs_offline, actions, valids = self.step(
-                envs_offline, actions, is_forward=False
+            t0_a_envs = time.time()
+            actions = self.sample_actions(
+                envs,
+                batch_train,
+                backward=True,
+                no_random=not train,
+                times=times,
             )
+            times["actions_envs"] += time.time() - t0_a_envs
+            # Update environments with sampled actions
+            envs, actions, valids = self.step(envs, actions, backward=True)
+            # Add to batch
+            batch_train.add_to_batch(envs, actions, valids, backward=True, train=train)
             assert all(valids)
             # Filter out finished trajectories
-            envs_offline = [env for env in envs_offline if env.state != env.source]
-        envs = envs[n_empirical:]
-        # Policy trajectories
-        masks_invalid_actions_forward = None
+            envs = [env for env in envs if not env.equal(env.state, env.source)]
+        times["train_actions"] = time.time() - t0_train
+
+        # REPLAY BACKWARD trajectories
+        t0_replay = time.time()
+        batch_replay = Batch(env=self.env, device=self.device, float_type=self.float)
+        if n_replay > 0 and self.buffer.replay_pkl is not None:
+            with open(self.buffer.replay_pkl, "rb") as f:
+                dict_replay = pickle.load(f)
+                n_replay = min(n_replay, len(dict_replay["x"]))
+                envs = [self.env.copy().reset(idx) for idx in range(n_replay)]
+                # TODO: implement other sampling options besides permutation
+                if n_replay > 0:
+                    x_replay = [x for x in dict_replay["x"].values()]
+                    x_replay = [x_replay[idx] for idx in self.rng.permutation(n_replay)]
+            actions = []
+            valids = []
+            for idx, env in enumerate(envs):
+                env.set_state(x_replay[idx], done=True)
         while envs:
-            # Sample forward actions
-            with torch.no_grad():
-                if train is False:
-                    actions = self.sample_actions(
-                        envs,
-                        times,
-                        sampling_method="policy",
-                        model=self.forward_policy,
-                        is_forward=True,
-                        temperature=1.0,
-                        random_action_prob=self.random_action_prob,
-                        mask_invalid_actions=masks_invalid_actions_forward,
-                    )
-                else:
-                    actions = self.sample_actions(
-                        envs,
-                        times,
-                        sampling_method="policy",
-                        model=self.forward_policy,
-                        is_forward=True,
-                        temperature=self.temperature_logits,
-                        random_action_prob=self.random_action_prob,
-                        mask_invalid_actions=masks_invalid_actions_forward,
-                    )
-            # Update environments with sampled actions
-            envs, actions, valids = self.step(envs, actions, is_forward=True)
-
-            # Compute updated action masks
-            masks_invalid_actions_forward = [
-                env.get_mask_invalid_actions_forward() for env in envs
-            ]
-
-            # Add to batch
+            # Sample backward actions
             t0_a_envs = time.time()
-            batch.add_to_batch(
+            actions = self.sample_actions(
                 envs,
-                actions,
-                valids,
-                masks_invalid_actions_forward,
-                train,
+                batch_replay,
+                backward=True,
+                no_random=not train,
+                times=times,
             )
+            times["actions_envs"] += time.time() - t0_a_envs
+            # Update environments with sampled actions
+            envs, actions, valids = self.step(envs, actions, backward=True)
+            # Add to batch
+            batch_replay.add_to_batch(envs, actions, valids, backward=True, train=train)
+            assert all(valids)
+            # Filter out finished trajectories
+            envs = [env for env in envs if not env.equal(env.state, env.source)]
+        times["replay_actions"] = time.time() - t0_replay
 
-            # Filter out finished trajectories, and the corresponding masks
-            not_done_envs = []
-            not_done_masks = []
-            for (
-                env,
-                mask,
-            ) in zip(envs, masks_invalid_actions_forward):
-                if not env.done:
-                    not_done_envs.append(env)
-                    not_done_masks.append(mask)
-            envs = not_done_envs
-            masks_invalid_actions_forward = not_done_masks
+        # Merge forward and backward batches
+        batch = batch.merge([batch_forward, batch_train, batch_replay])
 
-            t1_a_envs = time.time()
-            times["actions_envs"] += t1_a_envs - t0_a_envs
-            if progress and n_samples is not None:
-                print(f"{n_samples - len(envs)}/{n_samples} done")
+        times["all"] = time.time() - t0_all
+
         return batch, times
 
     def flowmatch_loss(self, it, batch):
@@ -509,19 +534,14 @@ class GFlowNetAgent:
         flow_loss : float
             Loss of the intermediate nodes only
         """
-        # Convert lists in the batch into tensors
-        batch.process_batch()
-        # Unpack batch
-        parents_state_idx = batch.parents_all_state_idx
-        states = batch.states_policy
-        parents = batch.parents_all_policy
-        parents_actions = batch.parents_actions_all
-        done = batch.done
-        masks_sf = batch.masks_invalid_actions_forward
-
+        assert batch.is_valid()
+        # Get necessary tensors from batch
+        states = batch.get_states(policy=True)
+        parents, parents_actions, parents_state_idx = batch.get_parents_all(policy=True)
+        done = batch.get_done()
+        masks_sf = batch.get_masks_forward()
         parents_a_idx = self.env.actions2indices(parents_actions)
-        # Compute rewards
-        rewards = batch.compute_rewards()
+        rewards = batch.get_rewards()
         assert torch.all(rewards[done] > 0)
         # In-flows
         inflow_logits = torch.full(
@@ -546,7 +566,7 @@ class GFlowNetAgent:
         contrib_interm = done.eq(0).to(self.float).mean()
         # Combined loss
         loss = contrib_term * loss_term + contrib_interm * loss_interm
-        return (loss, loss_term, loss_interm), rewards[done]
+        return loss, loss_term, loss_interm
 
     def trajectorybalance_loss(self, it, batch):
         """
@@ -571,63 +591,43 @@ class GFlowNetAgent:
         flow_loss : float
             Loss of the intermediate nodes only
         """
-        # Convert lists in the batch into tensors
-        batch.process_batch()
+        assert batch.is_valid()
+        # Get necessary tensors from batch
+        states = batch.get_states(policy=True)
+        actions = batch.get_actions()
+        parents = batch.get_parents(policy=True)
+        traj_indices = batch.get_trajectory_indices()
+        masks_f = batch.get_masks_forward(of_parents=True)
+        masks_b = batch.get_masks_backward()
+        rewards = batch.get_terminating_rewards(sort_by="trajectory")
 
-        states = batch.states_policy
-        actions = batch.actions
-        parents = batch.parents_policy
-        done = batch.done
-        masks_sf = batch.masks_invalid_actions_forward
-        masks_b = batch.masks_invalid_actions_backward
-        traj_ids = batch.env_ids
-        state_ids = batch.n_actions
-
-        # Shift state_ids to [1, 2, ...]
-        for tid in traj_ids.unique():
-            state_ids[traj_ids == tid] = (
-                state_ids[traj_ids == tid] - state_ids[traj_ids == tid].min() + 1
-            )
-        # Compute rewards
-        rewards = batch.compute_rewards()
-        # Build parents forward masks from state masks
-        masks_f = torch.cat(
-            [
-                masks_sf[torch.where((state_ids == sid - 1) & (traj_ids == pid))]
-                if sid > 1
-                else self.mask_source
-                for sid, pid in zip(state_ids, traj_ids)
-            ]
-        )
         # Forward trajectories
         policy_output_f = self.forward_policy(parents)
         logprobs_f = self.env.get_logprobs(
             policy_output_f, True, actions, states, masks_f
         )
         sumlogprobs_f = torch.zeros(
-            len(torch.unique(traj_ids, sorted=True)),
+            batch.get_n_trajectories(),
             dtype=self.float,
             device=self.device,
-        ).index_add_(0, traj_ids, logprobs_f)
+        ).index_add_(0, traj_indices, logprobs_f)
         # Backward trajectories
         policy_output_b = self.backward_policy(states)
         logprobs_b = self.env.get_logprobs(
             policy_output_b, False, actions, parents, masks_b
         )
         sumlogprobs_b = torch.zeros(
-            len(torch.unique(traj_ids, sorted=True)),
+            batch.get_n_trajectories(),
             dtype=self.float,
             device=self.device,
-        ).index_add_(0, traj_ids, logprobs_b)
-        # Sort rewards of done states by ascending traj id
-        rewards = rewards[done.eq(1)][torch.argsort(traj_ids[done.eq(1)])]
+        ).index_add_(0, traj_indices, logprobs_b)
         # Trajectory balance loss
         loss = (
             (self.logZ.sum() + sumlogprobs_f - sumlogprobs_b - torch.log(rewards))
             .pow(2)
             .mean()
         )
-        return (loss, loss, loss), rewards
+        return loss, loss, loss
 
     def train(self):
         # Metrics
@@ -635,8 +635,6 @@ class GFlowNetAgent:
         all_visited = []
         loss_term_ema = None
         loss_flow_ema = None
-        # Generate list of environments
-        envs = [self.env.copy().reset() for _ in range(self.batch_size)]
         # Train loop
         pbar = tqdm(range(1, self.n_train_steps + 1), disable=not self.logger.progress)
         for it in pbar:
@@ -648,18 +646,22 @@ class GFlowNetAgent:
                 )
                 self.logger.log_plots(figs, it, self.use_context)
             t0_iter = time.time()
-            data = Batch(loss=self.loss, device=self.device, float_type=self.float)
+            batch = Batch(env=self.env, device=self.device, float_type=self.float)
             for j in range(self.sttr):
-                batch, times = self.sample_batch(envs)
-                data.merge(batch)
+                sub_batch, times = self.sample_batch(
+                    n_forward=self.batch_size.forward,
+                    n_train=self.batch_size.train,
+                    n_replay=self.batch_size.replay,
+                )
+                batch.merge(sub_batch)
             for j in range(self.ttsr):
                 if self.loss == "flowmatch":
-                    losses, rewards = self.flowmatch_loss(
-                        it * self.ttsr + j, data
+                    losses = self.flowmatch_loss(
+                        it * self.ttsr + j, batch
                     )  # returns (opt loss, *metrics)
                 elif self.loss == "trajectorybalance":
-                    losses, rewards = self.trajectorybalance_loss(
-                        it * self.ttsr + j, data
+                    losses = self.trajectorybalance_loss(
+                        it * self.ttsr + j, batch
                     )  # returns (opt loss, *metrics)
                 else:
                     print("Unknown loss!")
@@ -680,12 +682,19 @@ class GFlowNetAgent:
                     all_losses.append([i.item() for i in losses])
             # Buffer
             t0_buffer = time.time()
-            states_term, trajs_term = batch.unpack_terminal_states()
+            states_term = batch.get_terminating_states(sort_by="trajectory")
+            rewards = batch.get_terminating_rewards(sort_by="trajectory")
+            actions_trajectories = batch.get_actions_trajectories()
             proxy_vals = self.env.reward2proxy(rewards).tolist()
             rewards = rewards.tolist()
-            self.buffer.add(states_term, trajs_term, rewards, proxy_vals, it)
+            self.buffer.add(states_term, actions_trajectories, rewards, proxy_vals, it)
             self.buffer.add(
-                states_term, trajs_term, rewards, proxy_vals, it, buffer="replay"
+                states_term,
+                actions_trajectories,
+                rewards,
+                proxy_vals,
+                it,
+                buffer="replay",
             )
             t1_buffer = time.time()
             times.update({"buffer": t1_buffer - t0_buffer})
@@ -706,7 +715,7 @@ class GFlowNetAgent:
                 rewards=rewards,
                 proxy_vals=proxy_vals,
                 states_term=states_term,
-                batch_size=len(data),
+                batch_size=len(batch),
                 logz=self.logZ,
                 learning_rates=self.lr_scheduler.get_last_lr(),
                 step=it,
@@ -747,7 +756,7 @@ class GFlowNetAgent:
         # Save final model
         self.logger.save_models(self.forward_policy, self.backward_policy, final=True)
         # Close logger
-        if self.use_context == False:
+        if self.use_context is False:
             self.logger.end()
 
     def test(self, **plot_kwargs):
@@ -759,9 +768,9 @@ class GFlowNetAgent:
         with open(self.buffer.test_pkl, "rb") as f:
             dict_tt = pickle.load(f)
             x_tt = dict_tt["x"]
-        batch, _ = self.sample_batch(self.env, self.logger.test.n, train=False)
-        batch.process_batch()
-        x_sampled = batch.states.tolist()
+        batch, _ = self.sample_batch(n_forward=self.logger.test.n, train=False)
+        assert batch.is_valid()
+        x_sampled = batch.get_terminating_states()
         if self.buffer.test_type is not None and self.buffer.test_type == "all":
             if "density_true" in dict_tt:
                 density_true = dict_tt["density_true"]
@@ -901,7 +910,7 @@ class GFlowNetAgent:
 
         # oracle metrics
         oracle_batch, oracle_times = self.sample_batch(
-            self.env, self.oracle_n, train=False
+            n_forward=self.oracle_n, train=False
         )
 
         if not self.logger.lightweight:
@@ -984,7 +993,7 @@ class Policy:
         activation : Activation
             Activation function
         """
-        if self.shared_weights == True and self.base is not None:
+        if self.shared_weights is True and self.base is not None:
             mlp = nn.Sequential(
                 self.base.model[:-1],
                 nn.Linear(
@@ -992,7 +1001,7 @@ class Policy:
                 ),
             )
             return mlp
-        elif self.shared_weights == False:
+        elif self.shared_weights is False:
             layers_dim = (
                 [self.state_dim] + [self.n_hid] * self.n_layers + [(self.output_dim)]
             )

--- a/gflownet/proxy/tetris.py
+++ b/gflownet/proxy/tetris.py
@@ -23,9 +23,5 @@ class Tetris(Proxy):
 
     def __call__(self, states: TensorType["batch", "state_dim"]) -> TensorType["batch"]:
         if states.dim() == 2:
-            return torch.sum(states) / self.norm
-
-        elif states.dim() == 3:
-            return torch.sum(states, axis=(1, 2)) / self.norm
-        else:
-            raise ValueError
+            states = torch.unsqueeze(states, dim=0)
+        return torch.sum(states, axis=(1, 2)) / self.norm

--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -1,19 +1,20 @@
-from collections import defaultdict
-from copy import deepcopy
+from collections import OrderedDict
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
+import numpy.typing as npt
 import torch
 from torchtyping import TensorType
 
 from gflownet.envs.base import GFlowNetEnv
 from gflownet.utils.common import (
     concat_items,
+    copy,
+    extend,
     set_device,
     set_float_precision,
     tbool,
     tfloat,
-    tint,
     tlong,
 )
 
@@ -22,66 +23,137 @@ class Batch:
     """
     Class to handle GFlowNet batches.
 
-    loss: string
-        String identifier of the GFlowNet loss.
-
-    device: str or torch.device
-        torch.device or string indicating the device to use ("cpu" or "cuda")
-
-    float_type: torch.dtype or int
-        One of float torch.dtype or an int indicating the float precision (16, 32 or
-        64).
-
     Important note: one env should correspond to only one trajectory, all env_id should
     be unique.
+
+    Note: self.state_indices start by index 1 to indicate that index 0 would correspond
+    to the source state but the latter is not stored in the batch for each trajectory.
+    This implies that one has to be careful when indexing the list of batch_indices in
+    self.trajectories by using self.state_indices. For example, the batch index of
+    state state_idx of trajectory traj_idx is self.trajectories[traj_idx][state_idx-1]
+    (not self.trajectories[traj_idx][state_idx]).
     """
 
     def __init__(
         self,
-        loss: str,
+        env: Optional[GFlowNetEnv] = None,
         device: Union[str, torch.device] = "cpu",
         float_type: Union[int, torch.dtype] = 32,
     ):
+        """
+        env : GFlowNetEnv
+            An instance of the environment that will be used to form the batch.
+
+        device : str or torch.device
+            torch.device or string indicating the device to use ("cpu" or "cuda")
+
+        float_type : torch.dtype or int
+            One of float torch.dtype or an int indicating the float precision (16, 32
+            or 64).
+
+        """
         # Device
         self.device = set_device(device)
         # Float precision
         self.float = set_float_precision(float_type)
-        # Loss
-        self.loss = loss
+        # Generic environment, properties and dictionary of state and forward mask of
+        # source (as tensor)
+        if env is not None:
+            self.set_env(env)
+        else:
+            self.env = None
+            self.source = None
+            self.conditional = None
+            self.continuous = None
+        # Initialize batch size 0
+        self.size = 0
         # Initialize empty batch variables
-        self.envs = dict()
+        # TODO: make single ordered dictionary of dictionaries
+        self.envs = OrderedDict()
+        self.trajectories = OrderedDict()
+        self.is_backward = OrderedDict()
+        self.traj_indices = []
+        # TODO: state_indices is currently unused, it is redundant and inconsistent
+        # between forward and backward trajectories. We may want to remove it.
+        self.state_indices = []
         self.states = []
         self.actions = []
         self.done = []
-        self.env_ids = []
         self.masks_invalid_actions_forward = []
         self.masks_invalid_actions_backward = []
         self.parents = []
         self.parents_all = []
         self.parents_actions_all = []
         self.n_actions = []
-        self.is_processed = False
         self.states_policy = None
         self.parents_policy = None
-        self.trajectory_indices = None
+        # Flags for available items
+        self.parents_available = True
+        self.parents_policy_available = False
+        self.parents_all_available = False
+        self.masks_forward_available = False
+        self.masks_backward_available = False
+        self.rewards_available = False
 
     def __len__(self):
-        return len(self.states)
+        return self.size
+
+    def batch_idx_to_traj_state_idx(self, batch_idx: int):
+        traj_idx = self.traj_indices[batch_idx]
+        state_idx = self.state_indices[batch_idx]
+        return traj_idx, state_id
+
+    def traj_idx_to_batch_indices(self, traj_idx: int):
+        batch_indices = self.trajectories[traj_idx]
+        return batch_indices
+
+    def traj_state_idx_to_batch_idx(self, traj_idx: int, state_idx: int):
+        batch_idx = self.trajectories[traj_idx][state_idx]
+        return batch_idx
+
+    def traj_idx_action_idx_to_batch_idx(
+        self, traj_idx: int, action_idx: int, backward: bool
+    ):
+        if traj_idx not in self.trajectories:
+            return None
+        if backward:
+            if action_idx >= len(self.trajectories[traj_idx]):
+                return None
+            return self.trajectories[traj_idx][::-1][action_idx]
+        if action_idx > len(self.trajectories[traj_idx]):
+            return None
+        return self.trajectories[traj_idx][action_idx - 1]
+
+    def idx2state_idx(self, idx: int):
+        return self.trajectories[self.traj_indices[idx]].index(idx)
+
+    def set_env(self, env: GFlowNetEnv):
+        """
+        Sets the generic environment passed as an argument an initializes the
+        environment-dependent properties.
+        """
+        self.env = env.copy().reset()
+        self.source = {
+            "state": self.env.source,
+            "mask_forward": tbool(
+                self.env.get_mask_invalid_actions_forward(), device=self.device
+            ),
+        }
+        self.conditional = self.env.conditional
+        self.continuous = self.env.continuous
 
     def add_to_batch(
         self,
         envs: List[GFlowNetEnv],
         actions: List[Tuple],
         valids: List[bool],
-        masks_invalid_actions_forward: Optional[List[List[bool]]] = None,
+        backward: Optional[bool] = False,
         train: Optional[bool] = True,
     ):
         """
         Adds information from a list of environments and actions to the batch after
-        performing steps in the envs. If train is True, it adds all the variables
-        required for computing the loss specified by self.loss. Otherwise, it stores
-        only states, env_id, step number (everything needed when sampling a trajectory
-        at inference)
+        performing steps in the envs. If train is False, only the variables of
+        terminating states are stored.
 
         Args
         ----
@@ -94,131 +166,164 @@ class Batch:
         valids : list
             A list of boolean values indicated whether the actions were valid.
 
-        masks_invalid_actions_forward : list
-            A list of masks indicating, among all the actions that could have been
-            selected for all environments, which ones were invalid. Optional, will be
-            computed if not provided.
+        backward : bool
+            A boolean value indicating whether the action was sampled backward (False
+            by dfefault). If True, the behavior is slightly different so as to match
+            what is stored in forward sampling:
+                - If it is the first state in the trajectory (action from a done
+                  state/env), then done is stored as True, instead of taking env.done
+                  which will be False after having performed the step.
+                - If it is not the first state in the trajectory, the stored state will
+                  be the previous one in the trajectory, to match the state-action
+                  stored in forward sampling and the convention that the source state
+                  is not stored, but the terminating state is repeated with action eos.
 
         train : bool
             A boolean value indicating whether the data to add to the batch will be used
             for training. Optional, default is True.
         """
-        if self.is_processed:
-            raise Exception("Cannot append to the processed batch")
-
-        # Sample masks of invalid actions if required and none are provided
-        if masks_invalid_actions_forward is None:
-            if train:
-                masks_invalid_actions_forward = [
-                    env.get_mask_invalid_actions_forward() for env in envs
-                ]
-            else:
-                masks_invalid_actions_forward = [None] * len(envs)
+        # TODO: do we need this?
+        if self.continuous is None:
+            self.continuous = envs[0].continuous
 
         # Add data samples to the batch
-        for sample_data in zip(envs, actions, valids, masks_invalid_actions_forward):
-            env, action, valid, mask_forward = sample_data
-            self.envs.update({env.id: env})
+        for env, action, valid in zip(envs, actions, valids):
+            if train is False and env.done is False:
+                continue
             if not valid:
                 continue
-            if train:
-                self.states.append(deepcopy(env.state))
-                self.actions.append(action)
-                self.env_ids.append(env.id)
-                self.done.append(env.done)
-                self.n_actions.append(env.n_actions)
-                self.masks_invalid_actions_forward.append(mask_forward)
-
-                if self.loss == "flowmatch":
-                    parents, parents_a = env.get_parents(action=action)
-                    assert (
-                        action in parents_a
-                    ), f"""
-                    Sampled action is not in the list of valid actions from parents.
-                    \nState:\n{env.state}\nAction:\n{action}
-                    """
-                    self.parents_all.append(parents)
-                    self.parents_actions_all.append(parents_a)
-                if self.loss == "trajectorybalance":
-                    self.masks_invalid_actions_backward.append(
-                        env.get_mask_invalid_actions_backward(
-                            env.state, env.done, [action]
-                        )
-                    )
+            # Add env to dictionary
+            if env.id not in self.envs:
+                self.envs.update({env.id: env})
+            # Add batch index to trajectory
+            if env.id not in self.trajectories:
+                self.trajectories.update({env.id: [len(self)]})
             else:
-                if env.done:
-                    self.states.append(env.state)
-                    self.env_ids.append(env.id)
-                    self.n_actions.append(env.n_actions)
+                if backward:
+                    self.trajectories[env.id].insert(0, len(self))
+                else:
+                    self.trajectories[env.id].append(len(self))
+            # Set whether trajectory is backward
+            if env.id not in self.is_backward:
+                self.is_backward.update({env.id: backward})
+            # Add trajectory index and state index
+            self.traj_indices.append(env.id)
+            self.state_indices.append(env.n_actions)
+            # Add states, parents, actions, done and masks
+            self.actions.append(action)
+            if backward:
+                self.parents.append(copy(env.state))
+                if len(self.trajectories[env.id]) == 1:
+                    self.states.append(copy(env.state))
+                    self.done.append(True)
+                else:
+                    self.states.append(copy(self.parents[self.trajectories[env.id][1]]))
+                    self.done.append(env.done)
+            else:
+                self.states.append(copy(env.state))
+                self.done.append(env.done)
+                if len(self.trajectories[env.id]) == 1:
+                    self.parents.append(copy(self.source["state"]))
+                else:
+                    self.parents.append(
+                        copy(self.states[self.trajectories[env.id][-2]])
+                    )
+            # Set masks to None
+            self.masks_invalid_actions_forward.append(None)
+            self.masks_invalid_actions_backward.append(None)
+            # Increment size of batch
+            self.size += 1
+        # Other variables are not available after new items were added to the batch
+        self.masks_forward_available = False
+        self.masks_backward_available = False
+        self.parents_policy_available = False
+        self.parents_all_available = False
+        self.rewards_available = False
 
-    def process_batch(self):
+    def get_n_trajectories(self) -> int:
         """
-        Converts internal lists into more convenient formats:
-        - converts and stacks lists into a single torch tensor
-        - computes trajectory indices (indices of the states in self.states
-          corresponding to each trajectory)
-        - if needed, converts states and parents into policy formats (stored in
-          self.states_policy, self.parents_policy)
-        """
-        self.env_ids = tlong(self.env_ids, device=self.device)
-        self.states, self.states_policy = self._process_states()
-        self.n_actions = tlong(self.n_actions, device=self.device)
-        self.trajectory_indices = self._process_trajectory_indices()
-        # process other variables, if we are in the train mode and recorded them
-        if len(self.actions) > 0:
-            self.actions = tfloat(
-                self.actions, device=self.device, float_type=self.float
-            )
-            self.done = tbool(self.done, device=self.device)
-            self.masks_invalid_actions_forward = tbool(
-                self.masks_invalid_actions_forward, device=self.device
-            )
-            if self.loss == "flowmatch":
-                self.parents_all_state_idx = tlong(
-                    sum(
-                        [[idx] * len(p) for idx, p in enumerate(self.parents_all)],
-                        [],
-                    ),
-                    device=self.device,
-                )
-                self.parents_actions_all = tfloat(
-                    [a for actions in self.parents_actions_all for a in actions],
-                    device=self.device,
-                    float_type=self.float,
-                )
-            elif self.loss == "trajectorybalance":
-                self.masks_invalid_actions_backward = tbool(
-                    self.masks_invalid_actions_backward, device=self.device
-                )
-            (
-                self.parents,
-                self.parents_policy,
-                self.parents_all,
-                self.parents_all_policy,
-            ) = self._process_parents()
-        self.is_processed = True
-
-    def _process_states(self):
-        """
-        Convert self.states from a list to a torch tensor and compute states in the policy format.
+        Returns the number of trajectories in the batch.
 
         Returns
         -------
-        states: torch.tensor
-            Tensor containing the states converted to a torch tensor.
-        states_policy: torch.tensor
-            Tensor containing the states converted to the policy format.
-
+        The number of trajectories in the batch (int).
         """
-        states = tfloat(self.states, device=self.device, float_type=self.float)
-        states_policy = self.states2policy(states, self.env_ids)
-        return states, states_policy
+        return len(self.trajectories)
+
+    def get_trajectory_indices(self) -> TensorType["n_states", int]:
+        """
+        Returns the trajectory index of all elements in the batch as a long int torch
+        tensor.
+
+        Returns
+        -------
+        traj_indices : torch.tensor
+            self.traj_indices as a long int torch tensor.
+        """
+        return tlong(self.traj_indices, device=self.device)
+
+    def get_state_indices(self) -> TensorType["n_states", int]:
+        """
+        Returns the state index of all elements in the batch as a long int torch
+        tensor.
+
+        Returns
+        -------
+        state_indices : torch.tensor
+            self.state_indices as a long int torch tensor.
+        """
+        return tlong(self.state_indices, device=self.device)
+
+    def get_states(
+        self,
+        policy: Optional[bool] = False,
+        proxy: Optional[bool] = False,
+        force_recompute: Optional[bool] = False,
+    ) -> Union[TensorType["n_states", "..."], npt.NDArray[np.float32], List]:
+        """
+        Returns all the states in the batch.
+
+        The states are returned in "policy format" if policy is True, in "proxy format"
+        if proxy is True and otherwise they are returned in "GFlowNet" format by
+        default. An error is raised if both policy and proxy are True.
+
+        Args
+        ----
+        policy : bool
+            If True, the policy format of the states is returned and self.states_policy
+            is updated if not available yet or if force_recompute is True.
+
+        proxy : bool
+            If True, the proxy format of the states is returned. States in proxy format
+            are not stored.
+
+        force_recompute : bool
+            If True, the policy states are recomputed even if they are available.
+            Ignored if policy is False.
+
+        Returns
+        -------
+        self.states or self.states_policy or self.states2proxy(self.states) : list or
+        torch.tensor or ndarray
+            The set of all states in the batch.
+        """
+        if policy is True and proxy is True:
+            raise ValueError(
+                "Ambiguous request! Only one of policy or proxy can be True."
+            )
+        if policy is True:
+            if self.states_policy is None or force_recompute is True:
+                self.states_policy = self.states2policy()
+            return self.states_policy
+        if proxy is True:
+            return self.states2proxy()
+        return self.states
 
     def states2policy(
         self,
         states: Optional[Union[List, TensorType["n_states", "..."]]] = None,
-        env_ids: Optional[List[int]] = None,
-    ):
+        traj_indices: Optional[Union[List, TensorType["n_states"]]] = None,
+    ) -> TensorType["n_states", "state_policy_dims"]:
         """
         Converts states from a list of states in GFlowNet format to a tensor of states
         in policy format.
@@ -228,80 +333,97 @@ class Batch:
         states: list or torch.tensor
             States in GFlowNet format.
 
-        env_ids: list
-            Ids indicating which env corresponds to each state in states.
+        traj_indices: list or torch.tensor
+            Ids indicating which env corresponds to each state in states. It is only
+            used if the environments are conditional to call state2policy from the
+            right environment. Ignored if self.conditional is False.
 
         Returns
         -------
         states: torch.tensor
             States in policy format.
         """
+        # If traj_indices is not None and self.conditional is True, then both states
+        # and traj_indices must be the same type and have the same length.
+        if traj_indices is not None and self.conditional is True:
+            assert type(states) == type(traj_indices)
+            assert len(states) == len(traj_indices)
         if states is None:
             states = self.states
-            env_ids = self.env_ids
-        elif env_ids is None:
-            # if states are provided, env_ids should be provided too
-            raise Exception(
-                """
-                env_ids must be provided to the batch for converting provided states to
-                the policy format.
-                """
-            )
-        env = self._get_first_env()
-        if env.conditional:
+            traj_indices = self.traj_indices
+        # TODO: will env.policy_input_dim be the same for all envs if conditional?
+        if self.conditional:
             states_policy = torch.zeros(
-                (states.shape[0], env.policy_input_dim),
+                (len(states), self.env.policy_input_dim),
                 device=self.device,
                 dtype=self.float,
             )
-            for env_id in torch.unique(env_ids):
-                states_policy[env_ids == env_id] = self.envs[
-                    env_id.item()
-                ].statetorch2policy(states[env_ids == env_id])
+            traj_indices_torch = tlong(traj_indices, device=self.device)
+            for traj_idx in self.trajectories:
+                if traj_idx not in traj_indices:
+                    continue
+                states_policy[traj_indices_torch == traj_idx] = self.envs[
+                    traj_idx
+                ].statebatchpolicy(
+                    self.get_states_of_trajectory(traj_idx, states, traj_indices)
+                )
             return states_policy
-        return env.statetorch2policy(states)
+        # TODO: do we need tfloat or is done in env.statebatch2policy?
+        return tfloat(
+            self.env.statebatch2policy(states),
+            device=self.device,
+            float_type=self.float,
+        )
 
     def states2proxy(
         self,
         states: Optional[Union[List, TensorType["n_states", "..."]]] = None,
-        env_ids: Optional[List[int]] = None,
-    ):
+        traj_indices: Optional[Union[List, TensorType["n_states"]]] = None,
+    ) -> Union[
+        TensorType["n_states", "state_proxy_dims"], npt.NDArray[np.float32], List
+    ]:
         """
         Converts states from a list of states in GFlowNet format to a tensor of states
-        in proxy format.
+        in proxy format. Note that the implementatiuon of this method differs from
+        Batch.states2policy() because the latter always returns torch.tensors. The
+        output of the present method can also be numpy arrays or Python lists,
+        depending on the proxy.
 
         Args
         ----
         states: list or torch.tensor
             States in GFlowNet format.
 
-        env_ids: list
-            Ids indicating which env corresponds to each state in states.
+        traj_indices: list or torch.tensor
+            Ids indicating which env corresponds to each state in states. It is only
+            used if the environments are conditional to call state2proxy from the right
+            environment. Ignored if self.conditional is False.
 
         Returns
         -------
-        states: torch.tensor
-            States in policy format.
+        states: torch.tensor or ndarray or list
+            States in proxy format.
         """
+        # If traj_indices is not None and self.conditional is True, then both states
+        # and traj_indices must be the same type and have the same length.
+        if traj_indices is not None and self.conditional is True:
+            assert type(states) == type(traj_indices)
+            assert len(states) == len(traj_indices)
         if states is None:
             states = self.states
-            env_ids = self.env_ids
-        elif env_ids is None:
-            # if states are provided, env_ids should be provided too
-            raise Exception(
-                """
-                env_ids must be provided to the batch for converting provided states to
-                the proxy format.
-                """
-            )
-        env = self._get_first_env()
-        if env.conditional:
+            traj_indices = self.traj_indices
+        if self.conditional:
             states_proxy = []
-            index = torch.arange(states.shape[0], device=self.device)
+            index = torch.arange(len(states), device=self.device)
             perm_index = []
-            for env_id in torch.unique(env_ids):
+            # TODO: rethink this
+            for traj_idx in self.trajectories:
+                if traj_idx not in traj_indices:
+                    continue
                 states_proxy.append(
-                    self.envs[env_id.item()].statetorch2proxy(states[env_ids == env_id])
+                    self.envs[traj_idx].statebatch2proxy(
+                        self.get_states_of_trajectory(traj_idx, states, traj_indices)
+                    )
                 )
                 perm_index.append(index[env_ids == env_id])
             perm_index = torch.cat(perm_index)
@@ -309,145 +431,772 @@ class Batch:
             index[perm_index] = index.clone()
             states_proxy = concat_items(states_proxy, index)
             return states_proxy
-        return env.statetorch2proxy(states)
+        return self.env.statebatch2proxy(states)
 
-    def _process_parents(self):
+    def get_actions(self) -> TensorType["n_states, action_dim"]:
         """
-        Process parents for the given loss type.
+        Returns the actions in the batch as a float tensor.
+        """
+        return tfloat(self.actions, float_type=self.float, device=self.device)
+
+    def get_done(self) -> TensorType["n_states"]:
+        """
+        Returns the list of done flags as a boolean tensor.
+        """
+        return tbool(self.done, device=self.device)
+
+    # TODO: check availability one by one as in get_masks
+    def get_parents(
+        self, policy: Optional[bool] = False, force_recompute: Optional[bool] = False
+    ) -> TensorType["n_states", "..."]:
+        """
+        Returns the parent (single parent for each state) of all states in the batch.
+        The parents are computed, obtaining all necessary components, if they are not
+        readily available. Missing components and newly computed components are added
+        to the batch (self.component is set).
+
+        The parents are returned in "policy format" if policy is True, otherwise they
+        are returned in "GFlowNet" format (default).
+
+        Args
+        ----
+        policy : bool
+            If True, the policy format of parents is returned. Otherwise, the GFlowNet
+            format is returned.
+
+        force_recompute : bool
+            If True, the parents are recomputed even if they are available.
 
         Returns
         -------
-        parents: torch.tensor
-            Tensor of parent states.
-        parents_policy: torch.tensor
-            Tensor of parent states converted to policy format.
-        parents_all: torch.tensor
-            Tensor of all parent states.
-        parents_all_policy: torch.tensor
-            Tensor of all parent states converted to policy format.
+        self.parents or self.parents_policy : torch.tensor
+            The parent of all states in the batch.
         """
-        parents = []
-        parents_policy = []
-        parents_all = []
-        parents_all_policy = []
-        if self.loss == "flowmatch":
-            for par, env_id in zip(self.parents_all, self.env_ids):
-                parents_all_policy.append(
-                    tfloat(
-                        self.envs[env_id.item()].statebatch2policy(par),
-                        device=self.device,
-                        float_type=self.float,
-                    )
-                )
-            parents_all_policy = torch.cat(parents_all_policy)
-            parents_all = tfloat(
-                [p for parents in self.parents_all for p in parents],
+        if self.parents_available is False or force_recompute is True:
+            self._compute_parents()
+        if policy:
+            if self.parents_policy_available is False or force_recompute is True:
+                self._compute_parents_policy()
+            return self.parents_policy
+        else:
+            return self.parents
+
+    def _compute_parents(self):
+        """
+        Obtains the parent (single parent for each state) of all states in the batch.
+        The parents are computed, obtaining all necessary components, if they are not
+        readily available. Missing components and newly computed components are added
+        to the batch (self.component is set). The following variable is stored:
+
+        - self.parents: the parent of each state in the batch. It will be the same type
+          as self.states (list of lists or tensor)
+            Length: n_states
+            Shape: [n_states, state_dims]
+
+        self.parents_available is set to True.
+        """
+        self.parents = []
+        indices = []
+        # Iterate over the trajectories to obtain the parents from the states
+        for traj_idx, batch_indices in self.trajectories.items():
+            # parent is source
+            self.parents.append(self.envs[traj_idx].source)
+            # parent is not source
+            # TODO: check if tensor and sort without iter
+            self.parents.extend([self.states[idx] for idx in batch_indices[:-1]])
+            indices.extend(batch_indices)
+        # Sort parents list in the same order as states
+        # TODO: check if tensor and sort without iter
+        self.parents = [self.parents[indices.index(idx)] for idx in range(len(self))]
+        self.parents_available = True
+
+    # TODO: consider converting directly from self.parents
+    def _compute_parents_policy(self):
+        """
+        Obtains the parent (single parent for each state) of all states in the batch,
+        in policy format.  The parents are computed, obtaining all necessary
+        components, if they are not readily available. Missing components and newly
+        computed components are added to the batch (self.component is set). The
+        following variable is stored:
+
+        - self.parents_policy: the parent of each state in the batch in policy format.
+            Shape: [n_states, state_policy_dims]
+
+        self.parents_policy is stored as a torch tensor and
+        self.parents_policy_available is set to True.
+        """
+        self.states_policy = self.get_states(policy=True)
+        self.parents_policy = torch.zeros_like(self.states_policy)
+        # Iterate over the trajectories to obtain the parents from the states
+        for traj_idx, batch_indices in self.trajectories.items():
+            # parent is source
+            self.parents_policy[batch_indices[0]] = tfloat(
+                self.envs[traj_idx].state2policy(self.envs[traj_idx].source),
                 device=self.device,
                 float_type=self.float,
             )
-        elif self.loss == "trajectorybalance":
-            assert self.trajectory_indices is not None
-            parents_policy = torch.zeros_like(self.states_policy)
-            parents = torch.zeros_like(self.states)
-            for env_id, traj in self.trajectory_indices.items():
-                # parent is source
-                parents_policy[traj[0]] = tfloat(
-                    self.envs[env_id].state2policy(self.envs[env_id].source),
-                    device=self.device,
-                    float_type=self.float,
-                )
-                parents[traj[0]] = tfloat(
-                    self.envs[env_id].source,
-                    device=self.device,
-                    float_type=self.float,
-                )
-                # parent is not source
-                parents_policy[traj[1:]] = self.states_policy[traj[:-1]]
-                parents[traj[1:]] = self.states[traj[:-1]]
-        return parents, parents_policy, parents_all, parents_all_policy
+            # parent is not source
+            self.parents_policy[batch_indices[1:]] = self.states_policy[
+                batch_indices[:-1]
+            ]
+        self.parents_policy_available = True
 
-    def merge(self, another_batch):
+    def get_parents_all(
+        self, policy: bool = False, force_recompute: bool = False
+    ) -> Tuple[
+        Union[List, TensorType["n_parents", "..."]],
+        TensorType["n_parents", "..."],
+        TensorType["n_parents"],
+    ]:
         """
-        Merges two unprocessed batches.
-        """
-        if self.is_processed or another_batch.is_processed:
-            raise Exception("Cannot merge processed batches.")
-        if self.loss != another_batch.loss:
-            raise Exception("Cannot merge batches with different losses.")
-        self.envs.update(another_batch.envs)
-        self.states += another_batch.states
-        self.actions += another_batch.actions
-        self.done += another_batch.done
-        self.env_ids += another_batch.env_ids
-        self.masks_invalid_actions_forward += (
-            another_batch.masks_invalid_actions_forward
-        )
-        self.masks_invalid_actions_backward += (
-            another_batch.masks_invalid_actions_backward
-        )
-        self.parents += another_batch.parents
-        self.parents_all += another_batch.parents_all
-        self.parents_actions_all += another_batch.parents_actions_all
-        self.n_actions += another_batch.n_actions
+        Returns the whole set of parents, their corresponding actions and indices of
+        all states in the batch. If the parents are not available
+        (self.parents_all_available is False) or if force_recompute is True, then
+        self._compute_parents_all() is called to compute the required components.
 
-    def _process_trajectory_indices(self):
-        """
-        Obtain the indices in the batch that correspond to each environment.
-        Creates a dictionary of trajectory indices (key: env_id, value: indices of the states in self.states
-        ordered from s_1 to s_f).
+        The parents are returned in "policy format" if policy is True, otherwise they
+        are returned in "GFlowNet" format (default).
+
+        Args
+        ----
+        policy : bool
+            If True, the policy format of parents is returned. Otherwise, the GFlowNet
+            format is returned.
+
+        force_recompute : bool
+            If True, the parents are recomputed even if they are available.
 
         Returns
         -------
-        trajs: dict
-            Dictionary containing trajectory indices for each environment.
-        """
-        trajs = defaultdict(list)
-        for idx, (env_id, step) in enumerate(zip(self.env_ids, self.n_actions)):
-            trajs[env_id.item()].append((idx, step))
-        trajs = {
-            env_id: list(map(lambda x: x[0], sorted(traj, key=lambda x: x[1])))
-            for env_id, traj in trajs.items()
-        }
-        return trajs
+        self.parents_all or self.parents_all_policy : list or torch.tensor
+            The whole set of parents of all states in the batch.
 
-    # TODO: rethink and re-implement. Outputs should not be tuples. It needs to be
-    # refactored together with the buffer.
-    # TODO: docstring
-    def unpack_terminal_states(self):
-        """
-        For storing terminal states and trajectory actions in the buffer
-        Unpacks the terminating states and trajectories of a batch and converts them
-        to Python lists/tuples.
-        """
-        # TODO: make sure that unpacked states and trajs are sorted by traj_id (like
-        # rewards will be)
-        if not self.is_processed:
-            self.process_batch()
-        terminal_states = []
-        traj_actions = []
-        for traj_idx in self.trajectory_indices.values():
-            traj_actions.append(self.actions[traj_idx].tolist())
-            terminal_states.append(tuple(self.states[traj_idx[-1]].tolist()))
-        traj_actions = [tuple([tuple(a) for a in t]) for t in traj_actions]
-        return terminal_states, traj_actions
+        self.parents_actions_all : torch.tensor
+            The actions corresponding to each parent in self.parents_all or
+            self.parents_all_policy, linking them to the corresponding state in the
+            trajectory.
 
-    def compute_rewards(self):
+        self.parents_all_indices : torch.tensor
+            The state index corresponding to each parent in self.parents_all or
+            self.parents_all_policy, linking them to the corresponding state in the
+            batch.
         """
-        Computes rewards for self.states using proxy from one of the self.envs
+        if self.continuous:
+            raise Exception("get_parents() is ill-defined for continuous environments!")
+        if self.parents_all_available is False or force_recompute is True:
+            self._compute_parents_all()
+        if policy:
+            return (
+                self.parents_all_policy,
+                self.parents_actions_all,
+                self.parents_all_indices,
+            )
+        else:
+            return self.parents_all, self.parents_actions_all, self.parents_all_indices
+
+    def _compute_parents_all(self):
+        """
+        Obtains the whole set of parents all states in the batch. The parents are
+        computed via env.get_parents(). The following components are obtained:
+
+        - self.parents_all: all the parents of all states in the batch. It will be the
+          same type as self.states (list of lists or tensor)
+            Length: n_parents
+            Shape: [n_parents, state_dims]
+        - self.parents_actions_all: the actions corresponding to the transition from
+          each parent in self.parents_all to its corresponding state in the batch.
+            Shape: [n_parents, action_dim]
+        - self.parents_all_indices: the indices corresponding to the state in the batch
+          of which each parent in self.parents_all is a parent.
+            Shape: [n_parents]
+        - self.parents_all_policy: self.parents_all in policy format.
+            Shape: [n_parents, state_policy_dims]
+
+        All the above components are stored as torch tensors and
+        self.parents_all_available is set to True.
+        """
+        # Iterate over the trajectories to obtain all parents
+        self.parents_all = []
+        self.parents_actions_all = []
+        self.parents_all_indices = []
+        self.parents_all_policy = []
+        for idx, traj_idx in enumerate(self.traj_indices):
+            state = self.states[idx]
+            done = self.done[idx]
+            action = self.actions[idx]
+            parents, parents_a = self.envs[traj_idx].get_parents(
+                state=state,
+                done=done,
+                action=action,
+            )
+            assert (
+                action in parents_a
+            ), f"""
+            Sampled action is not in the list of valid actions from parents.
+            \nState:\n{state}\nAction:\n{action}
+            """
+            self.parents_all.extend(parents)
+            self.parents_actions_all.extend(parents_a)
+            self.parents_all_indices.extend([idx] * len(parents))
+            self.parents_all_policy.append(
+                tfloat(
+                    self.envs[traj_idx].statebatch2policy(parents),
+                    device=self.device,
+                    float_type=self.float,
+                )
+            )
+        # Convert to tensors
+        self.parents_actions_all = tfloat(
+            self.parents_actions_all,
+            device=self.device,
+            float_type=self.float,
+        )
+        self.parents_all_indices = tlong(
+            self.parents_all_indices,
+            device=self.device,
+        )
+        self.parents_all_policy = torch.cat(self.parents_all_policy)
+        self.parents_all_available = True
+
+    # TODO: opportunity to improve efficiency by caching.
+    def get_masks_forward(
+        self,
+        of_parents: bool = False,
+        force_recompute: bool = False,
+    ) -> TensorType["n_states", "action_space_dim"]:
+        """
+        Returns the forward mask of invalid actions of all states in the batch or of
+        their parent in the trajectory if of_parents is True. The masks are computed
+        via self._compute_masks_forward if they are not available or if force_recompute
+        is True.
+
+        Args
+        ----
+        of_parents : bool
+            If True, the returned masks will correspond to the parents of the states,
+            instead of to the states (default).
+
+        force_recompute : bool
+            If True, the masks are recomputed even if they are available.
+
+        Returns
+        -------
+        self.masks_invalid_actions_forward : torch.tensor
+            The forward mask of all states in the batch.
+        """
+        if self.masks_forward_available is False or force_recompute is True:
+            self._compute_masks_forward()
+        # Make tensor
+        masks_invalid_actions_forward = tbool(
+            self.masks_invalid_actions_forward, device=self.device
+        )
+        if of_parents:
+            trajectories_parents = {
+                traj_idx: [-1] + batch_indices[:-1]
+                for traj_idx, batch_indices in self.trajectories.items()
+            }
+            parents_indices = tlong(
+                [
+                    trajectories_parents[traj_idx][
+                        self.trajectories[traj_idx].index(idx)
+                    ]
+                    for idx, traj_idx in enumerate(self.traj_indices)
+                ],
+                device=self.device,
+            )
+            masks_invalid_actions_forward_parents = torch.zeros_like(
+                masks_invalid_actions_forward
+            )
+            masks_invalid_actions_forward_parents[parents_indices == -1] = self.source[
+                "mask_forward"
+            ]
+            masks_invalid_actions_forward_parents[
+                parents_indices != -1
+            ] = masks_invalid_actions_forward[parents_indices[parents_indices != -1]]
+            return masks_invalid_actions_forward_parents
+        return masks_invalid_actions_forward
+
+    def _compute_masks_forward(self):
+        """
+        Computes the forward mask of invalid actions of all states in the batch, by
+        calling env.get_mask_invalid_actions_forward(). self.masks_forward_available is
+        set to True.
+        """
+        # Iterate over the trajectories to compute all forward masks
+        for idx, mask in enumerate(self.masks_invalid_actions_forward):
+            if mask is not None:
+                continue
+            state = self.states[idx]
+            done = self.done[idx]
+            traj_idx = self.traj_indices[idx]
+            self.masks_invalid_actions_forward[idx] = self.envs[
+                traj_idx
+            ].get_mask_invalid_actions_forward(state, done)
+        self.masks_forward_available = True
+
+    # TODO: opportunity to improve efficiency by caching. Note that
+    # env.get_masks_invalid_actions_backward() may be expensive because it calls
+    # env.get_parents().
+    def get_masks_backward(
+        self,
+        force_recompute: bool = False,
+    ) -> TensorType["n_states", "action_space_dim"]:
+        """
+        Returns the backward mask of invalid actions of all states in the batch. The
+        masks are computed via self._compute_masks_backward if they are not available
+        or if force_recompute is True.
+
+        Args
+        ----
+        force_recompute : bool
+            If True, the masks are recomputed even if they are available.
+
+        Returns
+        -------
+        self.masks_invalid_actions_backward : torch.tensor
+            The backward mask of all states in the batch.
+        """
+        if self.masks_backward_available is False or force_recompute is True:
+            self._compute_masks_backward()
+        return tbool(self.masks_invalid_actions_backward, device=self.device)
+
+    def _compute_masks_backward(self):
+        """
+        Computes the backward mask of invalid actions of all states in the batch, by
+        calling env.get_mask_invalid_actions_backward(). self.masks_backward_available
+        is set to True.
+        """
+        # Iterate over the trajectories to compute all backward masks
+        for idx, mask in enumerate(self.masks_invalid_actions_backward):
+            if mask is not None:
+                continue
+            state = self.states[idx]
+            done = self.done[idx]
+            traj_idx = self.traj_indices[idx]
+            self.masks_invalid_actions_backward[idx] = self.envs[
+                traj_idx
+            ].get_mask_invalid_actions_backward(state, done)
+        self.masks_backward_available = True
+
+    def get_rewards(
+        self, force_recompute: Optional[bool] = False
+    ) -> TensorType["n_states"]:
+        """
+        Returns the rewards of all states in the batch (including not done).
+
+        Args
+        ----
+        force_recompute : bool
+            If True, the rewards are recomputed even if they are available.
+        """
+        if self.rewards_available is False or force_recompute is True:
+            self._compute_rewards()
+        return self.rewards
+
+    def _compute_rewards(self):
+        """
+        Computes rewards for all self.states by first converting the states into proxy
+        format.
 
         Returns
         -------
         rewards: torch.tensor
             Tensor of rewards.
         """
-        states_proxy_done = self.states2proxy(
-            states=self.states[self.done], env_ids=self.env_ids[self.done]
-        )
-        env = self._get_first_env()
-        rewards = torch.zeros(self.done.shape[0], dtype=self.float, device=self.device)
-        if self.states[self.done, :].shape[0] > 0:
-            rewards[self.done] = env.proxy2reward(env.proxy(states_proxy_done))
-        return rewards
+        states_proxy_done = self.get_terminating_states(proxy=True)
+        self.rewards = torch.zeros(len(self), dtype=self.float, device=self.device)
+        done = self.get_done()
+        if len(done) > 0:
+            self.rewards[done] = self.env.proxy2reward(
+                self.env.proxy(states_proxy_done)
+            )
+        self.rewards_available = True
 
-    def _get_first_env(self):
-        return self.envs[next(iter(self.envs))]
+    def get_terminating_states(
+        self,
+        sort_by: str = "insertion",
+        policy: Optional[bool] = False,
+        proxy: Optional[bool] = False,
+    ) -> Union[TensorType["n_trajectories", "..."], npt.NDArray[np.float32], List]:
+        """
+        Returns the terminating states in the batch, that is all states with done =
+        True. The states will be returned in either GFlowNet format (default), policy
+        (policy = True) or proxy (proxy = True) format. If both policy and proxy are
+        True, it raises an error due to the ambiguity. The returned states may be
+        sorted by order of insertion (sort_by = "insert[ion]", default) or by
+        trajectory index (sort_by = "traj[ectory]".
+
+        Args
+        ----
+        sort_by : str
+            Indicates how to sort the output:
+                - insert[ion]: sort by order of insertion (states of trajectories that
+                  reached the terminating state first come first)
+                - traj[ectory]: sort by trajectory index (the order in the ordered
+                  dict self.trajectories)
+
+        policy : bool
+            If True, the policy format of the states is returned.
+
+        proxy : bool
+            If True, the proxy format of the states is returned.
+        """
+        if sort_by == "insert" or sort_by == "insertion":
+            indices = np.arange(len(self))
+        elif sort_by == "traj" or sort_by == "trajectory":
+            indices = np.argsort(self.traj_indices)
+        else:
+            raise ValueError("sort_by must be either insert[ion] or traj[ectory]")
+        if policy is True and proxy is True:
+            raise ValueError(
+                "Ambiguous request! Only one of policy or proxy can be True."
+            )
+        traj_indices = None
+        if torch.is_tensor(self.states):
+            indices = tlong(indices, device=self.device)
+            done = self.get_done()[indices]
+            states_term = self.states[indices][done, :]
+            if self.conditional and (policy is True or proxy is True):
+                traj_indices = tlong(self.traj_indices, device=self.device)[indices][
+                    done
+                ]
+                assert len(traj_indices) == len(torch.unique(traj_indices))
+        elif isinstance(self.states, list):
+            states_term = [self.states[idx] for idx in indices if self.done[idx]]
+            if self.conditional and (policy is True or proxy is True):
+                done = np.array(self.done, dtype=bool)[indices]
+                traj_indices = np.array(self.traj_indices)[indices][done]
+                assert len(traj_indices) == len(np.unique(traj_indices))
+        else:
+            raise NotImplementedError("self.states can only be list or torch.tensor")
+        if policy is True:
+            return self.states2policy(states_term, traj_indices)
+        elif proxy is True:
+            return self.states2proxy(states_term, traj_indices)
+        else:
+            return states_term
+
+    def get_terminating_rewards(
+        self,
+        sort_by: str = "insertion",
+        force_recompute: Optional[bool] = False,
+    ) -> TensorType["n_trajectories"]:
+        """
+        Returns the reward of the terminating states in the batch, that is all states
+        with done = True. The returned rewards may be sorted by order of insertion
+        (sort_by = "insert[ion]", default) or by trajectory index (sort_by =
+        "traj[ectory]".
+
+        Args
+        ----
+        sort_by : str
+            Indicates how to sort the output:
+                - insert[ion]: sort by order of insertion (rewards of trajectories that
+                  reached the terminating state first come first)
+                - traj[ectory]: sort by trajectory index (the order in the ordered
+                  dict self.trajectories)
+
+        force_recompute : bool
+            If True, the rewards are recomputed even if they are available.
+        """
+        if sort_by == "insert" or sort_by == "insertion":
+            indices = np.arange(len(self))
+        elif sort_by == "traj" or sort_by == "trajectory":
+            indices = np.argsort(self.traj_indices)
+        else:
+            raise ValueError("sort_by must be either insert[ion] or traj[ectory]")
+        if self.rewards_available is False or force_recompute is True:
+            self._compute_rewards()
+        done = self.get_done()[indices]
+        return self.rewards[indices][done]
+
+    def get_actions_trajectories(self) -> List[List[Tuple]]:
+        actions_trajectories = []
+        for batch_indices in self.trajectories.values():
+            actions_trajectories.append([self.actions[idx] for idx in batch_indices])
+        return actions_trajectories
+
+    def get_states_of_trajectory(
+        self,
+        traj_idx: int,
+        states: Optional[
+            Union[TensorType["n_states", "..."], npt.NDArray[np.float32], List]
+        ] = None,
+        traj_indices: Optional[Union[List, TensorType["n_states"]]] = None,
+    ) -> Union[
+        TensorType["n_states", "state_proxy_dims"], npt.NDArray[np.float32], List
+    ]:
+        """
+        TODO: docstring
+        """
+        # TODO: re-implement using the batch indices in self.trajectories[traj_idx]
+        # If either states or traj_indices are not None, both must be the same type and
+        # have the same length.
+        # TODO: or add sort_by
+        if states is not None or traj_indices is not None:
+            assert type(states) == type(traj_indices)
+            assert len(states) == len(traj_indices)
+        else:
+            states = self.states
+            traj_indices = self.traj_indices
+        if torch.is_tensor(states):
+            return states[tlong(traj_indices, device=self.device) == traj_idx]
+        elif isinstance(states, list):
+            return [
+                state for state, idx in zip(states, traj_indices) if idx == traj_idx
+            ]
+        elif isinstance(states, np.ndarray):
+            return states[np.array(traj_indices) == traj_idx]
+        else:
+            raise ValueError("states can only be list, torch.tensor or ndarray")
+
+    def merge(self, batches: List):
+        """
+        Merges the current Batch (self) with the Batch or list of Batches passed as
+        argument.
+
+        Returns
+        -------
+        self
+        """
+        if not isinstance(batches, list):
+            batches = [batches]
+        for batch in batches:
+            if len(batch) == 0:
+                continue
+            # Shift trajectory indices of batch to merge
+            if len(self) == 0:
+                traj_idx_shift = 0
+            else:
+                traj_idx_shift = np.max(list(self.trajectories.keys())) + 1
+            batch._shift_indices(traj_shift=traj_idx_shift, batch_shift=len(self))
+            # Merge main data
+            self.size += batch.size
+            self.envs.update(batch.envs)
+            self.trajectories.update(batch.trajectories)
+            self.traj_indices.extend(batch.traj_indices)
+            self.state_indices.extend(batch.state_indices)
+            self.states.extend(batch.states)
+            self.actions.extend(batch.actions)
+            self.done.extend(batch.done)
+            self.masks_invalid_actions_forward = extend(
+                self.masks_invalid_actions_forward,
+                batch.masks_invalid_actions_forward,
+            )
+            self.masks_invalid_actions_backward = extend(
+                self.masks_invalid_actions_backward,
+                batch.masks_invalid_actions_backward,
+            )
+            # Merge "optional" data
+            if self.states_policy is not None and batch.states_policy is not None:
+                self.states_policy = extend(self.states_policy, batch.states_policy)
+            else:
+                self.states_policy = None
+            if self.parents_available and batch.parents_available:
+                self.parents = extend(self.parents, batch.parents)
+            else:
+                self.parents = None
+            if self.parents_policy_available and batch.parents_policy_available:
+                self.parents_policy = extend(self.parents_policy, batch.parents_policy)
+            else:
+                self.parents_policy = None
+            if self.parents_all_available and batch.parents_all_available:
+                self.parents_all = extend(self.parents_all, batch.parents_all)
+            else:
+                self.parents_all = None
+            if self.rewards_available and batch.rewards_available:
+                self.rewards = extend(self.rewards, batch.rewards)
+            else:
+                self.rewards = None
+        assert self.is_valid()
+        return self
+
+    def is_valid(self) -> bool:
+        """
+        Performs basic checks on the current state of the batch.
+
+        Returns
+        -------
+        True if all the checks are valid, False otherwise.
+        """
+        if len(self.states) != len(self):
+            return False
+        if len(self.actions) != len(self):
+            return False
+        if len(self.done) != len(self):
+            return False
+        if len(self.traj_indices) != len(self):
+            return False
+        if len(self.state_indices) != len(self):
+            return False
+        if set(np.unique(self.traj_indices)) != set(self.envs.keys()):
+            return False
+        if set(self.trajectories.keys()) != set(self.envs.keys()):
+            return False
+        batch_indices = [
+            idx for indices in self.trajectories.values() for idx in indices
+        ]
+        if len(batch_indices) != len(self):
+            return False
+        if len(np.unique(batch_indices)) != len(batch_indices):
+            return False
+        return True
+
+    def _shift_indices(self, traj_shift: int, batch_shift: int):
+        """
+        Shifts all the trajectory indices and environment ids by traj_shift and the batch
+        indices by batch_shift.
+
+        Returns
+        -------
+        self
+        """
+        if not self.is_valid():
+            raise Exception("Batch is not valid before attempting indices shift")
+        self.traj_indices = [idx + traj_shift for idx in self.traj_indices]
+        self.trajectories = {
+            traj_idx + traj_shift: list(map(lambda x: x + batch_shift, batch_indices))
+            for traj_idx, batch_indices in self.trajectories.items()
+        }
+        self.envs = {
+            k + traj_shift: env.set_id(k + traj_shift) for k, env in self.envs.items()
+        }
+        if not self.is_valid():
+            raise Exception("Batch is not valid after performing indices shift")
+        return self
+
+    # TODO: rewrite once cache is implemnted
+    def get_item(
+        self,
+        item: str,
+        env: GFlowNetEnv = None,
+        traj_idx: int = None,
+        action_idx: int = None,
+        backward: bool = False,
+    ):
+        """
+        Returns the item specified by item of either:
+            - environment env, OR
+            - trajectory traj_idx AND action number action_idx (in the order of
+              sampling)
+
+        If all arguments are given, then they must be consistent, otherwise an
+        exception (assert) is raised due to ambiguity.
+
+        If a mask is requested but is missing, it is computed and stored.
+
+        Args
+        ----
+        item : str
+            String identifier of the item to retrieve from the batch. Options
+                - state
+                - parent
+                - action
+                - done
+                - mask_f[orward]
+                - mask_b[ackward]
+
+        traj_idx : int
+            Trajectory index
+
+        action_idx : int
+            Action index. Regardless of forward of backward, n-th item sampled when
+            forming the batch.
+
+        backward : bool
+            Whether the trajectory is sampling backward. False (forward) by default.
+
+        Returns
+        -------
+        The requested item if it is available or None if it is not. It raises an error
+        if the request can be identified as incorrect.
+        """
+        # Preliminary checks
+        if env is not None:
+            if traj_idx is not None:
+                assert (
+                    env.id == traj_idx
+                ), "env.id {env.id} different to traj_idx {traj_idx}."
+            else:
+                traj_idx = env.id
+            if action_idx is not None:
+                assert (
+                    env.n_actions == action_idx
+                ), "env.n_actions {env.n_actions} different to action_idx {action_idx}."
+            else:
+                action_idx = env.n_actions
+        else:
+            assert (
+                traj_idx is not None and action_idx is not None
+            ), "Either env or traj_idx AND action_idx must be provided"
+        # Handle action_idx = 0 (source state)
+        if action_idx == 0:
+            if backward is False:
+                if item == "state":
+                    return self.source["state"]
+                elif item == "mask_f" or item == "mask_forward":
+                    return self.source["mask_forward"]
+                else:
+                    raise ValueError(
+                        "Only state or mask_forward are available for a fresh env "
+                        "(action_idx = 0)"
+                    )
+        #             else:
+        #                 # TODO: handle backward masks with cache
+        #                 raise NotImplementedError(
+        #                     "get_item at action_idx = 0 for backward trajectories is currently "
+        #                     "not supported"
+        #                 )
+        batch_idx = self.traj_idx_action_idx_to_batch_idx(
+            traj_idx, action_idx, backward
+        )
+        if batch_idx is None:
+            # TODO: handle this
+            if env is None:
+                raise ValueError(
+                    "{item} not available for action {action_idx} of trajectory "
+                    "{traj_idx} and no env was provided."
+                )
+            else:
+                if item == "state":
+                    return env.state
+                elif item == "done":
+                    return env.done
+                elif item == "mask_f" or item == "mask_forward":
+                    return env.get_mask_invalid_actions_forward()
+                elif item == "mask_b" or item == "mask_backward":
+                    return env.get_mask_invalid_actions_backward()
+                else:
+                    raise ValueError(
+                        "Not available in the batch. item must be one of: state, done, "
+                        "mask_f[orward] or mask_b[ackward]."
+                    )
+        if item == "state":
+            return self.states[batch_idx]
+        elif item == "parent":
+            return self.parents[batch_idx]
+        elif item == "action":
+            return self.actions[batch_idx]
+        elif item == "done":
+            return self.done[batch_idx]
+        elif item == "mask_f" or item == "mask_forward":
+            if self.masks_invalid_actions_forward[batch_idx] is None:
+                state = self.states[batch_idx]
+                done = self.done[batch_idx]
+                self.masks_invalid_actions_forward[batch_idx] = self.envs[
+                    traj_idx
+                ].get_mask_invalid_actions_forward(state, done)
+            return self.masks_invalid_actions_forward[batch_idx]
+        elif item == "mask_b" or item == "mask_backward":
+            if self.masks_invalid_actions_backward[batch_idx] is None:
+                state = self.states[batch_idx]
+                done = self.done[batch_idx]
+                self.masks_invalid_actions_backward[batch_idx] = self.envs[
+                    traj_idx
+                ].get_mask_invalid_actions_backward(state, done)
+            return self.masks_invalid_actions_backward[batch_idx]
+        else:
+            raise ValueError(
+                "item must be one of: state, parent, action, done, mask_f[orward] or "
+                "mask_b[ackward]"
+            )

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -36,6 +36,11 @@ class Buffer:
         self.replay.reward = pd.to_numeric(self.replay.reward)
         self.replay.energy = pd.to_numeric(self.replay.energy)
         self.replay.reward = [-1 for _ in range(self.replay_capacity)]
+        self.replay_states = {}
+        self.replay_trajs = {}
+        self.replay_pkl = "replay.pkl"
+        with open(self.replay_pkl, "wb") as f:
+            pickle.dump({"x": self.replay_states, "trajs": self.replay_trajs}, f)
         # Define train and test data sets
         if train is not None and "type" in train:
             self.train_type = train.type
@@ -143,22 +148,29 @@ class Buffer:
         rewards,
         energies,
         it,
+        allow_duplicate_states=False,
     ):
-        rewards_old = self.replay["reward"].values
-        rewards_new = rewards.copy()
-        while np.max(rewards_new) > np.min(rewards_old):
-            idx_new_max = np.argmax(rewards_new)
-            readable_state = self.env.state2readable(states[idx_new_max])
-            if not self.replay["state"].isin([readable_state]).any():
-                self.replay.iloc[self.replay.reward.argmin()] = {
-                    "state": self.env.state2readable(states[idx_new_max]),
-                    "traj": self.env.traj2readable(trajs[idx_new_max]),
-                    "reward": rewards[idx_new_max],
-                    "energy": energies[idx_new_max],
+        for idx, (state, traj, reward, energy) in enumerate(
+            zip(states, trajs, rewards, energies)
+        ):
+            if allow_duplicate_states is False and state in self.replay_states.values():
+                continue
+            if (
+                reward > self.replay.iloc[-1]["reward"]
+                and traj not in self.replay_trajs.values()
+            ):
+                self.replay.iloc[-1] = {
+                    "state": self.env.state2readable(state),
+                    "traj": self.env.traj2readable(traj),
+                    "reward": reward,
+                    "energy": energy,
                     "iter": it,
                 }
-                rewards_old = self.replay["reward"].values
-            rewards_new[idx_new_max] = -1
+                self.replay_states[(idx, it)] = state
+                self.replay_trajs[(idx, it)] = traj
+                self.replay.sort_values(by="reward", ascending=False, inplace=True)
+        with open(self.replay_pkl, "wb") as f:
+            pickle.dump({"x": self.replay_states, "trajs": self.replay_trajs}, f)
         return self.replay
 
     def make_data_set(self, config):

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -189,6 +189,12 @@ class Buffer:
             and hasattr(self.env, "get_uniform_terminating_states")
         ):
             samples = self.env.get_uniform_terminating_states(config.n, config.seed)
+        elif (
+            config.type == "random"
+            and "n" in config
+            and hasattr(self.env, "get_random_terminating_states")
+        ):
+            samples = self.env.get_random_terminating_states(config.n)
         else:
             return None, None
         energies = self.env.oracle(self.env.statebatch2oracle(samples)).tolist()

--- a/mila/launch.py
+++ b/mila/launch.py
@@ -1,13 +1,14 @@
-from pathlib import Path
+import datetime
+import re
+import sys
+from argparse import ArgumentParser
+from copy import deepcopy
 from os import popen
 from os.path import expandvars
-from argparse import ArgumentParser
-import datetime
-from yaml import safe_load
-import re
+from pathlib import Path
 from textwrap import dedent
-import sys
-from copy import deepcopy
+
+from yaml import safe_load
 
 ROOT = Path(__file__).resolve().parent.parent
 

--- a/tests/gflownet/envs/test_tetris.py
+++ b/tests/gflownet/envs/test_tetris.py
@@ -7,27 +7,27 @@ from gflownet.envs.tetris import Tetris
 
 @pytest.fixture
 def env():
-    return Tetris(width=4, height=5)
+    return Tetris(width=4, height=5, device="cpu")
 
 
 @pytest.fixture
 def env6x4():
-    return Tetris(width=4, height=6)
+    return Tetris(width=4, height=6, device="cpu")
 
 
 @pytest.fixture
 def env_mini():
-    return Tetris(width=4, height=5, pieces=["I", "O"], rotations=[0])
+    return Tetris(width=4, height=5, pieces=["I", "O"], rotations=[0], device="cpu")
 
 
 @pytest.fixture
 def env_1piece():
-    return Tetris(width=4, height=5, pieces=["O"], rotations=[0])
+    return Tetris(width=4, height=5, pieces=["O"], rotations=[0], device="cpu")
 
 
 @pytest.fixture
 def env_full():
-    return Tetris(width=10, height=20)
+    return Tetris(width=10, height=20, device="cpu")
 
 
 @pytest.mark.parametrize(

--- a/tests/gflownet/utils/test_batch.py
+++ b/tests/gflownet/utils/test_batch.py
@@ -1,18 +1,27 @@
 import pytest
 import torch
 
+from gflownet.envs.ctorus import ContinuousTorus
 from gflownet.envs.grid import Grid
+from gflownet.envs.tetris import Tetris
+from gflownet.proxy.corners import Corners
+from gflownet.proxy.tetris import Tetris as TetrisScore
 from gflownet.utils.batch import Batch
+from gflownet.utils.common import (
+    concat_items,
+    copy,
+    set_device,
+    set_float_precision,
+    tbool,
+    tfloat,
+    tint,
+    tlong,
+)
 
 
 @pytest.fixture
-def batch_tb():
-    return Batch(loss="trajectorybalance")
-
-
-@pytest.fixture
-def batch_fm():
-    return Batch(loss="flowmatch")
+def batch():
+    return Batch()
 
 
 @pytest.fixture
@@ -20,36 +29,1093 @@ def grid2d():
     return Grid(n_dim=2, length=3, cell_min=-1.0, cell_max=1.0)
 
 
-def test__len__returnszero_at_init(batch_tb, batch_fm):
-    assert len(batch_tb) == 0
-    assert len(batch_fm) == 0
+#     return Grid(n_dim=5, length=10, cell_min=-1.0, cell_max=1.0)
 
 
+@pytest.fixture
+def tetris6x4():
+    return Tetris(width=6, height=4, device="cpu")
+
+
+#     return Tetris(width=10, height=20)
+
+
+@pytest.fixture
+def ctorus2d5l():
+    return ContinuousTorus(n_dim=2, length_traj=10, n_comp=2)
+
+
+#     return ContinuousTorus(n_dim=5, length_traj=10, n_comp=2)
+
+
+@pytest.fixture()
+def corners():
+    return Corners(device="cpu", float_precision=32, mu=0.75, sigma=0.05)
+
+
+@pytest.fixture()
+def tetris_score():
+    return TetrisScore(device="cpu", float_precision=32, normalize=False)
+
+
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__len__returnszero_at_init(batch):
+    assert len(batch) == 0
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize("env", ["grid2d", "tetris6x4", "ctorus2d5l"])
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__add_to_batch__single_env_adds_expected(env, batch, request):
+    env = request.getfixturevalue(env)
+    env = env.reset()
+    batch.set_env(env)
+    while not env.done:
+        # Sample random action
+        state, action, valid = env.step_random()
+        # Add to batch
+        batch.add_to_batch([env], [action], [valid])
+        if valid is False:
+            continue
+        # Checks
+        assert batch.traj_indices[-1] == env.id
+        if torch.is_tensor(state):
+            assert torch.equal(batch.states[-1], state)
+        else:
+            assert batch.states[-1] == state
+        assert batch.actions[-1] == action
+        assert batch.done[-1] == env.done
+        assert batch.state_indices[-1] == env.n_actions
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize("env", ["grid2d", "tetris6x4", "ctorus2d5l"])
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__get_states__single_env_returns_expected(env, batch, request):
+    env = request.getfixturevalue(env)
+    env = env.reset()
+    batch.set_env(env)
+    states = []
+    while not env.done:
+        # Sample random action
+        state, action, valid = env.step_random()
+        # Add to batch
+        batch.add_to_batch([env], [action], [valid])
+        if valid:
+            states.append(copy(state))
+    states_batch = batch.get_states()
+    states_policy_batch = batch.get_states(policy=True)
+    if torch.is_tensor(states[0]):
+        assert torch.equal(torch.stack(states_batch), torch.stack(states))
+    else:
+        assert states_batch == states
+    assert torch.equal(
+        states_policy_batch,
+        tfloat(
+            env.statebatch2policy(states),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize("env", ["grid2d", "tetris6x4", "ctorus2d5l"])
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__get_parents__single_env_returns_expected(env, batch, request):
+    env = request.getfixturevalue(env)
+    env = env.reset()
+    batch.set_env(env)
+    parents = []
+    while not env.done:
+        parent = copy(env.state)
+        # Sample random action
+        _, action, valid = env.step_random()
+        # Add to batch
+        batch.add_to_batch([env], [action], [valid])
+        if valid:
+            parents.append(parent)
+    parents_batch = batch.get_parents()
+    parents_policy_batch = batch.get_parents(policy=True)
+    if torch.is_tensor(parents[0]):
+        assert torch.equal(torch.stack(parents_batch), torch.stack(parents))
+    else:
+        assert parents_batch == parents
+    assert torch.equal(
+        parents_policy_batch,
+        tfloat(
+            env.statebatch2policy(parents),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize("env", ["grid2d", "tetris6x4"])
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__get_parents_all__single_env_returns_expected(env, batch, request):
+    env = request.getfixturevalue(env)
+    env = env.reset()
+    batch.set_env(env)
+    parents_all = []
+    parents_all_a = []
+    while not env.done:
+        # Sample random action
+        _, action, valid = env.step_random()
+        # Add to batch
+        batch.add_to_batch([env], [action], [valid])
+        if valid:
+            parents, parents_a = env.get_parents()
+            parents_all.extend(parents)
+            parents_all_a.extend(parents_a)
+    parents_all_batch, parents_all_a_batch, _ = batch.get_parents_all()
+    parents_all_policy_batch, _, _ = batch.get_parents_all(policy=True)
+    if torch.is_tensor(parents_all[0]):
+        assert torch.equal(torch.stack(parents_all_batch), torch.stack(parents_all))
+    else:
+        assert parents_all_batch == parents_all
+    assert torch.equal(
+        parents_all_a_batch,
+        tfloat(
+            parents_all_a,
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    assert torch.equal(
+        parents_all_policy_batch,
+        tfloat(
+            env.statebatch2policy(parents_all),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize("env", ["grid2d", "tetris6x4", "ctorus2d5l"])
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__get_masks_forward__single_env_returns_expected(env, batch, request):
+    env = request.getfixturevalue(env)
+    env = env.reset()
+    batch.set_env(env)
+    masks_forward = []
+    while not env.done:
+        parent = env.state
+        # Sample random action
+        _, action, valid = env.step_random()
+        # Add to batch
+        batch.add_to_batch([env], [action], [valid])
+        if valid:
+            masks_forward.append(env.get_mask_invalid_actions_forward())
+    masks_forward_batch = batch.get_masks_forward()
+    assert torch.equal(masks_forward_batch, tbool(masks_forward, device=batch.device))
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize("env", ["grid2d", "tetris6x4", "ctorus2d5l"])
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__get_masks_backward__single_env_returns_expected(env, batch, request):
+    env = request.getfixturevalue(env)
+    env = env.reset()
+    batch.set_env(env)
+    masks_backward = []
+    while not env.done:
+        parent = env.state
+        # Sample random action
+        _, action, valid = env.step_random()
+        # Add to batch
+        batch.add_to_batch([env], [action], [valid])
+        if valid:
+            masks_backward.append(env.get_mask_invalid_actions_backward())
+    masks_backward_batch = batch.get_masks_backward()
+    assert torch.equal(masks_backward_batch, tbool(masks_backward, device=batch.device))
+
+
+@pytest.mark.repeat(10)
 @pytest.mark.parametrize(
-    "action, state_expected",
-    [
-        (
-            (1, 0),
-            [1, 0],
-        ),
-        (
-            (0, 1),
-            [0, 1],
-        ),
-    ],
+    "env, proxy",
+    [("grid2d", "corners"), ("tetris6x4", "tetris_score"), ("ctorus2d5l", "corners")],
 )
-def test__add_to_batch__minimal_grid2d_returns_expected(
-    batch_tb, batch_fm, grid2d, action, state_expected
-):
-    state, action_step, valid = grid2d.step(action)
-    assert state == state_expected
-    assert action_step == action
-    assert valid
-    # TB
-    batch_tb.add_to_batch([grid2d], [action], [valid])
-    assert batch_tb.states == [state_expected]
-    assert batch_tb.actions == [action]
-    # FM
-    batch_fm.add_to_batch([grid2d], [action], [valid])
-    assert batch_fm.states == [state_expected]
-    assert batch_fm.actions == [action]
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__get_rewards__single_env_returns_expected(env, proxy, batch, request):
+    env = request.getfixturevalue(env)
+    proxy = request.getfixturevalue(proxy)
+    env = env.reset()
+    env.proxy = proxy
+    env.setup_proxy()
+    batch.set_env(env)
+
+    rewards = []
+    while not env.done:
+        parent = env.state
+        # Sample random action
+        _, action, valid = env.step_random()
+        # Add to batch
+        batch.add_to_batch([env], [action], [valid])
+        if valid:
+            rewards.append(env.reward())
+    rewards_batch = batch.get_rewards()
+    rewards = torch.stack(rewards)
+    assert torch.equal(
+        rewards_batch,
+        tfloat(rewards, device=batch.device, float_type=batch.float),
+    ), (rewards, rewards_batch)
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize(
+    "env, proxy",
+    [("grid2d", "corners"), ("tetris6x4", "tetris_score"), ("ctorus2d5l", "corners")],
+)
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__forward_sampling_multiple_envs_all_as_expected(env, proxy, batch, request):
+    batch_size = 10
+    env_ref = request.getfixturevalue(env)
+    proxy = request.getfixturevalue(proxy)
+    env_ref.proxy = proxy
+    env_ref.setup_proxy()
+    batch.set_env(env_ref)
+
+    # Make list of envs
+    envs = []
+    for idx in range(batch_size):
+        env_aux = env_ref.copy().reset(idx)
+        env_aux.proxy = proxy
+        env_aux.setup_proxy()
+        envs.append(env_aux)
+
+    # Initialize empty lists for checks
+    states = []
+    actions = []
+    done = []
+    masks_forward = []
+    masks_parents_forward = []
+    masks_backward = []
+    parents = []
+    parents_all = []
+    parents_all_a = []
+    rewards = []
+    traj_indices = []
+    state_indices = []
+    states_term_sorted = [None for _ in range(batch_size)]
+
+    # Iterate until envs is empty
+    while envs:
+        actions_iter = []
+        valids_iter = []
+        # Make step env by env (different to GFN Agent) to have full control
+        for env in envs:
+            parent = copy(env.state)
+            # Sample random action
+            state, action, valid = env.step_random()
+            if valid:
+                # Add to iter lists
+                actions_iter.append(action)
+                valids_iter.append(valid)
+                # Add to checking lists
+                states.append(copy(env.state))
+                actions.append(action)
+                done.append(env.done)
+                masks_forward.append(env.get_mask_invalid_actions_forward())
+                masks_parents_forward.append(
+                    env.get_mask_invalid_actions_forward(parent, done=False)
+                )
+                masks_backward.append(env.get_mask_invalid_actions_backward())
+                parents.append(parent)
+                if not env.continuous:
+                    env_parents, env_parents_a = env.get_parents()
+                    parents_all.extend(env_parents)
+                    parents_all_a.extend(env_parents_a)
+                rewards.append(env.reward())
+                traj_indices.append(env.id)
+                state_indices.append(env.n_actions)
+                if env.done:
+                    states_term_sorted[env.id] = env.state
+        # Add all envs, actions and valids to batch
+        batch.add_to_batch(envs, actions_iter, valids_iter)
+        # Remove done envs
+        envs = [env for env in envs if not env.done]
+
+    # Check trajectory indices
+    traj_indices_batch = batch.get_trajectory_indices()
+    assert torch.equal(traj_indices_batch, tlong(traj_indices, device=batch.device))
+    # Check state indices
+    state_indices_batch = batch.get_state_indices()
+    assert torch.equal(state_indices_batch, tlong(state_indices, device=batch.device))
+    # Check states
+    states_batch = batch.get_states()
+    states_policy_batch = batch.get_states(policy=True)
+    if torch.is_tensor(states[0]):
+        assert torch.equal(torch.stack(states_batch), torch.stack(states))
+    else:
+        assert states_batch == states
+    assert torch.equal(
+        states_policy_batch,
+        tfloat(
+            env.statebatch2policy(states),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    # Check actions
+    actions_batch = batch.get_actions()
+    assert torch.equal(
+        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
+    )
+    # Check done
+    done_batch = batch.get_done()
+    assert torch.equal(done_batch, tbool(done, device=batch.device))
+    # Check masks forward
+    masks_forward_batch = batch.get_masks_forward()
+    assert torch.equal(masks_forward_batch, tbool(masks_forward, device=batch.device))
+    # Check masks parents forward
+    masks_parents_forward_batch = batch.get_masks_forward(of_parents=True)
+    assert torch.equal(
+        masks_parents_forward_batch, tbool(masks_parents_forward, device=batch.device)
+    )
+    # Check masks backward
+    masks_backward_batch = batch.get_masks_backward()
+    assert torch.equal(masks_backward_batch, tbool(masks_backward, device=batch.device))
+    # Check parents
+    parents_batch = batch.get_parents()
+    parents_policy_batch = batch.get_parents(policy=True)
+    if torch.is_tensor(parents[0]):
+        assert torch.equal(torch.stack(parents_batch), torch.stack(parents))
+    else:
+        assert parents_batch == parents
+    assert torch.equal(
+        parents_policy_batch,
+        tfloat(
+            env.statebatch2policy(parents),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    # Check parents_all
+    if not env.continuous:
+        parents_all_batch, parents_all_a_batch, _ = batch.get_parents_all()
+        parents_all_policy_batch, _, _ = batch.get_parents_all(policy=True)
+        if torch.is_tensor(parents_all[0]):
+            assert torch.equal(torch.stack(parents_all_batch), torch.stack(parents_all))
+        else:
+            assert parents_all_batch == parents_all
+        assert torch.equal(
+            parents_all_a_batch,
+            tfloat(
+                parents_all_a,
+                device=batch.device,
+                float_type=batch.float,
+            ),
+        )
+        assert torch.equal(
+            parents_all_policy_batch,
+            tfloat(
+                env.statebatch2policy(parents_all),
+                device=batch.device,
+                float_type=batch.float,
+            ),
+        )
+    # Check rewards
+    rewards_batch = batch.get_rewards()
+    rewards = torch.stack(rewards)
+    assert torch.equal(
+        rewards_batch,
+        tfloat(rewards, device=batch.device, float_type=batch.float),
+    ), (rewards, rewards_batch)
+    # Check terminating states (sorted by trajectory)
+    states_term_batch = batch.get_terminating_states(sort_by="traj")
+    states_term_policy_batch = batch.get_terminating_states(sort_by="traj", policy=True)
+    if torch.is_tensor(states_term_sorted[0]):
+        assert torch.equal(
+            torch.stack(states_term_batch), torch.stack(states_term_sorted)
+        )
+    else:
+        assert states_term_batch == states_term_sorted
+    assert torch.equal(
+        states_term_policy_batch,
+        tfloat(
+            env.statebatch2policy(states_term_sorted),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize(
+    "env, proxy",
+    [("grid2d", "corners"), ("tetris6x4", "tetris_score")],
+)
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__backward_sampling_multiple_envs_all_as_expected(env, proxy, batch, request):
+    batch_size = 10
+    env_ref = request.getfixturevalue(env)
+    proxy = request.getfixturevalue(proxy)
+    env_ref.proxy = proxy
+    env_ref.setup_proxy()
+    batch.set_env(env_ref)
+
+    # Sample terminating states and build list of envs
+    x_batch = env_ref.get_uniform_terminating_states(n_states=batch_size)
+    envs = []
+    for idx, x in enumerate(x_batch):
+        env_aux = env_ref.copy().reset(idx)
+        env_aux = env_aux.set_state(state=x, done=True)
+        env_aux.n_actions = env_aux.get_max_traj_length()
+        env_aux.proxy = proxy
+        env_aux.setup_proxy()
+        envs.append(env_aux)
+
+    # Initialize empty lists for checks
+    states = []
+    actions = []
+    dones = []
+    masks_forward = []
+    masks_parents_forward = []
+    masks_backward = []
+    parents = []
+    parents_all = []
+    parents_all_a = []
+    rewards = []
+    traj_indices = []
+    state_indices = []
+    states_term_sorted = [copy(x) for x in x_batch]
+
+    # Iterate until envs is empty
+    while envs:
+        actions_iter = []
+        valids_iter = []
+        # Make step env by env (different to GFN Agent) to have full control
+        for env in envs:
+            # Compute variables before performing action
+            state = copy(env.state)
+            done = env.done
+            mask_forward = env.get_mask_invalid_actions_forward()
+            mask_backward = env.get_mask_invalid_actions_backward()
+            if not env.continuous:
+                env_parents, env_parents_a = env.get_parents()
+            reward = env.reward()
+            if env.done:
+                states_term_sorted[env.id] = env.state
+            # Sample random action
+            parent, action, valid = env.step_random(backward=True)
+            if valid:
+                # Add to iter lists
+                actions_iter.append(action)
+                valids_iter.append(valid)
+                # Add to checking lists
+                states.append(state)
+                actions.append(action)
+                dones.append(done)
+                masks_forward.append(mask_forward)
+                masks_parents_forward.append(env.get_mask_invalid_actions_forward())
+                masks_backward.append(mask_backward)
+                parents.append(parent)
+                if not env.continuous:
+                    parents_all.extend(env_parents)
+                    parents_all_a.extend(env_parents_a)
+                rewards.append(reward)
+                traj_indices.append(env.id)
+                state_indices.append(env.n_actions)
+        # Add all envs, actions and valids to batch
+        batch.add_to_batch(envs, actions_iter, valids_iter, backward=True)
+        # Remove finished trajectories (state reached source)
+        envs = [env for env in envs if not env.equal(env.state, env.source)]
+
+    # Check trajectory indices
+    traj_indices_batch = batch.get_trajectory_indices()
+    assert torch.equal(traj_indices_batch, tlong(traj_indices, device=batch.device))
+    # Check state indices
+    state_indices_batch = batch.get_state_indices()
+    assert torch.equal(state_indices_batch, tlong(state_indices, device=batch.device))
+    # Check states
+    states_batch = batch.get_states()
+    states_policy_batch = batch.get_states(policy=True)
+    if torch.is_tensor(states[0]):
+        assert torch.equal(torch.stack(states_batch), torch.stack(states))
+    else:
+        assert states_batch == states
+    assert torch.equal(
+        states_policy_batch,
+        tfloat(
+            env.statebatch2policy(states),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    # Check actions
+    actions_batch = batch.get_actions()
+    assert torch.equal(
+        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
+    )
+    # Check done
+    done_batch = batch.get_done()
+    assert torch.equal(done_batch, tbool(dones, device=batch.device))
+    # Check masks forward
+    masks_forward_batch = batch.get_masks_forward()
+    assert torch.equal(masks_forward_batch, tbool(masks_forward, device=batch.device))
+    # Check masks parents forward
+    masks_parents_forward_batch = batch.get_masks_forward(of_parents=True)
+    assert torch.equal(
+        masks_parents_forward_batch, tbool(masks_parents_forward, device=batch.device)
+    )
+    # Check masks backward
+    masks_backward_batch = batch.get_masks_backward()
+    assert torch.equal(masks_backward_batch, tbool(masks_backward, device=batch.device))
+    # Check parents
+    parents_batch = batch.get_parents()
+    parents_policy_batch = batch.get_parents(policy=True)
+    if torch.is_tensor(parents[0]):
+        assert torch.equal(torch.stack(parents_batch), torch.stack(parents))
+    else:
+        assert parents_batch == parents
+    assert torch.equal(
+        parents_policy_batch,
+        tfloat(
+            env.statebatch2policy(parents),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    # Check parents_all
+    if not env.continuous:
+        parents_all_batch, parents_all_a_batch, _ = batch.get_parents_all()
+        parents_all_policy_batch, _, _ = batch.get_parents_all(policy=True)
+        if torch.is_tensor(parents_all[0]):
+            assert torch.equal(torch.stack(parents_all_batch), torch.stack(parents_all))
+        else:
+            assert parents_all_batch == parents_all
+        assert torch.equal(
+            parents_all_a_batch,
+            tfloat(
+                parents_all_a,
+                device=batch.device,
+                float_type=batch.float,
+            ),
+        )
+        assert torch.equal(
+            parents_all_policy_batch,
+            tfloat(
+                env.statebatch2policy(parents_all),
+                device=batch.device,
+                float_type=batch.float,
+            ),
+        )
+    # Check rewards
+    rewards_batch = batch.get_rewards()
+    rewards = torch.stack(rewards)
+    assert torch.equal(
+        rewards_batch,
+        tfloat(rewards, device=batch.device, float_type=batch.float),
+    ), (rewards, rewards_batch)
+    # Check terminating states (sorted by trajectory)
+    states_term_batch = batch.get_terminating_states(sort_by="traj")
+    states_term_policy_batch = batch.get_terminating_states(sort_by="traj", policy=True)
+    if torch.is_tensor(states_term_sorted[0]):
+        assert torch.equal(
+            torch.stack(states_term_batch), torch.stack(states_term_sorted)
+        )
+    else:
+        assert states_term_batch == states_term_sorted
+    assert torch.equal(
+        states_term_policy_batch,
+        tfloat(
+            env.statebatch2policy(states_term_sorted),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize(
+    "env, proxy",
+    [("grid2d", "corners"), ("tetris6x4", "tetris_score")],
+)
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__mixed_sampling_multiple_envs_all_as_expected(env, proxy, batch, request):
+    # Initialize fixtures and batch
+    env_ref = request.getfixturevalue(env)
+    proxy = request.getfixturevalue(proxy)
+    env_ref.proxy = proxy
+    env_ref.setup_proxy()
+    batch.set_env(env_ref)
+
+    # Initialize empty lists for checks
+    states = []
+    actions = []
+    dones = []
+    masks_forward = []
+    masks_parents_forward = []
+    masks_backward = []
+    parents = []
+    parents_all = []
+    parents_all_a = []
+    rewards = []
+    traj_indices = []
+    state_indices = []
+    states_term_sorted = []
+
+    ### FORWARD ###
+
+    # Make list of envs
+    batch_size_forward = 10
+    envs = []
+    for idx in range(batch_size_forward):
+        env_aux = env_ref.copy().reset(idx)
+        env_aux.proxy = proxy
+        env_aux.setup_proxy()
+        envs.append(env_aux)
+
+    states_term_sorted.extend([None for _ in range(batch_size_forward)])
+
+    # Iterate until envs is empty
+    while envs:
+        actions_iter = []
+        valids_iter = []
+        # Make step env by env (different to GFN Agent) to have full control
+        for env in envs:
+            parent = copy(env.state)
+            # Sample random action
+            state, action, valid = env.step_random()
+            if valid:
+                # Add to iter lists
+                actions_iter.append(action)
+                valids_iter.append(valid)
+                # Add to checking lists
+                states.append(copy(env.state))
+                actions.append(action)
+                dones.append(env.done)
+                masks_forward.append(env.get_mask_invalid_actions_forward())
+                masks_parents_forward.append(
+                    env.get_mask_invalid_actions_forward(parent, done=False)
+                )
+                masks_backward.append(env.get_mask_invalid_actions_backward())
+                parents.append(parent)
+                if not env.continuous:
+                    env_parents, env_parents_a = env.get_parents()
+                    parents_all.extend(env_parents)
+                    parents_all_a.extend(env_parents_a)
+                rewards.append(env.reward())
+                traj_indices.append(env.id)
+                state_indices.append(env.n_actions)
+                if env.done:
+                    states_term_sorted[env.id] = env.state
+        # Add all envs, actions and valids to batch
+        batch.add_to_batch(envs, actions_iter, valids_iter)
+        # Remove done envs
+        envs = [env for env in envs if not env.done]
+
+    ### BACKWARD ###
+
+    # Sample terminating states and build list of envs
+    batch_size_backward = 10
+    x_batch = env_ref.get_uniform_terminating_states(n_states=batch_size_backward)
+    envs = []
+    for idx, x in enumerate(x_batch):
+        env_aux = env_ref.copy().reset(idx + batch_size_forward)
+        env_aux = env_aux.set_state(state=x, done=True)
+        env_aux.n_actions = env_aux.get_max_traj_length()
+        env_aux.proxy = proxy
+        env_aux.setup_proxy()
+        envs.append(env_aux)
+
+    states_term_sorted.extend([copy(x) for x in x_batch])
+
+    # Iterate until envs is empty
+    while envs:
+        actions_iter = []
+        valids_iter = []
+        # Make step env by env (different to GFN Agent) to have full control
+        for env in envs:
+            # Compute variables before performing action
+            state = copy(env.state)
+            done = env.done
+            mask_forward = env.get_mask_invalid_actions_forward()
+            mask_backward = env.get_mask_invalid_actions_backward()
+            if not env.continuous:
+                env_parents, env_parents_a = env.get_parents()
+            reward = env.reward()
+            if env.done:
+                states_term_sorted[env.id] = env.state
+            # Sample random action
+            parent, action, valid = env.step_random(backward=True)
+            if valid:
+                # Add to iter lists
+                actions_iter.append(action)
+                valids_iter.append(valid)
+                # Add to checking lists
+                states.append(state)
+                actions.append(action)
+                dones.append(done)
+                masks_forward.append(mask_forward)
+                masks_parents_forward.append(env.get_mask_invalid_actions_forward())
+                masks_backward.append(mask_backward)
+                parents.append(parent)
+                if not env.continuous:
+                    parents_all.extend(env_parents)
+                    parents_all_a.extend(env_parents_a)
+                rewards.append(reward)
+                traj_indices.append(env.id)
+                state_indices.append(env.n_actions)
+        # Add all envs, actions and valids to batch
+        batch.add_to_batch(envs, actions_iter, valids_iter, backward=True)
+        # Remove finished trajectories (state reached source)
+        envs = [env for env in envs if not env.equal(env.state, env.source)]
+
+    ### CHECKS ###
+
+    # Check trajectory indices
+    traj_indices_batch = batch.get_trajectory_indices()
+    assert torch.equal(traj_indices_batch, tlong(traj_indices, device=batch.device))
+    # Check state indices
+    state_indices_batch = batch.get_state_indices()
+    assert torch.equal(state_indices_batch, tlong(state_indices, device=batch.device))
+    # Check states
+    states_batch = batch.get_states()
+    states_policy_batch = batch.get_states(policy=True)
+    if torch.is_tensor(states[0]):
+        assert torch.equal(torch.stack(states_batch), torch.stack(states))
+    else:
+        assert states_batch == states
+    assert torch.equal(
+        states_policy_batch,
+        tfloat(
+            env.statebatch2policy(states),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    # Check actions
+    actions_batch = batch.get_actions()
+    assert torch.equal(
+        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
+    )
+    # Check done
+    done_batch = batch.get_done()
+    assert torch.equal(done_batch, tbool(dones, device=batch.device))
+    # Check masks forward
+    masks_forward_batch = batch.get_masks_forward()
+    assert torch.equal(masks_forward_batch, tbool(masks_forward, device=batch.device))
+    # Check masks parents forward
+    masks_parents_forward_batch = batch.get_masks_forward(of_parents=True)
+    assert torch.equal(
+        masks_parents_forward_batch, tbool(masks_parents_forward, device=batch.device)
+    )
+    # Check masks backward
+    masks_backward_batch = batch.get_masks_backward()
+    assert torch.equal(masks_backward_batch, tbool(masks_backward, device=batch.device))
+    # Check parents
+    parents_batch = batch.get_parents()
+    parents_policy_batch = batch.get_parents(policy=True)
+    if torch.is_tensor(parents[0]):
+        assert torch.equal(torch.stack(parents_batch), torch.stack(parents))
+    else:
+        assert parents_batch == parents
+    assert torch.equal(
+        parents_policy_batch,
+        tfloat(
+            env.statebatch2policy(parents),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    # Check parents_all
+    if not env.continuous:
+        parents_all_batch, parents_all_a_batch, _ = batch.get_parents_all()
+        parents_all_policy_batch, _, _ = batch.get_parents_all(policy=True)
+        if torch.is_tensor(parents_all[0]):
+            assert torch.equal(torch.stack(parents_all_batch), torch.stack(parents_all))
+        else:
+            assert parents_all_batch == parents_all
+        assert torch.equal(
+            parents_all_a_batch,
+            tfloat(
+                parents_all_a,
+                device=batch.device,
+                float_type=batch.float,
+            ),
+        )
+        assert torch.equal(
+            parents_all_policy_batch,
+            tfloat(
+                env.statebatch2policy(parents_all),
+                device=batch.device,
+                float_type=batch.float,
+            ),
+        )
+    # Check rewards
+    rewards_batch = batch.get_rewards()
+    rewards = torch.stack(rewards)
+    assert torch.equal(
+        rewards_batch,
+        tfloat(rewards, device=batch.device, float_type=batch.float),
+    ), (rewards, rewards_batch)
+    # Check terminating states (sorted by trajectory)
+    states_term_batch = batch.get_terminating_states(sort_by="traj")
+    states_term_policy_batch = batch.get_terminating_states(sort_by="traj", policy=True)
+    if torch.is_tensor(states_term_sorted[0]):
+        assert torch.equal(
+            torch.stack(states_term_batch), torch.stack(states_term_sorted)
+        )
+    else:
+        assert states_term_batch == states_term_sorted
+    assert torch.equal(
+        states_term_policy_batch,
+        tfloat(
+            env.statebatch2policy(states_term_sorted),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+
+
+@pytest.mark.repeat(10)
+@pytest.mark.parametrize(
+    "env, proxy",
+    [("grid2d", "corners"), ("tetris6x4", "tetris_score")],
+)
+# @pytest.mark.skip(reason="skip while developping other tests")
+def test__mixed_sampling_merged_all_as_expected(env, proxy, request):
+    # Initialize fixtures and batch
+    env_ref = request.getfixturevalue(env)
+    proxy = request.getfixturevalue(proxy)
+    env_ref.proxy = proxy
+    env_ref.setup_proxy()
+    batch_fw = Batch(env=env_ref)
+    batch_bw = Batch(env=env_ref)
+
+    # Initialize empty lists for checks
+    states = []
+    actions = []
+    dones = []
+    masks_forward = []
+    masks_parents_forward = []
+    masks_backward = []
+    parents = []
+    parents_all = []
+    parents_all_a = []
+    rewards = []
+    traj_indices = []
+    state_indices = []
+    states_term_sorted = []
+
+    ### FORWARD ###
+
+    # Make list of envs
+    batch_size_forward = 10
+    envs = []
+    for idx in range(batch_size_forward):
+        env_aux = env_ref.copy().reset(idx)
+        env_aux.proxy = proxy
+        env_aux.setup_proxy()
+        envs.append(env_aux)
+
+    states_term_sorted.extend([None for _ in range(batch_size_forward)])
+
+    # Iterate until envs is empty
+    while envs:
+        actions_iter = []
+        valids_iter = []
+        # Make step env by env (different to GFN Agent) to have full control
+        for env in envs:
+            parent = copy(env.state)
+            # Sample random action
+            state, action, valid = env.step_random()
+            if valid:
+                # Add to iter lists
+                actions_iter.append(action)
+                valids_iter.append(valid)
+                # Add to checking lists
+                states.append(copy(env.state))
+                actions.append(action)
+                dones.append(env.done)
+                masks_forward.append(env.get_mask_invalid_actions_forward())
+                masks_parents_forward.append(
+                    env.get_mask_invalid_actions_forward(parent, done=False)
+                )
+                masks_backward.append(env.get_mask_invalid_actions_backward())
+                parents.append(parent)
+                if not env.continuous:
+                    env_parents, env_parents_a = env.get_parents()
+                    parents_all.extend(env_parents)
+                    parents_all_a.extend(env_parents_a)
+                rewards.append(env.reward())
+                traj_indices.append(env.id)
+                state_indices.append(env.n_actions)
+                if env.done:
+                    states_term_sorted[env.id] = env.state
+        # Add all envs, actions and valids to batch
+        batch_fw.add_to_batch(envs, actions_iter, valids_iter)
+        # Remove done envs
+        envs = [env for env in envs if not env.done]
+
+    ### BACKWARD ###
+
+    # Sample terminating states and build list of envs
+    batch_size_backward = 10
+    x_batch = env_ref.get_uniform_terminating_states(n_states=batch_size_backward)
+    envs = []
+    for idx, x in enumerate(x_batch):
+        env_aux = env_ref.copy().reset(idx)
+        env_aux = env_aux.set_state(state=x, done=True)
+        env_aux.n_actions = env_aux.get_max_traj_length()
+        env_aux.proxy = proxy
+        env_aux.setup_proxy()
+        envs.append(env_aux)
+
+    states_term_sorted.extend([copy(x) for x in x_batch])
+
+    # Iterate until envs is empty
+    while envs:
+        actions_iter = []
+        valids_iter = []
+        # Make step env by env (different to GFN Agent) to have full control
+        for env in envs:
+            # Compute variables before performing action
+            state = copy(env.state)
+            done = env.done
+            mask_forward = env.get_mask_invalid_actions_forward()
+            mask_backward = env.get_mask_invalid_actions_backward()
+            if not env.continuous:
+                env_parents, env_parents_a = env.get_parents()
+            reward = env.reward()
+            if env.done:
+                states_term_sorted[env.id + batch_size_forward] = env.state
+            # Sample random action
+            parent, action, valid = env.step_random(backward=True)
+            if valid:
+                # Add to iter lists
+                actions_iter.append(action)
+                valids_iter.append(valid)
+                # Add to checking lists
+                states.append(state)
+                actions.append(action)
+                dones.append(done)
+                masks_forward.append(mask_forward)
+                masks_parents_forward.append(env.get_mask_invalid_actions_forward())
+                masks_backward.append(mask_backward)
+                parents.append(parent)
+                if not env.continuous:
+                    parents_all.extend(env_parents)
+                    parents_all_a.extend(env_parents_a)
+                rewards.append(reward)
+                traj_indices.append(env.id + batch_size_forward)
+                state_indices.append(env.n_actions)
+        # Add all envs, actions and valids to batch
+        batch_bw.add_to_batch(envs, actions_iter, valids_iter, backward=True)
+        # Remove finished trajectories (state reached source)
+        envs = [env for env in envs if not env.equal(env.state, env.source)]
+
+    ### MERGE BATCHES ###
+
+    batch = Batch(env=env_ref)
+    batch = batch.merge([batch_fw, batch_bw])
+
+    ### CHECKS ###
+
+    # Check trajectory indices
+    traj_indices_batch = batch.get_trajectory_indices()
+    assert torch.equal(traj_indices_batch, tlong(traj_indices, device=batch.device))
+    # Check state indices
+    state_indices_batch = batch.get_state_indices()
+    assert torch.equal(state_indices_batch, tlong(state_indices, device=batch.device))
+    # Check states
+    states_batch = batch.get_states()
+    states_policy_batch = batch.get_states(policy=True)
+    if torch.is_tensor(states[0]):
+        assert torch.equal(torch.stack(states_batch), torch.stack(states))
+    else:
+        assert states_batch == states
+    assert torch.equal(
+        states_policy_batch,
+        tfloat(
+            env.statebatch2policy(states),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    # Check actions
+    actions_batch = batch.get_actions()
+    assert torch.equal(
+        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
+    )
+    # Check done
+    done_batch = batch.get_done()
+    assert torch.equal(done_batch, tbool(dones, device=batch.device))
+    # Check masks forward
+    masks_forward_batch = batch.get_masks_forward()
+    assert torch.equal(masks_forward_batch, tbool(masks_forward, device=batch.device))
+    # Check masks parents forward
+    masks_parents_forward_batch = batch.get_masks_forward(of_parents=True)
+    assert torch.equal(
+        masks_parents_forward_batch, tbool(masks_parents_forward, device=batch.device)
+    )
+    # Check masks backward
+    masks_backward_batch = batch.get_masks_backward()
+    assert torch.equal(masks_backward_batch, tbool(masks_backward, device=batch.device))
+    # Check parents
+    parents_batch = batch.get_parents()
+    parents_policy_batch = batch.get_parents(policy=True)
+    if torch.is_tensor(parents[0]):
+        assert torch.equal(torch.stack(parents_batch), torch.stack(parents))
+    else:
+        assert parents_batch == parents
+    assert torch.equal(
+        parents_policy_batch,
+        tfloat(
+            env.statebatch2policy(parents),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )
+    # Check parents_all
+    if not env.continuous:
+        parents_all_batch, parents_all_a_batch, _ = batch.get_parents_all()
+        parents_all_policy_batch, _, _ = batch.get_parents_all(policy=True)
+        if torch.is_tensor(parents_all[0]):
+            assert torch.equal(torch.stack(parents_all_batch), torch.stack(parents_all))
+        else:
+            assert parents_all_batch == parents_all
+        assert torch.equal(
+            parents_all_a_batch,
+            tfloat(
+                parents_all_a,
+                device=batch.device,
+                float_type=batch.float,
+            ),
+        )
+        assert torch.equal(
+            parents_all_policy_batch,
+            tfloat(
+                env.statebatch2policy(parents_all),
+                device=batch.device,
+                float_type=batch.float,
+            ),
+        )
+    # Check rewards
+    rewards_batch = batch.get_rewards()
+    rewards = torch.stack(rewards)
+    assert torch.equal(
+        rewards_batch,
+        tfloat(rewards, device=batch.device, float_type=batch.float),
+    ), (rewards, rewards_batch)
+    # Check terminating states (sorted by trajectory)
+    states_term_batch = batch.get_terminating_states(sort_by="traj")
+    states_term_policy_batch = batch.get_terminating_states(sort_by="traj", policy=True)
+    if torch.is_tensor(states_term_sorted[0]):
+        assert torch.equal(
+            torch.stack(states_term_batch), torch.stack(states_term_sorted)
+        )
+    else:
+        assert states_term_batch == states_term_sorted
+    assert torch.equal(
+        states_term_policy_batch,
+        tfloat(
+            env.statebatch2policy(states_term_sorted),
+            device=batch.device,
+            float_type=batch.float,
+        ),
+    )


### PR DESCRIPTION
A generic method in `gflownet/envs/base.py` to sample random trajectories by using the random policy of the environment, that is by using `self.trajectory_random()` which in turn uses `self.step_random()`.

I have also implemented alongside the option `random` for the buffers, which constructs a train or test buffer by calling `get_random_terminating_states()`. 

It can be used by setting `type: random` and `n: 100` (for example) in the buffers config. For instance, from the command line:

```
python main.py proxy=corners env=grid env.length=10 logger.do.online=False env.buffer.test.type=random +env.buffer.test.n=25
python main.py proxy=tetris env=tetris env.height=6 env.width=4 logger.do.online=False +env.buffer.test.type=random +env.buffer.test.n=10
``` 
Note that I had to merge `batch-v2` so as to be able to use method `equal()` from the environment, so the changes are hard to see.