### PR TITLE
[WIP] Continuous lattice parameters environment

### DIFF
--- a/config/env/crystals/clattice_parameters.yaml
+++ b/config/env/crystals/clattice_parameters.yaml
@@ -1,0 +1,43 @@
+defaults:
+  - base
+
+_target_: gflownet.envs.crystals.clattice_parameters.CLatticeParameters
+
+id: clattice_parameters
+continuous: True
+
+# Lattice system
+lattice_system: triclinic
+# Allowed ranges of size and angles
+min_length: 1.0
+max_length: 5.0
+min_angle: 30.0
+max_angle: 150.0
+
+# Policy
+beta_params_min: 0.01
+beta_params_max: 1000.0
+min_incr: 0.1
+n_comp: 1
+fixed_distribution:
+  beta_weights: 1.0
+  beta_alpha: 0.01
+  beta_beta: 0.01
+  bernoulli_source_logit: 0.0
+  bernoulli_eos_logit: 0.0
+random_distribution:
+  beta_weights: 1.0
+  # IMPORTANT: adjust because of sigmoid!
+  beta_alpha: 0.01
+  beta_beta: $beta_params_max
+  bernoulli_source_logit: 0.0
+  bernoulli_eos_logit: 0.0
+# Buffer
+buffer:
+  data_path: null
+  train: null
+  test:
+    type: grid
+    n: 1000
+    output_csv: ccube_test.csv
+    output_pkl: ccube_test.pkl

--- a/config/env/crystals/clattice_parameters.yaml
+++ b/config/env/crystals/clattice_parameters.yaml
@@ -4,7 +4,6 @@ defaults:
 _target_: gflownet.envs.crystals.clattice_parameters.CLatticeParameters
 
 id: clattice_parameters
-continuous: True
 
 # Lattice system
 lattice_system: triclinic

--- a/config/experiments/clatticeparams/clatticeparams_owl.yaml
+++ b/config/experiments/clatticeparams/clatticeparams_owl.yaml
@@ -1,7 +1,7 @@
 # @package _global_
 
 defaults:
-   - override /env: ccube
+   - override /env: crystals/clattice_parameters
    - override /gflownet: trajectorybalance
    - override /proxy: corners
    - override /logger: wandb

--- a/config/experiments/clatticeparams/clatticeparams_owl.yaml
+++ b/config/experiments/clatticeparams/clatticeparams_owl.yaml
@@ -1,0 +1,78 @@
+# @package _global_
+
+defaults:
+   - override /env: ccube
+   - override /gflownet: trajectorybalance
+   - override /proxy: corners
+   - override /logger: wandb
+   - override /user: alex
+
+# Environment
+env:
+  # Lattice system
+  lattice_system: cubic
+  # Allowed ranges of size and angles
+  min_length: 1.0
+  max_length: 5.0
+  min_angle: 30.0
+  max_angle: 150.0
+  # Cube
+  n_comp: 5
+  beta_params_min: 0.01
+  beta_params_max: 100.0
+  min_incr: 0.1
+  fixed_distribution:
+    beta_weights: 1.0
+    beta_alpha: 0.01
+    beta_beta: 0.01
+    bernoulli_source_logit: 1.0
+    bernoulli_eos_logit: 1.0
+  random_distribution:
+    beta_weights: 1.0
+    beta_alpha: 0.01
+    beta_beta: 0.01
+    bernoulli_source_logit: 1.0
+    bernoulli_eos_logit: 1.0
+  reward_func: identity
+
+# GFlowNet hyperparameters
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      forward: 100
+    lr: 0.0001
+    z_dim: 16
+    lr_z_mult: 100
+    n_train_steps: 10000
+  policy:
+    forward:
+      type: mlp
+      n_hid: 512
+      n_layers: 5
+      checkpoint: forward
+    backward:
+      type: mlp
+      n_hid: 512
+      n_layers: 5
+      shared_weights: False
+      checkpoint: backward
+
+# WandB
+logger:
+  lightweight: True
+  project_name: "GFlowNet Cube"
+  tags: 
+    - gflownet
+    - continuous
+    - ccube
+  test:
+    period: 500
+    n: 1000
+  checkpoints:
+    period: 500
+
+# Hydra
+hydra:
+  run:
+    dir: ${user.logdir.root}/debug/ccube/${now:%Y-%m-%d_%H-%M-%S}

--- a/gflownet/envs/crystals/clattice_parameters.py
+++ b/gflownet/envs/crystals/clattice_parameters.py
@@ -22,6 +22,10 @@ from gflownet.utils.crystals.constants import (
     TRICLINIC,
 )
 
+LENGTHS = ("a", "b", "c")
+ANGLES = ("alpha", "beta", "gamma")
+PARAMETERS = LENGTHS + ANGLES
+
 
 # TODO: figure out a way to inherit the (discrete) LatticeParameters env or create a
 # common class for both discrete and continous with the common methods.
@@ -35,9 +39,9 @@ class CLatticeParameters(ContinuousCube):
     from the (continuous) cube environment, creating a mapping between cell position
     and edge length or angle, and imposing lattice system constraints on their values.
 
-    Similar to the Cube environment, the values are initialized with zeros
-    (or target angles, if they are predetermined by the lattice system), and are
-    incremented by sampling from a (mixture of) Beta distribution(s).
+    The environment is a hyper cube of dimensionality 6 (the number of lattice
+    parameters), but it takes advantage of the mask of ignored dimensions implemented
+    in the Cube environment.
 
     The values of the state will remain in the default [0, 1] range of the Cube, but
     they are mapped to [min_length, max_length] in the case of the lengths and
@@ -71,9 +75,247 @@ class CLatticeParameters(ContinuousCube):
         max_angle : float
             Maximum value of the angles.
         """
-        self.lengths = ("a", "b", "c")
-        self.angles = ("alpha", "beta", "gamma")
-        self.parameters = self.lengths + self.angles
+        self.lattice_system = lattice_system
+        self.min_length = min_length
+        self.max_length = max_length
+        self.length_range = self.max_length - self.min_length
+        self.min_angle = min_angle
+        self.max_angle = max_angle
+        self.angle_range = self.max_angle - self.min_angle
+        self._setup_constraints()
+        super().__init__(n_dim=6, **kwargs)
+
+    def _statevalue2length(self, value):
+        return self.min_length + value * self.length_range
+
+    def _length2statevalue(self, length):
+        return (length - self.min_length) / self.length_range
+
+    def _statevalue2angle(self, value):
+        return self.min_angle + value * self.angle_range
+
+    def _angle2statevalue(self, angle):
+        return (angle - self.min_angle) / self.angle_range
+
+    def _get_param(self, param):
+        if hasattr(self, param):
+            return getattr(self, param)
+        else:
+            if param in LENGTHS:
+                return self._statevalue2length(
+                    self.state[self._get_index_of_param(param)]
+                )
+            elif param in ANGLES:
+                return self._statevalue2angle(
+                    self.state[self._get_index_of_param(param)]
+                )
+            else:
+                raise ValueError(f"{param} is not a valid lattice parameter")
+
+    def _set_param(self, state, param, value):
+        param_idx = self._get_index_of_param(param)
+        if param_idx is not None:
+            if param in LENGTHS:
+                state[param_idx] = self._length2statevalue(value)
+            elif param in ANGLES:
+                state[param_idx] = self._angle2statevalue(value)
+            else:
+                raise ValueError(f"{param} is not a valid lattice parameter")
+        return state
+
+    def _get_index_of_param(self, param):
+        param_idx = f"{param}_idx"
+        if hasattr(self, param_idx):
+            return getattr(self, param_idx)
+        else:
+            return None
+
+    def _setup_constraints(self):
+        """
+        Computes the mask of ignored dimensions, given the constraints imposed by the
+        lattice system. Sets self.ignored_dims.
+        """
+        # Lengths: a, b, c
+        # a == b == c
+        if self.lattice_system in [CUBIC, RHOMBOHEDRAL]:
+            lengths_ignored_dims = [False, True, True]
+            self.a_idx = 0
+            self.b_idx = 0
+            self.c_idx = 0
+        # a == b != c
+        elif self.lattice_system in [HEXAGONAL, TETRAGONAL]:
+            lengths_ignored_dims = [False, True, False]
+            self.a_idx = 0
+            self.b_idx = 0
+            self.c_idx = 1
+        # a != b and a != c and b != c
+        elif self.lattice_system in [MONOCLINIC, ORTHORHOMBIC, TRICLINIC]:
+            lengths_ignored_dims = [False, False, False]
+            self.a_idx = 0
+            self.b_idx = 1
+            self.c_idx = 2
+        else:
+            raise NotImplementedError
+        # Angles: alpha, beta, gamma
+        # alpha == beta == gamma == 90.0
+        if self.lattice_system in [CUBIC, ORTHORHOMBIC, TETRAGONAL]:
+            angles_ignored_dims = [True, True, True]
+            self.alpha_idx = None
+            self.alpha = 90.0
+            self.alpha_state = self._angle2statevalue(self.alpha)
+            self.beta_idx = None
+            self.beta = 90.0
+            self.beta_state = self._angle2statevalue(self.beta)
+            self.gamma_idx = None
+            self.gamma = 90.0
+            self.gamma_state = self._angle2statevalue(self.gamma)
+        #  alpha == beta == 90.0 and gamma == 120.0
+        elif self.lattice_system == HEXAGONAL:
+            angles_ignored_dims = [True, True, True]
+            self.alpha_idx = None
+            self.alpha = 90.0
+            self.alpha_state = self._angle2statevalue(self.alpha)
+            self.beta_idx = None
+            self.beta = 90.0
+            self.beta_state = self._angle2statevalue(self.beta)
+            self.gamma_idx = None
+            self.gamma = 120.0
+            self.gamma_state = self._angle2statevalue(self.gamma)
+        # alpha == gamma == 90.0 and beta != 90.0
+        elif self.lattice_system == MONOCLINIC:
+            angles_ignored_dims = [True, False, True]
+            self.alpha_idx = None
+            self.alpha = 90.0
+            self.alpha_state = self._angle2statevalue(self.alpha)
+            self.beta_idx = 4
+            self.gamma_idx = None
+            self.gamma = 90.0
+            self.gamma_state = self._angle2statevalue(self.gamma)
+        # alpha == beta == gamma != 90.0
+        elif self.lattice_system == RHOMBOHEDRAL:
+            angles_ignored_dims = [False, True, True]
+            self.alpha_idx = 3
+            self.beta_idx = 3
+            self.gamma_idx = 3
+        # alpha != beta, alpha != gamma, beta != gamma
+        elif self.lattice_system == TRICLINIC:
+            angles_ignored_dims = [False, False, False]
+            self.alpha_idx = 3
+            self.beta_idx = 4
+            self.gamma_idx = 5
+        else:
+            raise NotImplementedError
+        self.ignored_dims = lengths_ignored_dims + angles_ignored_dims
+
+    def _step(
+        self,
+        action: Tuple[float],
+        backward: bool,
+    ) -> Tuple[List[float], Tuple[float], bool]:
+        """
+        Updates the dimensions of the state corresponding to the ignored dimensions
+        after a call to the Cube's _step().
+        """
+        state, action, valid = super()._step(action, backward)
+        for idx, (param, is_ignored) in enumerate(zip(PARAMETERS, self.ignored_dims)):
+            if not is_ignored:
+                continue
+            param_idx = self._get_index_of_param(param)
+            if param_idx is not None:
+                state[idx] = state[param_idx]
+            else:
+                state[idx] = getattr(self, f"{param}_state")
+        self.state = copy(state)
+        return self.state, action, valid
+
+    def _unpack_lengths_angles(
+        self, state: Optional[List[int]] = None
+    ) -> Tuple[Tuple, Tuple]:
+        """
+        Helper that 1) unpacks values coding lengths and angles from the state or from
+        the attributes of the instance and 2) converts them to actual edge lengths and
+        angles in the target units (angstroms or degrees).
+        """
+        state = self._get_state(state)
+
+        a, b, c, alpha, beta, gamma = [self._get_param(p) for p in PARAMETERS]
+        return (a, b, c), (alpha, beta, gamma)
+
+    def state2readable(self, state: Optional[List[int]] = None) -> str:
+        """
+        Converts the state into a human-readable string in the format "(a, b, c),
+        (alpha, beta, gamma)".
+        """
+        state = self._get_state(state)
+
+        lengths, angles = self._unpack_lengths_angles(state)
+        return f"{lengths}, {angles}"
+
+    def readable2state(self, readable: str) -> List[int]:
+        """
+        Converts a human-readable representation of a state into the standard format.
+        """
+        state = copy(self.source)
+
+        for c in ["(", ")", " "]:
+            readable = readable.replace(c, "")
+        values = readable.split(",")
+        values = [float(value) for value in values]
+
+        for param, value in zip(PARAMETERS, values):
+            state = self._set_param(state, param, value)
+        return state
+
+
+# TODO: figure out a way to inherit the (discrete) LatticeParameters env or create a
+# common class for both discrete and continous with the common methods.
+class CLatticeParametersEffectiveDim(ContinuousCube):
+    """
+    Continuous lattice parameters environment for crystal structures generation.
+
+    Models lattice parameters (three edge lengths and three angles describing unit
+    cell) with the constraints given by the provided lattice system (see
+    https://en.wikipedia.org/wiki/Bravais_lattice). This is implemented by inheriting
+    from the (continuous) cube environment, creating a mapping between cell position
+    and edge length or angle, and imposing lattice system constraints on their values.
+
+    The environment is simply a hyper cube with a number of dimensions equal to the the
+    number of "effective dimensions". While this is nice and simple, it does not allow
+    us to integrate it in the general crystals such that lattices of any lattice system
+    can be sampled.
+
+    The values of the state will remain in the default [0, 1] range of the Cube, but
+    they are mapped to [min_length, max_length] in the case of the lengths and
+    [min_angle, max_angle] in the case of the angles.
+    """
+
+    def __init__(
+        self,
+        lattice_system: str,
+        min_length: float = 1.0,
+        max_length: float = 5.0,
+        min_angle: float = 30.0,
+        max_angle: float = 150.0,
+        **kwargs,
+    ):
+        """
+        Args
+        ----
+        lattice_system : str
+            One of the seven lattice systems.
+
+        min_length : float
+            Minimum value of the lengths.
+
+        max_length : float
+            Maximum value of the lengths.
+
+        min_angle : float
+            Minimum value of the angles.
+
+        max_angle : float
+            Maximum value of the angles.
+        """
         self.lattice_system = lattice_system
         self.min_length = min_length
         self.max_length = max_length
@@ -97,14 +339,18 @@ class CLatticeParameters(ContinuousCube):
         return (angle - self.min_angle) / self.angle_range
 
     def _get_param(self, param):
+        """
+        Returns the value of parameter param (a, b, c, alpha, beta, gamma) in the
+        target units (angstroms or degrees).
+        """
         if hasattr(self, param):
             return getattr(self, param)
         else:
-            if param in self.lengths:
+            if param in LENGTHS:
                 return self._statevalue2length(
                     self.state[self._get_index_of_param(param)]
                 )
-            elif param in self.angles:
+            elif param in ANGLES:
                 return self._statevalue2angle(
                     self.state[self._get_index_of_param(param)]
                 )
@@ -112,11 +358,16 @@ class CLatticeParameters(ContinuousCube):
                 raise ValueError(f"{param} is not a valid lattice parameter")
 
     def _set_param(self, state, param, value):
+        """
+        Sets the value of parameter param (a, b, c, alpha, beta, gamma) given in target
+        units (angstroms or degrees) in the state, after conversion to state units in
+        [0, 1].
+        """
         param_idx = self._get_index_of_param(param)
         if param_idx:
-            if param in self.lengths:
+            if param in LENGTHS:
                 state[param_idx] = self._length2statevalue(value)
-            elif param in self.angles:
+            elif param in ANGLES:
                 state[param_idx] = self._angle2statevalue(value)
             else:
                 raise ValueError(f"{param} is not a valid lattice parameter")
@@ -213,7 +464,7 @@ class CLatticeParameters(ContinuousCube):
         """
         state = self._get_state(state)
 
-        a, b, c, alpha, beta, gamma = [self._get_param(p) for p in self.parameters]
+        a, b, c, alpha, beta, gamma = [self._get_param(p) for p in PARAMETERS]
         return (a, b, c), (alpha, beta, gamma)
 
     def state2readable(self, state: Optional[List[int]] = None) -> str:
@@ -237,6 +488,6 @@ class CLatticeParameters(ContinuousCube):
         values = readable.split(",")
         values = [float(value) for value in values]
 
-        for param, value in zip(self.parameters, values):
+        for param, value in zip(PARAMETERS, values):
             state = self._set_param(state, param, value)
         return state

--- a/gflownet/envs/crystals/clattice_parameters.py
+++ b/gflownet/envs/crystals/clattice_parameters.py
@@ -75,6 +75,7 @@ class CLatticeParameters(ContinuousCube):
         max_angle : float
             Maximum value of the angles.
         """
+        self.continuous = True
         self.lattice_system = lattice_system
         self.min_length = min_length
         self.max_length = max_length

--- a/gflownet/envs/crystals/clattice_parameters.py
+++ b/gflownet/envs/crystals/clattice_parameters.py
@@ -1,0 +1,242 @@
+"""
+Classes to represent continuous lattice parameters environments.
+"""
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+from torchtyping import TensorType
+
+from gflownet.envs.crystals.lattice_parameters import LatticeParameters
+from gflownet.envs.cube import ContinuousCube
+from gflownet.utils.common import copy
+from gflownet.utils.crystals.constants import (
+    CUBIC,
+    HEXAGONAL,
+    LATTICE_SYSTEMS,
+    MONOCLINIC,
+    ORTHORHOMBIC,
+    RHOMBOHEDRAL,
+    TETRAGONAL,
+    TRICLINIC,
+)
+
+
+# TODO: figure out a way to inherit the (discrete) LatticeParameters env or create a
+# common class for both discrete and continous with the common methods.
+class CLatticeParameters(ContinuousCube):
+    """
+    Continuous lattice parameters environment for crystal structures generation.
+
+    Models lattice parameters (three edge lengths and three angles describing unit
+    cell) with the constraints given by the provided lattice system (see
+    https://en.wikipedia.org/wiki/Bravais_lattice). This is implemented by inheriting
+    from the (continuous) cube environment, creating a mapping between cell position
+    and edge length or angle, and imposing lattice system constraints on their values.
+
+    Similar to the Cube environment, the values are initialized with zeros
+    (or target angles, if they are predetermined by the lattice system), and are
+    incremented by sampling from a (mixture of) Beta distribution(s).
+
+    The values of the state will remain in the default [0, 1] range of the Cube, but
+    they are mapped to [min_length, max_length] in the case of the lengths and
+    [min_angle, max_angle] in the case of the angles.
+    """
+
+    def __init__(
+        self,
+        lattice_system: str,
+        min_length: float = 1.0,
+        max_length: float = 5.0,
+        min_angle: float = 30.0,
+        max_angle: float = 150.0,
+        **kwargs,
+    ):
+        """
+        Args
+        ----
+        lattice_system : str
+            One of the seven lattice systems.
+
+        min_length : float
+            Minimum value of the lengths.
+
+        max_length : float
+            Maximum value of the lengths.
+
+        min_angle : float
+            Minimum value of the angles.
+
+        max_angle : float
+            Maximum value of the angles.
+        """
+        self.lengths = ("a", "b", "c")
+        self.angles = ("alpha", "beta", "gamma")
+        self.parameters = self.lengths + self.angles
+        self.lattice_system = lattice_system
+        self.min_length = min_length
+        self.max_length = max_length
+        self.length_range = self.max_length - self.min_length
+        self.min_angle = min_angle
+        self.max_angle = max_angle
+        self.angle_range = self.max_angle - self.min_angle
+        n_dim = self._setup_constraints()
+        super().__init__(n_dim=n_dim, **kwargs)
+
+    def _statevalue2length(self, value):
+        return self.min_length + value * self.length_range
+
+    def _length2statevalue(self, length):
+        return (length - self.min_length) / self.length_range
+
+    def _statevalue2angle(self, value):
+        return self.min_angle + value * self.angle_range
+
+    def _angle2statevalue(self, angle):
+        return (angle - self.min_angle) / self.angle_range
+
+    def _get_param(self, param):
+        if hasattr(self, param):
+            return getattr(self, param)
+        else:
+            if param in self.lengths:
+                return self._statevalue2length(
+                    self.state[self._get_index_of_param(param)]
+                )
+            elif param in self.angles:
+                return self._statevalue2angle(
+                    self.state[self._get_index_of_param(param)]
+                )
+            else:
+                raise ValueError(f"{param} is not a valid lattice parameter")
+
+    def _set_param(self, state, param, value):
+        param_idx = self._get_index_of_param(param)
+        if param_idx:
+            if param in self.lengths:
+                state[param_idx] = self._length2statevalue(value)
+            elif param in self.angles:
+                state[param_idx] = self._angle2statevalue(value)
+            else:
+                raise ValueError(f"{param} is not a valid lattice parameter")
+        return state
+
+    def _get_index_of_param(self, param):
+        param_idx = f"{param}_idx"
+        if hasattr(self, param_idx):
+            return getattr(self, param_idx)
+        else:
+            return None
+
+    def _setup_constraints(self):
+        """
+        Computes the effective number of dimensions, given the constraints imposed by
+        the lattice system.
+
+        Returns
+        -------
+        n_dim : int
+            The number of effective dimensions that can be be udpated in the
+            environment, given the constraints set by the lattice system.
+        """
+        # Lengths: a, b, c
+        n_dim = 0
+        # a == b == c
+        if self.lattice_system in [CUBIC, RHOMBOHEDRAL]:
+            n_dim += 1
+            self.a_idx = 0
+            self.b_idx = 0
+            self.c_idx = 0
+        # a == b != c
+        elif self.lattice_system in [HEXAGONAL, TETRAGONAL]:
+            n_dim += 2
+            self.a_idx = 0
+            self.b_idx = 0
+            self.c_idx = 1
+        # a != b and a != c and b != c
+        elif self.lattice_system in [MONOCLINIC, ORTHORHOMBIC, TRICLINIC]:
+            n_dim += 3
+            self.a_idx = 0
+            self.b_idx = 1
+            self.c_idx = 2
+        else:
+            raise NotImplementedError
+        # Angles: alpha, beta, gamma
+        # alpha == beta == gamma == 90.0
+        if self.lattice_system in [CUBIC, ORTHORHOMBIC, TETRAGONAL]:
+            self.alpha_idx = None
+            self.alpha = 90.0
+            self.beta_idx = None
+            self.beta = 90.0
+            self.gamma_idx = None
+            self.gamma = 90.0
+        #  alpha == beta == 90.0 and gamma == 120.0
+        elif self.lattice_system == HEXAGONAL:
+            self.alpha_idx = None
+            self.alpha = 90.0
+            self.beta_idx = None
+            self.beta = 90.0
+            self.gamma_idx = None
+            self.gamma = 120.0
+        # alpha == gamma == 90.0 and beta != 90.0
+        elif self.lattice_system == MONOCLINIC:
+            n_dim += 1
+            self.alpha_idx = None
+            self.alpha = 90.0
+            self.beta_idx = n_dim - 1
+            self.gamma_idx = None
+            self.gamma = 90.0
+        # alpha == beta == gamma != 90.0
+        elif self.lattice_system == RHOMBOHEDRAL:
+            n_dim += 1
+            self.alpha_idx = n_dim - 1
+            self.beta_idx = n_dim - 1
+            self.gamma_idx = n_dim - 1
+        # alpha != beta, alpha != gamma, beta != gamma
+        elif self.lattice_system == TRICLINIC:
+            n_dim += 3
+            self.alpha_idx = 3
+            self.beta_idx = 4
+            self.gamma_idx = 5
+        else:
+            raise NotImplementedError
+        return n_dim
+
+    def _unpack_lengths_angles(
+        self, state: Optional[List[int]] = None
+    ) -> Tuple[Tuple, Tuple]:
+        """
+        Helper that 1) unpacks values coding lengths and angles from the state or from
+        the attributes of the instance and 2) converts them to actual edge lengths and
+        angles.
+        """
+        state = self._get_state(state)
+
+        a, b, c, alpha, beta, gamma = [self._get_param(p) for p in self.parameters]
+        return (a, b, c), (alpha, beta, gamma)
+
+    def state2readable(self, state: Optional[List[int]] = None) -> str:
+        """
+        Converts the state into a human-readable string in the format "(a, b, c),
+        (alpha, beta, gamma)".
+        """
+        state = self._get_state(state)
+
+        lengths, angles = self._unpack_lengths_angles(state)
+        return f"{lengths}, {angles}"
+
+    def readable2state(self, readable: str) -> List[int]:
+        """
+        Converts a human-readable representation of a state into the standard format.
+        """
+        state = copy(self.source)
+
+        for c in ["(", ")", " "]:
+            readable = readable.replace(c, "")
+        values = readable.split(",")
+        values = [float(value) for value in values]
+
+        for param, value in zip(self.parameters, values):
+            state = self._set_param(state, param, value)
+        return state

--- a/gflownet/envs/crystals/clattice_parameters.py
+++ b/gflownet/envs/crystals/clattice_parameters.py
@@ -22,9 +22,9 @@ from gflownet.utils.crystals.constants import (
     TRICLINIC,
 )
 
-LENGTHS = ("a", "b", "c")
-ANGLES = ("alpha", "beta", "gamma")
-PARAMETERS = LENGTHS + ANGLES
+LENGTH_PARAMETER_NAMES = ("a", "b", "c")
+ANGLE_PARAMETER_NAMES = ("alpha", "beta", "gamma")
+PARAMETER_NAMES = LENGTH_PARAMETER_NAMES + ANGLE_PARAMETER_NAMES
 
 
 # TODO: figure out a way to inherit the (discrete) LatticeParameters env or create a
@@ -102,11 +102,11 @@ class CLatticeParameters(ContinuousCube):
         if hasattr(self, param):
             return getattr(self, param)
         else:
-            if param in LENGTHS:
+            if param in LENGTH_PARAMETER_NAMES:
                 return self._statevalue2length(
                     self.state[self._get_index_of_param(param)]
                 )
-            elif param in ANGLES:
+            elif param in ANGLE_PARAMETER_NAMES:
                 return self._statevalue2angle(
                     self.state[self._get_index_of_param(param)]
                 )
@@ -116,9 +116,9 @@ class CLatticeParameters(ContinuousCube):
     def _set_param(self, state, param, value):
         param_idx = self._get_index_of_param(param)
         if param_idx is not None:
-            if param in LENGTHS:
+            if param in LENGTH_PARAMETER_NAMES:
                 state[param_idx] = self._length2statevalue(value)
-            elif param in ANGLES:
+            elif param in ANGLE_PARAMETER_NAMES:
                 state[param_idx] = self._angle2statevalue(value)
             else:
                 raise ValueError(f"{param} is not a valid lattice parameter")
@@ -218,7 +218,9 @@ class CLatticeParameters(ContinuousCube):
         after a call to the Cube's _step().
         """
         state, action, valid = super()._step(action, backward)
-        for idx, (param, is_ignored) in enumerate(zip(PARAMETERS, self.ignored_dims)):
+        for idx, (param, is_ignored) in enumerate(
+            zip(PARAMETER_NAMES, self.ignored_dims)
+        ):
             if not is_ignored:
                 continue
             param_idx = self._get_index_of_param(param)
@@ -239,7 +241,7 @@ class CLatticeParameters(ContinuousCube):
         """
         state = self._get_state(state)
 
-        a, b, c, alpha, beta, gamma = [self._get_param(p) for p in PARAMETERS]
+        a, b, c, alpha, beta, gamma = [self._get_param(p) for p in PARAMETER_NAMES]
         return (a, b, c), (alpha, beta, gamma)
 
     def state2readable(self, state: Optional[List[int]] = None) -> str:
@@ -263,7 +265,7 @@ class CLatticeParameters(ContinuousCube):
         values = readable.split(",")
         values = [float(value) for value in values]
 
-        for param, value in zip(PARAMETERS, values):
+        for param, value in zip(PARAMETER_NAMES, values):
             state = self._set_param(state, param, value)
         return state
 
@@ -347,11 +349,11 @@ class CLatticeParametersEffectiveDim(ContinuousCube):
         if hasattr(self, param):
             return getattr(self, param)
         else:
-            if param in LENGTHS:
+            if param in LENGTH_PARAMETER_NAMES:
                 return self._statevalue2length(
                     self.state[self._get_index_of_param(param)]
                 )
-            elif param in ANGLES:
+            elif param in ANGLE_PARAMETER_NAMES:
                 return self._statevalue2angle(
                     self.state[self._get_index_of_param(param)]
                 )
@@ -366,9 +368,9 @@ class CLatticeParametersEffectiveDim(ContinuousCube):
         """
         param_idx = self._get_index_of_param(param)
         if param_idx:
-            if param in LENGTHS:
+            if param in LENGTH_PARAMETER_NAMES:
                 state[param_idx] = self._length2statevalue(value)
-            elif param in ANGLES:
+            elif param in ANGLE_PARAMETER_NAMES:
                 state[param_idx] = self._angle2statevalue(value)
             else:
                 raise ValueError(f"{param} is not a valid lattice parameter")
@@ -465,7 +467,7 @@ class CLatticeParametersEffectiveDim(ContinuousCube):
         """
         state = self._get_state(state)
 
-        a, b, c, alpha, beta, gamma = [self._get_param(p) for p in PARAMETERS]
+        a, b, c, alpha, beta, gamma = [self._get_param(p) for p in PARAMETER_NAMES]
         return (a, b, c), (alpha, beta, gamma)
 
     def state2readable(self, state: Optional[List[int]] = None) -> str:
@@ -489,6 +491,6 @@ class CLatticeParametersEffectiveDim(ContinuousCube):
         values = readable.split(",")
         values = [float(value) for value in values]
 
-        for param, value in zip(PARAMETERS, values):
+        for param, value in zip(PARAMETER_NAMES, values):
             state = self._set_param(state, param, value)
         return state

--- a/gflownet/envs/cube.py
+++ b/gflownet/envs/cube.py
@@ -498,7 +498,7 @@ class ContinuousCube(Cube):
         if done:
             mask[2] = False
             return mask
-        mask[-self.n_dim :] = False
+        mask = [True] * 3 + [False] * self.n_dim
         # If any dimension is smaller than m, then back-to-source action is the only
         # possible actiona.
         if any([s < self.min_incr for s in state]):
@@ -765,6 +765,8 @@ class ContinuousCube(Cube):
         # Initialize variables
         n_states = policy_outputs.shape[0]
         is_bts = torch.zeros(n_states, dtype=torch.bool, device=self.device)
+        # Mask of effective dimensions
+        is_effective_dim = ~mask[-self.n_dim :]
         # EOS is the only possible action only if done is True (mask[2] is False)
         is_eos = ~mask[:, 2]
         # Back-to-source (BTS) is the only possible action if mask[1] is False
@@ -885,6 +887,8 @@ class ContinuousCube(Cube):
             (n_states, self.n_dim), device=self.device, dtype=self.float
         )
         eos_tensor = tfloat(self.eos, float_type=self.float, device=self.device)
+        # Mask of effective dimensions
+        is_effective_dim = ~mask[-self.n_dim :]
         # Determine source states
         is_source = ~mask[:, 1]
         # EOS is the only possible action if continuous actions are invalid (mask[0] is
@@ -968,6 +972,8 @@ class ContinuousCube(Cube):
         jacobian_diag = torch.ones(
             (n_states, self.n_dim), device=self.device, dtype=self.float
         )
+        # Mask of effective dimensions
+        is_effective_dim = ~mask[-self.n_dim :]
         # EOS is the only possible action only if done is True (mask[2] is False)
         is_eos = ~mask[:, 2]
         # Back-to-source (BTS) is the only possible action if mask[1] is False

--- a/gflownet/envs/cube.py
+++ b/gflownet/envs/cube.py
@@ -808,8 +808,6 @@ class ContinuousCube(Cube):
         # Initialize variables
         n_states = policy_outputs.shape[0]
         is_bts = torch.zeros(n_states, dtype=torch.bool, device=self.device)
-        # Mask of effective dimensions
-        is_effective_dim = ~mask[:, -self.n_dim :]
         # EOS is the only possible action only if done is True (mask[2] is False)
         is_eos = ~mask[:, 2]
         # Back-to-source (BTS) is the only possible action if mask[1] is False
@@ -938,8 +936,6 @@ class ContinuousCube(Cube):
             (n_states, self.n_dim), device=self.device, dtype=self.float
         )
         eos_tensor = tfloat(self.eos, float_type=self.float, device=self.device)
-        # Mask of effective dimensions
-        is_effective_dim = ~mask[:, -self.n_dim :]
         # Determine source states
         is_source = ~mask[:, 1]
         # EOS is the only possible action if continuous actions are invalid (mask[0] is
@@ -1031,8 +1027,6 @@ class ContinuousCube(Cube):
         log_jacobian_diag = torch.zeros(
             (n_states, self.n_dim), device=self.device, dtype=self.float
         )
-        # Mask of effective dimensions
-        is_effective_dim = ~mask[:, -self.n_dim :]
         # EOS is the only possible action only if done is True (mask[2] is False)
         is_eos = ~mask[:, 2]
         # Back-to-source (BTS) is the only possible action if mask[1] is False

--- a/gflownet/envs/cube.py
+++ b/gflownet/envs/cube.py
@@ -498,7 +498,7 @@ class ContinuousCube(Cube):
         if done:
             mask[2] = False
             return mask
-        mask[-self.n_dim] = False
+        mask[-self.n_dim :] = False
         # If any dimension is smaller than m, then back-to-source action is the only
         # possible actiona.
         if any([s < self.min_incr for s in state]):

--- a/tests/gflownet/envs/test_ccube.py
+++ b/tests/gflownet/envs/test_ccube.py
@@ -95,19 +95,19 @@ def test__mask_backward__returns_all_true_except_eos_if_done(env, request):
     [
         (
             [0.0],
-            [False, False, True],
+            [False, False, True, False],
         ),
         (
             [0.5],
-            [False, True, False],
+            [False, True, False, False],
         ),
         (
             [0.90],
-            [False, True, False],
+            [False, True, False, False],
         ),
         (
             [0.95],
-            [True, True, False],
+            [True, True, False, False],
         ),
     ],
 )
@@ -122,31 +122,31 @@ def test__mask_forward__1d__returns_expected(cube1d, state, mask_expected):
     [
         (
             [0.0, 0.0],
-            [False, False, True],
+            [False, False, True, False, False],
         ),
         (
             [0.5, 0.5],
-            [False, True, False],
+            [False, True, False, False, False],
         ),
         (
             [0.90, 0.5],
-            [False, True, False],
+            [False, True, False, False, False],
         ),
         (
             [0.95, 0.5],
-            [True, True, False],
+            [True, True, False, False, False],
         ),
         (
             [0.5, 0.90],
-            [False, True, False],
+            [False, True, False, False, False],
         ),
         (
             [0.5, 0.95],
-            [True, True, False],
+            [True, True, False, False, False],
         ),
         (
             [0.95, 0.95],
-            [True, True, False],
+            [True, True, False, False, False],
         ),
     ],
 )
@@ -161,27 +161,27 @@ def test__mask_forward__2d__returns_expected(cube2d, state, mask_expected):
     [
         (
             [0.0],
-            [True, False, True],
+            [True, False, True, False],
         ),
         (
             [0.1],
-            [False, True, True],
+            [False, True, True, False],
         ),
         (
             [0.05],
-            [True, False, True],
+            [True, False, True, False],
         ),
         (
             [0.5],
-            [False, True, True],
+            [False, True, True, False],
         ),
         (
             [0.90],
-            [False, True, True],
+            [False, True, True, False],
         ),
         (
             [0.95],
-            [False, True, True],
+            [False, True, True, False],
         ),
     ],
 )
@@ -196,43 +196,43 @@ def test__mask_backward__1d__returns_expected(cube1d, state, mask_expected):
     [
         (
             [0.0, 0.0],
-            [True, False, True],
+            [True, False, True, False, False],
         ),
         (
             [0.5, 0.5],
-            [False, True, True],
+            [False, True, True, False, False],
         ),
         (
             [0.05, 0.5],
-            [True, False, True],
+            [True, False, True, False, False],
         ),
         (
             [0.5, 0.05],
-            [True, False, True],
+            [True, False, True, False, False],
         ),
         (
             [0.05, 0.05],
-            [True, False, True],
+            [True, False, True, False, False],
         ),
         (
             [0.90, 0.5],
-            [False, True, True],
+            [False, True, True, False, False],
         ),
         (
             [0.5, 0.90],
-            [False, True, True],
+            [False, True, True, False, False],
         ),
         (
             [0.95, 0.5],
-            [False, True, True],
+            [False, True, True, False, False],
         ),
         (
             [0.5, 0.95],
-            [False, True, True],
+            [False, True, True, False, False],
         ),
         (
             [0.95, 0.95],
-            [False, True, True],
+            [False, True, True, False, False],
         ),
     ],
 )

--- a/tests/gflownet/envs/test_ccube.py
+++ b/tests/gflownet/envs/test_ccube.py
@@ -86,8 +86,8 @@ def test__mask_backward__returns_all_true_except_eos_if_done(env, request):
     for state in states:
         env.set_state(state, done=True)
         mask = env.get_mask_invalid_actions_backward()
-        assert all(mask[:-1])
-        assert mask[-1] is False
+        assert all(mask[:2])
+        assert mask[2] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/gflownet/envs/test_clattice_parameters.py
+++ b/tests/gflownet/envs/test_clattice_parameters.py
@@ -14,7 +14,7 @@ from gflownet.envs.crystals.clattice_parameters import (
     CLatticeParameters,
 )
 
-N_REPETITIONS = 100
+N_REPETITIONS = 1000
 
 
 @pytest.fixture()
@@ -66,12 +66,8 @@ def test__cubic__constraints_remain_after_random_actions(env, lattice_system):
     env = env.reset()
     while not env.done:
         (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
-        assert a == b
-        assert b == c
-        assert a == c
-        assert alpha == 90.0
-        assert beta == 90.0
-        assert gamma == 90.0
+        assert len({a, b, c}) == 1
+        assert len({alpha, beta, gamma, 90.0}) == 1
         env.step_random()
 
 
@@ -83,12 +79,12 @@ def test__cubic__constraints_remain_after_random_actions(env, lattice_system):
 def test__hexagonal__constraints_remain_after_random_actions(env, lattice_system):
     env = env.reset()
     while not env.done:
+        env.step_random()
         (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
         assert a == b
-        assert alpha == 90.0
-        assert beta == 90.0
+        assert len({a, b, c}) == 2
+        assert len({alpha, beta, 90.0}) == 1
         assert gamma == 120.0
-        env.step_random()
 
 
 @pytest.mark.parametrize(
@@ -99,11 +95,11 @@ def test__hexagonal__constraints_remain_after_random_actions(env, lattice_system
 def test__monoclinic__constraints_remain_after_random_actions(env, lattice_system):
     env = env.reset()
     while not env.done:
-        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
-        assert alpha == 90.0
-        assert beta != 90.0
-        assert gamma == 90.0
         env.step_random()
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert len({a, b, c}) == 3
+        assert len({alpha, gamma, 90.0}) == 1
+        assert beta != 90.0
 
 
 @pytest.mark.parametrize(
@@ -114,11 +110,10 @@ def test__monoclinic__constraints_remain_after_random_actions(env, lattice_syste
 def test__orthorhombic__constraints_remain_after_random_actions(env, lattice_system):
     env = env.reset()
     while not env.done:
-        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
-        assert alpha == 90.0
-        assert beta == 90.0
-        assert gamma == 90.0
         env.step_random()
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert len({a, b, c}) == 3
+        assert len({alpha, beta, gamma, 90.0}) == 1
 
 
 @pytest.mark.parametrize(
@@ -129,15 +124,11 @@ def test__orthorhombic__constraints_remain_after_random_actions(env, lattice_sys
 def test__rhombohedral__constraints_remain_after_random_actions(env, lattice_system):
     env = env.reset()
     while not env.done:
-        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
-        assert a == b
-        assert b == c
-        assert a == c
-        assert alpha == beta
-        assert beta == gamma
-        assert alpha == gamma
-        assert alpha != 90.0
         env.step_random()
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert len({a, b, c}) == 1
+        assert len({alpha, beta, gamma}) == 1
+        assert len({alpha, beta, gamma, 90.0}) == 2
 
 
 @pytest.mark.parametrize(
@@ -148,12 +139,11 @@ def test__rhombohedral__constraints_remain_after_random_actions(env, lattice_sys
 def test__tetragonal__constraints_remain_after_random_actions(env, lattice_system):
     env = env.reset()
     while not env.done:
+        env.step_random()
         (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
         assert a == b
-        assert alpha == 90.0
-        assert beta == 90.0
-        assert gamma == 90.0
-        env.step_random()
+        assert len({a, b, c}) == 2
+        assert len({alpha, beta, gamma, 90.0}) == 1
 
 
 @pytest.mark.parametrize(
@@ -166,9 +156,7 @@ def test__triclinic__constraints_remain_after_random_actions(env, lattice_system
     while not env.done:
         env.step_random()
         (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
-        assert a != b
-        assert a != c
-        assert b != c
+        assert len({a, b, c}) == 3
         assert len({alpha, beta, gamma, 90.0}) == 4
 
 

--- a/tests/gflownet/envs/test_clattice_parameters.py
+++ b/tests/gflownet/envs/test_clattice_parameters.py
@@ -164,9 +164,11 @@ def test__tetragonal__constraints_remain_after_random_actions(env, lattice_syste
 def test__triclinic__constraints_remain_after_random_actions(env, lattice_system):
     env = env.reset()
     while not env.done:
-        # TODO: Test not equality constraints
         env.step_random()
         (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert a != b
+        assert a != c
+        assert b != c
         assert len({alpha, beta, gamma, 90.0}) == 4
 
 

--- a/tests/gflownet/envs/test_clattice_parameters.py
+++ b/tests/gflownet/envs/test_clattice_parameters.py
@@ -204,3 +204,11 @@ def test__readable2state__returns_initial_state_for_rhombohedral_and_triclinic(
     env, lattice_system, readable
 ):
     assert env.readable2state(readable) == env.state
+
+
+@pytest.mark.parametrize(
+    "lattice_system",
+    [CUBIC, HEXAGONAL, MONOCLINIC, ORTHORHOMBIC, RHOMBOHEDRAL, TETRAGONAL, TRICLINIC],
+)
+def test__continuous_env_common(env, lattice_system):
+    return common.test__continuous_env_common(env)

--- a/tests/gflownet/envs/test_clattice_parameters.py
+++ b/tests/gflownet/envs/test_clattice_parameters.py
@@ -190,7 +190,7 @@ def test__state2readable__gives_expected_results_for_initial_states(
         (TRICLINIC, "(1.0, 1.0, 1.0), (30.0, 30.0, 30.0)"),
     ],
 )
-def test__readable2state__returns_initial_state_for_rhombohedral_and_triclinic(
+def test__readable2state__gives_expected_results_for_initial_states(
     env, lattice_system, readable
 ):
     assert env.readable2state(readable) == env.state

--- a/tests/gflownet/envs/test_clattice_parameters.py
+++ b/tests/gflownet/envs/test_clattice_parameters.py
@@ -1,0 +1,206 @@
+import common
+import pytest
+import torch
+
+from gflownet.envs.crystals.clattice_parameters import (
+    CUBIC,
+    HEXAGONAL,
+    LATTICE_SYSTEMS,
+    MONOCLINIC,
+    ORTHORHOMBIC,
+    RHOMBOHEDRAL,
+    TETRAGONAL,
+    TRICLINIC,
+    CLatticeParameters,
+)
+
+N_REPETITIONS = 100
+
+
+@pytest.fixture()
+def env(lattice_system):
+    return CLatticeParameters(
+        lattice_system=lattice_system,
+        min_length=1.0,
+        max_length=5.0,
+        min_angle=30.0,
+        max_angle=150.0,
+    )
+
+
+@pytest.mark.parametrize("lattice_system", LATTICE_SYSTEMS)
+def test__environment__initializes_properly(env, lattice_system):
+    pass
+
+
+@pytest.mark.parametrize(
+    "lattice_system, expected_params",
+    [
+        (CUBIC, [1, 1, 1, 90, 90, 90]),
+        (HEXAGONAL, [1, 1, 1, 90, 90, 120]),
+        (MONOCLINIC, [1, 1, 1, 90, 30, 90]),
+        (ORTHORHOMBIC, [1, 1, 1, 90, 90, 90]),
+        (RHOMBOHEDRAL, [1, 1, 1, 30, 30, 30]),
+        (TETRAGONAL, [1, 1, 1, 90, 90, 90]),
+        (TRICLINIC, [1, 1, 1, 30, 30, 30]),
+    ],
+)
+def test__environment__has_expected_initial_parameters(
+    env, lattice_system, expected_params
+):
+    (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+    assert a == expected_params[0]
+    assert b == expected_params[1]
+    assert c == expected_params[2]
+    assert alpha == expected_params[3]
+    assert beta == expected_params[4]
+    assert gamma == expected_params[5]
+
+
+@pytest.mark.parametrize(
+    "lattice_system",
+    [CUBIC],
+)
+@pytest.mark.repeat(N_REPETITIONS)
+def test__cubic__constraints_remain_after_random_actions(env, lattice_system):
+    env = env.reset()
+    while not env.done:
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert a == b
+        assert b == c
+        assert a == c
+        assert alpha == 90.0
+        assert beta == 90.0
+        assert gamma == 90.0
+        env.step_random()
+
+
+@pytest.mark.parametrize(
+    "lattice_system",
+    [HEXAGONAL],
+)
+@pytest.mark.repeat(N_REPETITIONS)
+def test__hexagonal__constraints_remain_after_random_actions(env, lattice_system):
+    env = env.reset()
+    while not env.done:
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert a == b
+        assert alpha == 90.0
+        assert beta == 90.0
+        assert gamma == 120.0
+        env.step_random()
+
+
+@pytest.mark.parametrize(
+    "lattice_system",
+    [MONOCLINIC],
+)
+@pytest.mark.repeat(N_REPETITIONS)
+def test__monoclinic__constraints_remain_after_random_actions(env, lattice_system):
+    env = env.reset()
+    while not env.done:
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert alpha == 90.0
+        assert beta != 90.0
+        assert gamma == 90.0
+        env.step_random()
+
+
+@pytest.mark.parametrize(
+    "lattice_system",
+    [ORTHORHOMBIC],
+)
+@pytest.mark.repeat(N_REPETITIONS)
+def test__orthorhombic__constraints_remain_after_random_actions(env, lattice_system):
+    env = env.reset()
+    while not env.done:
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert alpha == 90.0
+        assert beta == 90.0
+        assert gamma == 90.0
+        env.step_random()
+
+
+@pytest.mark.parametrize(
+    "lattice_system",
+    [RHOMBOHEDRAL],
+)
+@pytest.mark.repeat(N_REPETITIONS)
+def test__rhombohedral__constraints_remain_after_random_actions(env, lattice_system):
+    env = env.reset()
+    while not env.done:
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert a == b
+        assert b == c
+        assert a == c
+        assert alpha == beta
+        assert beta == gamma
+        assert alpha == gamma
+        assert alpha != 90.0
+        env.step_random()
+
+
+@pytest.mark.parametrize(
+    "lattice_system",
+    [TETRAGONAL],
+)
+@pytest.mark.repeat(N_REPETITIONS)
+def test__tetragonal__constraints_remain_after_random_actions(env, lattice_system):
+    env = env.reset()
+    while not env.done:
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert a == b
+        assert alpha == 90.0
+        assert beta == 90.0
+        assert gamma == 90.0
+        env.step_random()
+
+
+@pytest.mark.parametrize(
+    "lattice_system",
+    [TRICLINIC],
+)
+@pytest.mark.repeat(N_REPETITIONS)
+def test__triclinic__constraints_remain_after_random_actions(env, lattice_system):
+    env = env.reset()
+    while not env.done:
+        # TODO: Test not equality constraints
+        env.step_random()
+        (a, b, c), (alpha, beta, gamma) = env._unpack_lengths_angles()
+        assert len({alpha, beta, gamma, 90.0}) == 4
+
+
+@pytest.mark.parametrize(
+    "lattice_system, expected_output",
+    [
+        (CUBIC, "(1.0, 1.0, 1.0), (90.0, 90.0, 90.0)"),
+        (HEXAGONAL, "(1.0, 1.0, 1.0), (90.0, 90.0, 120.0)"),
+        (MONOCLINIC, "(1.0, 1.0, 1.0), (90.0, 30.0, 90.0)"),
+        (ORTHORHOMBIC, "(1.0, 1.0, 1.0), (90.0, 90.0, 90.0)"),
+        (RHOMBOHEDRAL, "(1.0, 1.0, 1.0), (30.0, 30.0, 30.0)"),
+        (TETRAGONAL, "(1.0, 1.0, 1.0), (90.0, 90.0, 90.0)"),
+        (TRICLINIC, "(1.0, 1.0, 1.0), (30.0, 30.0, 30.0)"),
+    ],
+)
+def test__state2readable__gives_expected_results_for_initial_states(
+    env, lattice_system, expected_output
+):
+    assert env.state2readable() == expected_output
+
+
+@pytest.mark.parametrize(
+    "lattice_system, readable",
+    [
+        (CUBIC, "(1.0, 1.0, 1.0), (90.0, 90.0, 90.0)"),
+        (HEXAGONAL, "(1.0, 1.0, 1.0), (90.0, 90.0, 120.0)"),
+        (MONOCLINIC, "(1.0, 1.0, 1.0), (90.0, 30.0, 90.0)"),
+        (ORTHORHOMBIC, "(1.0, 1.0, 1.0), (90.0, 90.0, 90.0)"),
+        (RHOMBOHEDRAL, "(1.0, 1.0, 1.0), (30.0, 30.0, 30.0)"),
+        (TETRAGONAL, "(1.0, 1.0, 1.0), (90.0, 90.0, 90.0)"),
+        (TRICLINIC, "(1.0, 1.0, 1.0), (30.0, 30.0, 30.0)"),
+    ],
+)
+def test__readable2state__returns_initial_state_for_rhombohedral_and_triclinic(
+    env, lattice_system, readable
+):
+    assert env.readable2state(readable) == env.state


### PR DESCRIPTION
Implementation of the a lattice parameters environment with continuous parameters as a (continuous) hypercube.

The implementation relies entirely on the hypercube and does not require any additional obscure modifications to deal with the constraints imposed by the lattice system. Simply the number of "effective dimensions" is obtained depending on the lattice system and is used as the (effective) dimensionality of the hypercube.

[Test runs](https://wandb.ai/alexhg/latticeparams)

---

To do list:

- [x] Adapt both the Cube and the CLatticeParameters environment so that it works within the Crystal: modify `sample_actions` and `get_logprobs` so that only the "effective dimensions" are taken into account.
- [x] Decide whether it is necessary to set "not equality" constraints of the kind `angle != 90` (in order to prevent one lattice system becoming another lattice system) or whether it is fine as is because continuous actions will never in theory and very rarely in practice yield the equality. *We have decided that this is not necessary because it will be extremely rare if possible at all and it should not cause important issues anyway.*
- [ ] Implement `state2policy` (and the like) such that angles are encoded with sinusoidal embeddings.
- [ ] Implement `state2proxy` (and the like).
- [ ] Design testing proxies to evaluate the environment. 
- [ ] Implement an elegant way of integrating the discrete and continuous environments, since some methods are common. 
 