### PR TITLE
Refactor spacegroup's ref-related stuff: Rename variables and add docstring

### DIFF
--- a/tests/gflownet/envs/test_spacegroup.py
+++ b/tests/gflownet/envs/test_spacegroup.py
@@ -230,11 +230,11 @@ def test__get_mask_invalid_actions_forward__incompatible_sg_are_invalid(
         state[env_with_composition.sg_idx] = 0
         env_with_composition.set_state(state=state, done=False)
         mask_f = env_with_composition.get_mask_invalid_actions_forward()
-        ref = env_with_composition.get_ref_index(state)
+        state_type = env_with_composition.get_state_type(state)
         for sg in range(1, env_with_composition.n_space_groups + 1):
             sg_pyxtal = Group(sg)
             is_compatible = sg_pyxtal.check_compatible(N_ATOMS)[0]
-            action = (env_with_composition.sg_idx, sg, ref)
+            action = (env_with_composition.sg_idx, sg, state_type)
             if not is_compatible:
                 assert mask_f[env_with_composition.action_space.index(action)] is True
 


### PR DESCRIPTION
This PR barely changes if at all the functionality of the code. I have simply 1) renamed some variables and 2) added/updated the docstring and comments regarding the formerly (poorly) called `ref` in the space group. I have renamed it to "state type" and it refers to the four types of state from which an action can be executed in the space group environment:
- 0: both crystal-lattice system and point symmetry are unset (== 0)
- 1: crystal-lattice system is set (!= 0); point symmetry is unset
- 2: crystal-lattice system is unset; point symmetry is set
- 3: both crystal-lattice system and point symmetry are set

This is needed and is actually part of the actions and the action space so as to account for the possible multiple parents of a given state and the (important) detail that GFlowNet must learn a distribution over states and not over actions.