### PR TITLE
Shared policy config

### DIFF
--- a/config/experiments/tree.yaml
+++ b/config/experiments/tree.yaml
@@ -38,13 +38,12 @@ gflownet:
 
 # MLP policy
 policy:
-  forward:
-    n_hid: 256
-    n_layers: 3
-  backward:
+  shared:
     type: mlp
     n_hid: 256
     n_layers: 3
+  forward: null
+  backward:
     shared_weights: False
 
 # WandB

--- a/config/policy/mlp.yaml
+++ b/config/policy/mlp.yaml
@@ -1,5 +1,7 @@
 _target_: gflownet.policy.base.Policy
 
+shared: null
+
 forward:
   type: mlp
   n_hid: 128

--- a/gflownet/utils/policy.py
+++ b/gflownet/utils/policy.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from omegaconf import DictConfig, OmegaConf
+
+
+def parse_policy_config(config: DictConfig, kind: str) -> Optional[DictConfig]:
+    """
+    Helper for parsing forward/backward policy_config from the given global config.
+
+    Parameters
+    ----------
+    config : DictConfig
+        Global hydra config.
+
+    kind : str
+        Type of config, either 'forward' or 'backward'.
+    """
+    assert kind in ["forward", "backward"]
+
+    policy_config = OmegaConf.create(config.policy)
+    policy_config["config"] = config.policy.shared or {}
+    policy_config["config"].update(config.policy[kind] or {})
+
+    # Preserve backward compatibility: if neither shared nor forward/backward
+    # configs were given, return None instead of an empty config.
+    if len(policy_config["config"]) == 0:
+        policy_config["config"] = None
+
+    del policy_config.forward
+    del policy_config.backward
+    del policy_config.shared
+
+    return policy_config

--- a/main.py
+++ b/main.py
@@ -8,9 +8,9 @@ import sys
 
 import hydra
 import pandas as pd
-from omegaconf import OmegaConf
 
 from gflownet.utils.common import chdir_random_subdir
+from gflownet.utils.policy import parse_policy_config
 
 
 @hydra.main(config_path="./config", config_name="main", version_base="1.1")
@@ -44,19 +44,8 @@ def main(config):
         float_precision=config.float_precision,
     )
     # The policy is used to model the probability of a forward/backward action
-    forward_config = OmegaConf.create(config.policy)
-    forward_config["config"] = config.policy.shared or {}
-    forward_config["config"].update(config.policy.forward or {})
-    del forward_config.forward
-    del forward_config.backward
-    del forward_config.shared
-
-    backward_config = OmegaConf.create(config.policy)
-    backward_config["config"] = config.policy.shared or {}
-    backward_config["config"].update(config.policy.backward or {})
-    del backward_config.forward
-    del backward_config.backward
-    del backward_config.shared
+    forward_config = parse_policy_config(config, kind="forward")
+    backward_config = parse_policy_config(config, kind="backward")
 
     forward_policy = hydra.utils.instantiate(
         forward_config,

--- a/main.py
+++ b/main.py
@@ -45,14 +45,18 @@ def main(config):
     )
     # The policy is used to model the probability of a forward/backward action
     forward_config = OmegaConf.create(config.policy)
-    forward_config["config"] = config.policy.forward
+    forward_config["config"] = config.policy.shared or {}
+    forward_config["config"].update(config.policy.forward or {})
     del forward_config.forward
     del forward_config.backward
+    del forward_config.shared
 
     backward_config = OmegaConf.create(config.policy)
-    backward_config["config"] = config.policy.backward
+    backward_config["config"] = config.policy.shared or {}
+    backward_config["config"].update(config.policy.backward or {})
     del backward_config.forward
     del backward_config.backward
+    del backward_config.shared
 
     forward_policy = hydra.utils.instantiate(
         forward_config,

--- a/tests/gflownet/envs/common.py
+++ b/tests/gflownet/envs/common.py
@@ -7,6 +7,7 @@ from hydra import compose, initialize
 from omegaconf import OmegaConf
 
 from gflownet.utils.common import copy
+from gflownet.utils.policy import parse_policy_config
 
 
 def test__all_env_common(env):
@@ -158,14 +159,8 @@ def test__gflownet_minimal_runs(env):
         config.proxy, device=config.device, float_precision=config.float_precision
     )
     # Policy
-    forward_config = OmegaConf.create(config.policy)
-    forward_config["config"] = config.policy.forward
-    del forward_config.forward
-    del forward_config.backward
-    backward_config = OmegaConf.create(config.policy)
-    backward_config["config"] = config.policy.backward
-    del backward_config.forward
-    del backward_config.backward
+    forward_config = parse_policy_config(config, kind="forward")
+    backward_config = parse_policy_config(config, kind="backward")
     forward_policy = hydra.utils.instantiate(
         forward_config,
         env=env,


### PR DESCRIPTION
Added option to specify `policy.shared` config (in addition to `policy.forward` and `policy.backward`), which will be used by both types of policies. Required for running sweeps. Tested on grid environment in https://wandb.ai/michalkoziarski/gfn_sanity_checks.