### PR TITLE
[IMPORTANT BUG FIX] Fix that random action prob. > 0 was doing nothing

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -202,7 +202,7 @@ class GFlowNetAgent:
         sampling_method: Optional[str] = "policy",
         backward: Optional[bool] = False,
         temperature: Optional[float] = 1.0,
-        random_action_prob: Optional[float] = 0.0,
+        random_action_prob: Optional[float] = None,
         no_random: Optional[bool] = True,
         times: Optional[dict] = None,
     ) -> List[Tuple]:
@@ -241,8 +241,9 @@ class GFlowNetAgent:
             self.temperature_logits is used.
 
         random_action_prob : float
-            Probability of sampling random actions. If None, self.random_action_prob is used.
-
+            Probability of sampling random actions. If None (default),
+            self.random_action_prob is used, unless its value is forced to either 0.0
+            or 1.0 by other arguments (sampling_method or no_random).
         no_random : bool
             If True, the samples will strictly be on-policy, that is
                 - temperature = 1.0


### PR DESCRIPTION
Small but important PR, I guess the title is self-explanatory. But for context: I changed the method `gflownet.sample_actions()` (as well as `gflownet.sample_batch()` quite a bit in the Batch v2 PR and admittedly I didn't test everything in depth. As you can see, the default of `random_action_prob` should have been `None` and I kept it in 0.0, which made that `self.random_action_prob` (which contains the random action probability passed as argument/config) was never picked up. 

I am sorry for the impact of this bug!