### PR TITLE
Use Dave v3.1 as latest crystals proxy

### DIFF
--- a/config/proxy/crystals/dave.yaml
+++ b/config/proxy/crystals/dave.yaml
@@ -1,6 +1,6 @@
 _target_: gflownet.proxy.crystals.dave.DAVE
 
-release: v2-graph-phys
+release: v3.1-physmlp-mbform
 ckpt_path:
   mila: /network/scratch/s/schmidtv/Public/crystals/proxy-ckpts
   victor: ~/Documents/Github/ActiveLearningMaterials/checkpoints/980065c0/checkpoints-3ff648a2

--- a/config/proxy/crystals/dave.yaml
+++ b/config/proxy/crystals/dave.yaml
@@ -2,6 +2,6 @@ _target_: gflownet.proxy.crystals.dave.DAVE
 
 release: v3.1-physmlp-mbform
 ckpt_path:
-  mila: /network/scratch/s/schmidtv/Public/crystals/proxy-ckpts
+  mila: /network/scratch/s/schmidtv/crystals-proxys/proxy-ckpts/
   victor: ~/Documents/Github/ActiveLearningMaterials/checkpoints/980065c0/checkpoints-3ff648a2
 rescale_outputs: true


### PR DESCRIPTION
## 💥 Breaking changes: new packages

```
pip install pyxtal faenet
```

---

Proxy trained on matbench formation energy with conventional cell

Proxy is an MLP with Physical embeddings for atomic species

Release details: https://github.com/sh-divya/ActiveLearningMaterials/releases/tag/v3.1-physmlp-mbform

Elements in the data set (atomic numbers `Z`, total=84):

```
1, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 
29, 30, 31, 32, 33, 34, 35, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 
53, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 
77, 78, 79, 80, 81, 82, 83, 89, 90, 91, 92, 93, 94
```

Top-12: `O, H, F, S, Li, P, Mg, C, N, Cl, Si, Fe`
Top-22: `O, H, F, S, Li, P, Mg, C, N, Cl, Si, Fe, Se, B, Al, Mn, Co, Na, Ni, Cu, K, V`

![number-samples-with-only-topk-elements-top12-6132-462-binarized-counts](https://github.com/alexhernandezgarcia/gflownet/assets/9283470/89b9dda8-7fea-4faf-92f1-cd63a3e235ef)

See Slack discussions [here](https://mila-umontreal.slack.com/archives/C04SC06HCTH/p1694023721620159) and [here](https://mila-umontreal.slack.com/archives/C04SC06HCTH/p1694196154321179)