### PR TITLE
Fix action selection in space group

### DIFF
--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -160,12 +160,12 @@ class SpaceGroup(GFlowNetEnv):
             crystal_lattice_systems = [
                 (self.cls_idx, idx + 1, ref)
                 for idx in range(self.n_crystal_lattice_systems)
-                if self._is_cls_compatible(idx + 1)
+                if self._is_compatible(cls_idx=idx + 1)
             ]
             point_symmetries = [
                 (self.ps_idx, idx + 1, ref)
                 for idx in range(self.n_point_symmetries)
-                if self._is_ps_compatible(idx + 1)
+                if self._is_compatible(ps_idx=idx + 1)
             ]
         # Constraints after having selected crystal-lattice system
         if cls_idx != 0:
@@ -180,7 +180,7 @@ class SpaceGroup(GFlowNetEnv):
                 point_symmetries = [
                     (self.ps_idx, idx, ref)
                     for idx in self.crystal_lattice_systems[cls_idx]["point_symmetries"]
-                    if self._is_ps_compatible(idx, cls_idx=cls_idx)
+                    if self._is_compatible(cls_idx=cls_idx, ps_idx=idx)
                 ]
         else:
             space_groups_cls = [
@@ -201,7 +201,7 @@ class SpaceGroup(GFlowNetEnv):
                 crystal_lattice_systems = [
                     (self.cls_idx, idx, ref)
                     for idx in self.point_symmetries[ps_idx]["crystal_lattice_systems"]
-                    if self._is_cls_compatible(idx, ps_idx=ps_idx)
+                    if self._is_compatible(cls_idx=idx, ps_idx=ps_idx)
                 ]
         else:
             space_groups_ps = [
@@ -587,55 +587,31 @@ class SpaceGroup(GFlowNetEnv):
             n_atoms, self.space_groups.keys()
         )
 
-    def _is_cls_compatible(self, cls_idx: int, ps_idx: Optional[int] = None):
+    def _is_compatible(
+        self, cls_idx: Optional[int] = None, ps_idx: Optional[int] = None
+    ):
         """
-        Returns True it at least one of the space group in the crystal-lattice system
-        passed as an argument is compatible with the composition, according to
-        self.n_atoms_compatibility_dict, and with the point symmetry, if provided.
+        Returns True if there is exists at least one space group compatible with the
+        atom composition (according to self.n_atoms_compatibility_dict), with the
+        crystal-lattice system (if provided), and with the point symmetry (if provided).
         False otherwise.
         """
-        # Determine the list of candidate space groups
-        if ps_idx is None:
-            # No point symmetries has been provided so the crystal-latttice system is
-            # considered valid if any of the associated space groups is compatible
-            # with the composition
-            space_groups = self.crystal_lattice_systems[cls_idx]["space_groups"]
-        else:
-            # A point symmetry has been provided so the crystal-lattice system is only
-            # considered valid if a space group associated with both the crystal-
-            # lattice system and the point symmetry is compatible with the composition.
+        # Get list of space groups compatible with the composition
+        spacegroups = [self.n_atoms_compatibility_dict[sg] for sg in self.space_groups]
+
+        # Prune the list of space groups to those compatible with the provided crystal-
+        # lattice system
+        if cls_idx is not None:
             space_groups_cls = self.crystal_lattice_systems[cls_idx]["space_groups"]
+            space_groups = list(set(spacegroups).intersection(set(space_groups_cls)))
+
+        # Prune the list of space groups to those compatible with the provided point
+        # symmetry
+        if ps_idx is not None:
             space_groups_ps = self.point_symmetries[ps_idx]["space_groups"]
-            space_groups = list(
-                set(space_groups_cls).intersection(set(space_groups_ps))
-            )
+            space_groups = list(set(spacegroups).intersection(set(space_groups_ps)))
 
-        return any([self.n_atoms_compatibility_dict[sg] for sg in space_groups])
-
-    def _is_ps_compatible(self, ps_idx: int, cls_idx: Optional[int] = None):
-        """
-        Returns True it at least one of the space group in the point symmetry passed as
-        an argument is compatible with the composition, according to
-        self.n_atoms_compatibility_dict, and with the crystal-lattice system, if
-        provided. False otherwise.
-        """
-        # Determine the list of candidate space groups
-        if cls_idx is None:
-            # No crystal-lattice system has been provided so the point symmetry is
-            # considered valid if any of the associated space groups is compatible
-            # with the composition
-            space_groups = self.point_symmetries[ps_idx]["space_groups"]
-        else:
-            # A crystal-lattice system has been provided so the point symmetry is only
-            # considered valid if a space group associated with both the crystal-
-            # lattice system and the point symmetry is compatible with the composition.
-            space_groups_cls = self.crystal_lattice_systems[cls_idx]["space_groups"]
-            space_groups_ps = self.point_symmetries[ps_idx]["space_groups"]
-            space_groups = list(
-                set(space_groups_cls).intersection(set(space_groups_ps))
-            )
-
-        return any([self.n_atoms_compatibility_dict[sg] for sg in space_groups])
+        return len(space_groups) > 0
 
     @staticmethod
     def build_n_atoms_compatibility_dict(n_atoms: List[int], space_groups: List[int]):

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -606,7 +606,9 @@ class SpaceGroup(GFlowNetEnv):
             # lattice system and the point symmetry is compatible with the composition.
             space_groups_cls = self.crystal_lattice_systems[cls_idx]["space_groups"]
             space_groups_ps = self.point_symmetries[ps_idx]["space_groups"]
-            space_groups = list(set(space_groups_cls).intersection(set(space_groups_ps)))
+            space_groups = list(
+                set(space_groups_cls).intersection(set(space_groups_ps))
+            )
 
         return any([self.n_atoms_compatibility_dict[sg] for sg in space_groups])
 
@@ -629,7 +631,9 @@ class SpaceGroup(GFlowNetEnv):
             # lattice system and the point symmetry is compatible with the composition.
             space_groups_cls = self.crystal_lattice_systems[cls_idx]["space_groups"]
             space_groups_ps = self.point_symmetries[ps_idx]["space_groups"]
-            space_groups = list(set(space_groups_cls).intersection(set(space_groups_ps)))
+            space_groups = list(
+                set(space_groups_cls).intersection(set(space_groups_ps))
+            )
 
         return any([self.n_atoms_compatibility_dict[sg] for sg in space_groups])
 


### PR DESCRIPTION
This PR fixes a problem that was occuring when we provided a composition to the space group. 

Essentially, whenever the agent would like to pick a crystal-lattice system or a point symmetry, we would only allow option where at least one of the associated space groups was compatible with the composition.

The problem is that we would allow the agent to choose crystal-lattice systems and point symmetries that were individually compatible, but not jointly compatible.

We only ensured that each of them had 1+ space group compatible with the composition. But we didn't ensure that at least one of these space groups was shared by both the crystal-lattice system and the point symmetry.