### PR TITLE
Add hyperparam to change crystal envs ordering

### DIFF
--- a/gflownet/envs/crystals/crystal.py
+++ b/gflownet/envs/crystals/crystal.py
@@ -57,7 +57,9 @@ class Crystal(GFlowNetEnv):
         do_sg_before_composition: bool = False,
         **kwargs,
     ):
-        self.composition_kwargs = composition_kwargs or {}
+        self.composition_kwargs = dict(
+            composition_kwargs or {}, do_spacegroup_check=do_stoichiometry_sg_check
+        )
         self.space_group_kwargs = space_group_kwargs or {}
         self.lattice_parameters_kwargs = lattice_parameters_kwargs or {}
         self.do_stoichiometry_sg_check = do_stoichiometry_sg_check
@@ -480,13 +482,9 @@ class Crystal(GFlowNetEnv):
                 next_stage = self._get_next_stage(Stage.SPACE_GROUP)
                 self._set_stage(next_stage)
 
-                # If composition is the next stage, set up the composition checks, if
-                # needed.
-                """
-                self.space_group = space_group
-               self.do_charge_check = do_charge_check
-                self.do_spacegroup_check = do_spacegroup_check
-                """
+                # If composition is the next stage, set up the composition checks.
+                if next_stage == Stage.COMPOSITION and self.do_stoichiometry_sg_check:
+                    self.composition.space_group = self.space_group.space_group
 
                 # The lattice parameter stage needs to be set up but only depending on
                 # the selected space group (not the composition) so we set it up now

--- a/gflownet/envs/crystals/crystal.py
+++ b/gflownet/envs/crystals/crystal.py
@@ -294,7 +294,10 @@ class Crystal(GFlowNetEnv):
         elif stage == Stage.SPACE_GROUP:
             return self._get_space_group_state(state) == self.space_group.source
         elif stage == Stage.LATTICE_PARAMETERS:
-            return self._get_lattice_parameters_state(state) == self.lattice_parameters.source
+            return (
+                self._get_lattice_parameters_state(state)
+                == self.lattice_parameters.source
+            )
         else:
             raise ValueError(f"Unrecognized stage {stage}.")
 
@@ -512,10 +515,7 @@ class Crystal(GFlowNetEnv):
         """
         if stage == Stage.COMPOSITION:
             output = (
-                [0]
-                + substate
-                + self.space_group.state
-                + self.lattice_parameters.source
+                [0] + substate + self.space_group.state + self.lattice_parameters.source
             )
         elif stage == Stage.SPACE_GROUP:
             output = (
@@ -552,9 +552,9 @@ class Crystal(GFlowNetEnv):
         # - The environment has only just entered the stage after composition and is
         #   still in that environment's initial state
         if (
-            (stage == Stage.COMPOSITION and not is_source_state) or
-            (stage == Stage.COMPOSITION and previous_stage is None) or
-            (is_source_state and previous_stage == Stage.COMPOSITION)
+            (stage == Stage.COMPOSITION and not is_source_state)
+            or (stage == Stage.COMPOSITION and previous_stage is None)
+            or (is_source_state and previous_stage == Stage.COMPOSITION)
         ):
             composition_done = previous_stage == Stage.COMPOSITION
             parents, actions = self.composition.get_parents(
@@ -571,9 +571,9 @@ class Crystal(GFlowNetEnv):
         # - The environment has only just entered the stage after space group and is
         #   still in that environment's initial state
         elif (
-            (stage == Stage.SPACE_GROUP and not is_source_state) or
-            (stage == Stage.SPACE_GROUP and previous_stage is None) or
-            (is_source_state and previous_stage == Stage.SPACE_GROUP)
+            (stage == Stage.SPACE_GROUP and not is_source_state)
+            or (stage == Stage.SPACE_GROUP and previous_stage is None)
+            or (is_source_state and previous_stage == Stage.SPACE_GROUP)
         ):
             space_group_done = previous_stage == Stage.SPACE_GROUP
             parents, actions = self.space_group.get_parents(

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -529,6 +529,21 @@ class SpaceGroup(GFlowNetEnv):
     def space_group_symbol(self) -> str:
         return self.get_space_group_symbol(self.state)
 
+    def get_space_group(self, state: List[int] = None) -> int:
+        """
+        Returns the index of the space group symbol given a state.
+        """
+        if state is None:
+            state = self.state
+        if state[self.sg_idx] != 0:
+            return state[self.sg_idx]
+        else:
+            return None
+
+    @property
+    def space_group(self) -> int:
+        return self.get_space_group(self.state)
+
     # TODO: Technically the crystal class could be determined from crystal-lattice
     # system + point symmetry
     def get_crystal_class(self, state: List[int] = None) -> str:

--- a/tests/gflownet/envs/test_crystal.py
+++ b/tests/gflownet/envs/test_crystal.py
@@ -23,6 +23,25 @@ def env_with_stoichiometry_sg_check():
     )
 
 
+@pytest.fixture
+def env_with_space_group_stage_first():
+    return Crystal(
+        composition_kwargs={"elements": 4},
+        lattice_parameters_kwargs={"grid_size": 10},
+        do_sg_before_composition=True,
+    )
+
+
+@pytest.fixture
+def env_with_space_group_stage_first_sg_check():
+    return Crystal(
+        composition_kwargs={"elements": 4},
+        lattice_parameters_kwargs={"grid_size": 10},
+        do_stoichiometry_sg_check=True,
+        do_sg_before_composition=True,
+    )
+
+
 def test__environment__initializes_properly(env):
     pass
 
@@ -372,5 +391,13 @@ def test__all_env_common(env):
     return common.test__all_env_common(env)
 
 
-def test__all_env_common(env_with_stoichiometry_sg_check):
+def test__all_env_common_sg_check(env_with_stoichiometry_sg_check):
     return common.test__all_env_common(env_with_stoichiometry_sg_check)
+
+
+def test_all_env_common_space_group(env_with_space_group_stage_first):
+    return common.test__all_env_common(env_with_space_group_stage_first)
+
+
+def test_all_env_common_space_group_sg_check(env_with_space_group_stage_first_sg_check):
+    return common.test__all_env_common(env_with_space_group_stage_first_sg_check)

--- a/tests/gflownet/envs/test_crystal.py
+++ b/tests/gflownet/envs/test_crystal.py
@@ -533,6 +533,38 @@ def test__get_mask_invalid_actions_forward__masks_all_actions_from_different_sta
         )
 
 
+def test__composition_constraints(env_with_space_group_stage_first_sg_check):
+    env = env_with_space_group_stage_first_sg_check
+
+    # Pick space group 227 for which the most specific wyckoff position has
+    # multiplicity 8
+    env.step((2, 227, 0, -3, -3, -3))
+    env.step((-1, -1, -1, -3, -3, -3))
+
+    # Validate that the composition constraints are active by trying to add a number of
+    # atoms incompatible with the space group
+    for i in range(1, 8):
+        _, _, valid = env.step((1, i, -2, -2, -2, -2))
+        assert not valid
+    for i in range(9, 16):
+        _, _, valid = env.step((1, i, -2, -2, -2, -2))
+        assert not valid
+
+    # Validate that we can add a compatible number of atoms
+    _, _, valid = env.step((1, 8, -2, -2, -2, -2))
+    assert valid
+
+    # Reset and pick space group 1 which has no constraint on composition
+    env.reset()
+    env.step((2, 1, 0, -3, -3, -3))
+    env.step((-1, -1, -1, -3, -3, -3))
+
+    # Validate that the composition constraints have been updated for the new
+    # space group by adding a number of atoms incompatible with space group 227.
+    _, _, valid = env.step((1, 1, -2, -2, -2, -2))
+    assert valid
+
+
 @pytest.mark.parametrize(
     "environment",
     [

--- a/tests/gflownet/envs/test_crystal.py
+++ b/tests/gflownet/envs/test_crystal.py
@@ -46,9 +46,14 @@ def test__environment__initializes_properly(env):
     pass
 
 
-def test__environment__has_expected_initial_state(env):
+@pytest.mark.parametrize(
+    "environment, initial_stage", [["env", 0], ["env_with_space_group_stage_first", 1]]
+)
+def test__environment__has_expected_initial_state(environment, initial_stage, request):
+    environment = request.getfixturevalue(environment)
+    expected_initial_state = [initial_stage] + [0] * (4 + 3 + 6)
     assert (
-        env.state == env.source == [0] * (1 + 4 + 3 + 6)
+        environment.state == environment.source == expected_initial_state
     )  # stage + n elements + space groups + lattice parameters
 
 
@@ -143,27 +148,31 @@ def test__step__single_action_works(env, action):
 
 
 @pytest.mark.parametrize(
-    "actions, exp_result, exp_stage, last_action_valid",
+    "environment, actions, exp_result, exp_stage, last_action_valid",
     [
         [
+            "env",
             [(1, 1, -2, -2, -2, -2), (3, 4, -2, -2, -2, -2)],
             [0, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             Stage.COMPOSITION,
             True,
         ],
         [
+            "env",
             [(2, 225, 3, -3, -3, -3)],
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             Stage.COMPOSITION,
             False,
         ],
         [
+            "env",
             [(1, 1, -2, -2, -2, -2), (3, 4, -2, -2, -2, -2), (-1, -1, -2, -2, -2, -2)],
             [1, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             Stage.SPACE_GROUP,
             True,
         ],
         [
+            "env",
             [
                 (1, 1, -2, -2, -2, -2),
                 (3, 4, -2, -2, -2, -2),
@@ -175,6 +184,7 @@ def test__step__single_action_works(env, action):
             True,
         ],
         [
+            "env",
             [
                 (1, 1, -2, -2, -2, -2),
                 (3, 4, -2, -2, -2, -2),
@@ -187,6 +197,7 @@ def test__step__single_action_works(env, action):
             False,
         ],
         [
+            "env",
             [
                 (1, 1, -2, -2, -2, -2),
                 (3, 4, -2, -2, -2, -2),
@@ -199,6 +210,7 @@ def test__step__single_action_works(env, action):
             True,
         ],
         [
+            "env",
             [
                 (1, 1, -2, -2, -2, -2),
                 (3, 4, -2, -2, -2, -2),
@@ -212,6 +224,7 @@ def test__step__single_action_works(env, action):
             False,
         ],
         [
+            "env",
             [
                 (1, 1, -2, -2, -2, -2),
                 (3, 4, -2, -2, -2, -2),
@@ -225,6 +238,7 @@ def test__step__single_action_works(env, action):
             True,
         ],
         [
+            "env",
             [
                 (1, 1, -2, -2, -2, -2),
                 (3, 4, -2, -2, -2, -2),
@@ -239,6 +253,7 @@ def test__step__single_action_works(env, action):
             False,
         ],
         [
+            "env",
             [
                 (1, 1, -2, -2, -2, -2),
                 (3, 4, -2, -2, -2, -2),
@@ -253,76 +268,207 @@ def test__step__single_action_works(env, action):
             Stage.LATTICE_PARAMETERS,
             True,
         ],
-    ],
-)
-def test__step__action_sequence_has_expected_result(
-    env, actions, exp_result, exp_stage, last_action_valid
-):
-    for action in actions:
-        _, _, valid = env.step(action)
-
-    assert env.state == exp_result
-    assert env._get_stage() == exp_stage
-    assert valid == last_action_valid
-
-
-def test__get_parents__returns_no_parents_in_initial_state(env):
-    return common.test__get_parents__returns_no_parents_in_initial_state(env)
-
-
-@pytest.mark.parametrize(
-    "actions",
-    [
-        [(1, 1, -2, -2, -2, -2), (3, 4, -2, -2, -2, -2)],
         [
-            (1, 1, -2, -2, -2, -2),
-            (3, 4, -2, -2, -2, -2),
-            (-1, -1, -2, -2, -2, -2),
-            (2, 105, 0, -3, -3, -3),
-            (-1, -1, -1, -3, -3, -3),
-            (1, 1, 1, 0, 0, 0),
-            (1, 1, 0, 0, 0, 0),
-            (0, 0, 0, 0, 0, 0),
+            "env_with_space_group_stage_first",
+            [(2, 105, 0, -3, -3, -3)],
+            [1, 0, 0, 0, 0, 4, 3, 105, 0, 0, 0, 0, 0, 0],
+            Stage.SPACE_GROUP,
+            True,
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [(2, 105, 0, -3, -3, -3), (2, 105, 0, -3, -3, -3)],
+            [1, 0, 0, 0, 0, 4, 3, 105, 0, 0, 0, 0, 0, 0],
+            Stage.SPACE_GROUP,
+            False,
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [(1, 1, -2, -2, -2, -2)],
+            [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            Stage.SPACE_GROUP,
+            False,
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [(2, 105, 0, -3, -3, -3), (-1, -1, -1, -3, -3, -3)],
+            [0, 0, 0, 0, 0, 4, 3, 105, 0, 0, 0, 5, 5, 5],
+            Stage.COMPOSITION,
+            True,
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [
+                (2, 105, 0, -3, -3, -3),
+                (-1, -1, -1, -3, -3, -3),
+                (1, 1, -2, -2, -2, -2),
+                (3, 4, -2, -2, -2, -2),
+                (3, 2, -2, -2, -2, -2),
+            ],
+            [0, 1, 0, 4, 0, 4, 3, 105, 0, 0, 0, 5, 5, 5],
+            Stage.COMPOSITION,
+            False,
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [
+                (2, 105, 0, -3, -3, -3),
+                (-1, -1, -1, -3, -3, -3),
+                (1, 1, -2, -2, -2, -2),
+                (3, 4, -2, -2, -2, -2),
+                (-1, -1, -2, -2, -2, -2),
+            ],
+            [2, 1, 0, 4, 0, 4, 3, 105, 0, 0, 0, 5, 5, 5],
+            Stage.LATTICE_PARAMETERS,
+            True,
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [
+                (2, 105, 0, -3, -3, -3),
+                (-1, -1, -1, -3, -3, -3),
+                (1, 1, -2, -2, -2, -2),
+                (3, 4, -2, -2, -2, -2),
+                (-1, -1, -2, -2, -2, -2),
+                (1, 0, 0, 0, 0, 0),
+            ],
+            [2, 1, 0, 4, 0, 4, 3, 105, 0, 0, 0, 5, 5, 5],
+            Stage.LATTICE_PARAMETERS,
+            False,
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [
+                (2, 105, 0, -3, -3, -3),
+                (-1, -1, -1, -3, -3, -3),
+                (1, 1, -2, -2, -2, -2),
+                (3, 4, -2, -2, -2, -2),
+                (-1, -1, -2, -2, -2, -2),
+                (1, 1, 1, 0, 0, 0),
+                (1, 1, 0, 0, 0, 0),
+                (0, 0, 0, 0, 0, 0),
+            ],
+            [2, 1, 0, 4, 0, 4, 3, 105, 2, 2, 1, 5, 5, 5],
+            Stage.LATTICE_PARAMETERS,
+            True,
         ],
     ],
 )
-def test__get_parents__contains_previous_action_after_a_step(env, actions):
+def test__step__action_sequence_has_expected_result(
+    environment, actions, exp_result, exp_stage, last_action_valid, request
+):
+    environment = request.getfixturevalue(environment)
     for action in actions:
-        env.step(action)
-        parents, parent_actions = env.get_parents()
+        _, _, valid = environment.step(action)
+
+    assert environment.state == exp_result
+    assert environment._get_stage() == exp_stage
+    assert valid == last_action_valid
+
+
+@pytest.mark.parametrize("environment", ["env", "env_with_space_group_stage_first"])
+def test__get_parents__returns_no_parents_in_initial_state(environment, request):
+    environment = request.getfixturevalue(environment)
+    return common.test__get_parents__returns_no_parents_in_initial_state(environment)
+
+
+@pytest.mark.parametrize(
+    "environment, actions",
+    [
+        ["env", [(1, 1, -2, -2, -2, -2), (3, 4, -2, -2, -2, -2)]],
+        [
+            "env",
+            [
+                (1, 1, -2, -2, -2, -2),
+                (3, 4, -2, -2, -2, -2),
+                (-1, -1, -2, -2, -2, -2),
+                (2, 105, 0, -3, -3, -3),
+                (-1, -1, -1, -3, -3, -3),
+                (1, 1, 1, 0, 0, 0),
+                (1, 1, 0, 0, 0, 0),
+                (0, 0, 0, 0, 0, 0),
+            ],
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [
+                (2, 105, 0, -3, -3, -3),
+                (-1, -1, -1, -3, -3, -3),
+                (1, 1, -2, -2, -2, -2),
+                (3, 4, -2, -2, -2, -2),
+                (-1, -1, -2, -2, -2, -2),
+                (1, 1, 1, 0, 0, 0),
+                (1, 1, 0, 0, 0, 0),
+                (0, 0, 0, 0, 0, 0),
+            ],
+        ],
+    ],
+)
+def test__get_parents__contains_previous_action_after_a_step(
+    environment, actions, request
+):
+    environment = request.getfixturevalue(environment)
+    for action in actions:
+        environment.step(action)
+        parents, parent_actions = environment.get_parents()
         assert action in parent_actions
 
 
 @pytest.mark.parametrize(
-    "actions",
+    "environment, actions",
     [
         [
-            (1, 1, -2, -2, -2, -2),
-            (3, 4, -2, -2, -2, -2),
-            (-1, -1, -2, -2, -2, -2),
-            (2, 105, 0, -3, -3, -3),
-            (-1, -1, -1, -3, -3, -3),
-            (1, 1, 1, 0, 0, 0),
-            (1, 1, 0, 0, 0, 0),
-            (0, 0, 0, 0, 0, 0),
-        ]
+            "env",
+            [
+                (1, 1, -2, -2, -2, -2),
+                (3, 4, -2, -2, -2, -2),
+                (-1, -1, -2, -2, -2, -2),
+                (2, 105, 0, -3, -3, -3),
+                (-1, -1, -1, -3, -3, -3),
+                (1, 1, 1, 0, 0, 0),
+                (1, 1, 0, 0, 0, 0),
+                (0, 0, 0, 0, 0, 0),
+            ],
+        ],
+        [
+            "env_with_space_group_stage_first",
+            [
+                (2, 105, 0, -3, -3, -3),
+                (-1, -1, -1, -3, -3, -3),
+                (1, 1, -2, -2, -2, -2),
+                (3, 4, -2, -2, -2, -2),
+                (-1, -1, -2, -2, -2, -2),
+                (1, 1, 1, 0, 0, 0),
+                (1, 1, 0, 0, 0, 0),
+                (0, 0, 0, 0, 0, 0),
+            ],
+        ],
     ],
 )
-def test__reset(env, actions):
+def test__reset(environment, actions, request):
+    environment = request.getfixturevalue(environment)
     for action in actions:
-        env.step(action)
+        environment.step(action)
 
-    assert env.state != env.source
-    for subenv in [env.composition, env.space_group, env.lattice_parameters]:
+    assert environment.state != environment.source
+    for subenv in [
+        environment.composition,
+        environment.space_group,
+        environment.lattice_parameters,
+    ]:
         assert subenv.state != subenv.source
-    assert env.lattice_parameters.lattice_system != TRICLINIC
+    assert environment.lattice_parameters.lattice_system != TRICLINIC
 
-    env.reset()
+    environment.reset()
 
-    assert env.state == env.source
-    for subenv in [env.composition, env.space_group, env.lattice_parameters]:
+    assert environment.state == environment.source
+    for subenv in [
+        environment.composition,
+        environment.space_group,
+        environment.lattice_parameters,
+    ]:
         assert subenv.state == subenv.source
-    assert env.lattice_parameters.lattice_system == TRICLINIC
+    assert environment.lattice_parameters.lattice_system == TRICLINIC
 
 
 @pytest.mark.parametrize(
@@ -387,17 +533,15 @@ def test__get_mask_invalid_actions_forward__masks_all_actions_from_different_sta
         )
 
 
-def test__all_env_common(env):
-    return common.test__all_env_common(env)
-
-
-def test__all_env_common_sg_check(env_with_stoichiometry_sg_check):
-    return common.test__all_env_common(env_with_stoichiometry_sg_check)
-
-
-def test_all_env_common_space_group(env_with_space_group_stage_first):
-    return common.test__all_env_common(env_with_space_group_stage_first)
-
-
-def test_all_env_common_space_group_sg_check(env_with_space_group_stage_first_sg_check):
-    return common.test__all_env_common(env_with_space_group_stage_first_sg_check)
+@pytest.mark.parametrize(
+    "environment",
+    [
+        "env",
+        "env_with_stoichiometry_sg_check",
+        "env_with_space_group_stage_first",
+        "env_with_space_group_stage_first_sg_check",
+    ],
+)
+def test__all_env_common(environment, request):
+    environment = request.getfixturevalue(environment)
+    return common.test__all_env_common(environment)


### PR DESCRIPTION
This PR adds a new option `do_sg_before_composition` to the Crystal environment to change the order in which the stages are traveled. With `do_sg_before_composition=False`, the default value, the order is : composition -> space group -> lattice parameters. With `do_sg_before_composition=True`, the order is : space group -> composition -> lattice parameters.

The reasoning behind this new option is that some space groups (like 220, 227 and 230) are very highly symmetric, to the point where it would be difficult to randomly generate a composition that would be valid with them. Thus, having an option for picking the space group first (and then enforce spacegroup-related constraints on the composition) might make it easier for the GFN to generate samples from those space groups.

To do : 
- [x] Adapt crystal env as it is right now in the main
- [x] Rebase on top of the backwards sampling branch to get Michal's fix to Crystal's set_state() and adapt that method to work with the new hyperparameter
- [x] Add tests for the new hyperparameter
- [x] Add tests for Crystal.set_state()
- [x] Make sure that when the space group stage ends, it activates the stochiometry checks in the composition stage.

Comments for the reviewers  : 
- Given the potential for this PR to break something, I would tend to set the bar to at least 2 reviewers approving
- Please look at the various tests in test_crystal.py and tell me if you think there are additional tests that you think I should have added/expanded to evaluate the new hyperparameter. 
- I would also like feedback on the way that I handle attempts to set the state of an environment (which uses composition/space-group checks) with a state that shouldn't be reachable with these checks active. I want to know if the approach makes sense to you.