### PR TITLE
Change max number of atoms per elements in crystals

### DIFF
--- a/config/env/crystals/composition.yaml
+++ b/config/env/crystals/composition.yaml
@@ -11,7 +11,7 @@ elements: 5
 min_atoms: 2
 max_atoms: 20
 min_atom_i: 1
-max_atom_i: 10
+max_atom_i: 16
 space_group: null
 do_charge_check: False
 do_spacegroup_check: True

--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -34,7 +34,7 @@ class Composition(GFlowNetEnv):
         min_atoms: int = 2,
         max_atoms: int = 20,
         min_atom_i: int = 1,
-        max_atom_i: int = 10,
+        max_atom_i: int = 16,
         oxidation_states: Optional[Dict] = None,
         alphabet: Optional[Dict] = None,
         required_elements: Optional[Union[Tuple, List]] = (),


### PR DESCRIPTION
Tiny PR to change the max number of atoms per elements from 10 to 16 in the crystal/composition environment.

This is because of the following spacegroups for which the default value prevent generating a valid composition : 
- Spacegroup 220 : requires at least 12 atoms per element
- Spacegroup 228 : requires at least 16 atoms per element
- Spacegroup 230 : requires at least 16 atoms per element