### PR TITLE
[FIX] Policy checkpoint was not being added to the policy configs.

### DIFF
--- a/gflownet/policy/base.py
+++ b/gflownet/policy/base.py
@@ -7,13 +7,11 @@ from gflownet.utils.common import set_device, set_float_precision
 
 class Policy:
     def __init__(
-        self, config, env, device, float_precision, base=None, checkpoint=None
+        self, config, env, device, float_precision, base=None
     ):
         # Device and float precision
         self.device = set_device(device)
         self.float = set_float_precision(float_precision)
-        # Checkpoint
-        self.checkpoint = checkpoint
         # Input and output dimensions
         self.state_dim = env.policy_input_dim
         self.fixed_output = torch.tensor(env.fixed_policy_output).to(
@@ -34,6 +32,10 @@ class Policy:
         if config is None:
             config = OmegaConf.create()
             config.type = "uniform"
+        if "checkpoint" in config:
+            self.checkpoint = config.checkpoint
+        else:
+            self.checkpoint = None
         if "shared_weights" in config:
             self.shared_weights = config.shared_weights
         else:


### PR DESCRIPTION
The checkpoint variable of the config was being omitted from the policy configuration. Hence, model checkpoints were not stored. This small PR fixes this issue. 

That the checkpoint are now indeed stored in the `ckpts` (by default) directory of the logging directory can be checked, for instance, with:

FM (only forward policy):
```
python main.py env=grid user=$USER logger.do.online=False policy.forward.checkpoint=pf.ckpt`
```

TB (both forward and backward policies):
```
python main.py env=grid gflownet=trajectorybalance user=$USER logger.do.online=False policy.forward.checkpoint=pf.ckpt policy.backward.checkpoint=pb.ckpt
```