### PR TITLE
Space group env accepts an iterable of valid space groups

### DIFF
--- a/config/env/crystals/spacegroup.yaml
+++ b/config/env/crystals/spacegroup.yaml
@@ -4,6 +4,9 @@ defaults:
 _target_: gflownet.envs.crystals.spacegroup.SpaceGroup
 
 id: spacegroup
+
+# Subset of space groups
+space_groups_subset: null
 # Stoichiometry
 n_atoms: null
 

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -692,7 +692,9 @@ class SpaceGroup(GFlowNetEnv):
         sg_subset = set(sg_subset)
 
         # Update self.space_groups
-        self.space_groups = [sg for sg in self.space_groups if sg in sg_subset]
+        self.space_groups = {
+            k: v for (k, v) in self.space_groups.items() if k in sg_subset
+        }
 
         # Update self.crystal_lattice_systems based on space groups
         self.crystal_lattice_systems = deepcopy(self.crystal_lattice_systems)

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -726,7 +726,7 @@ class SpaceGroup(GFlowNetEnv):
         for ps in ps_to_remove:
             del self.point_symmetries[ps]
 
-        # Update self.crystal_lattice_systems based on point symmetries
+        # Update point symmetries of remaining crystal lattice systems
         point_symmetries = set(self.point_symmetries)
         for cls in self.crystal_lattice_systems:
             cls_point_symmetries = point_symmetries.intersection(
@@ -736,7 +736,7 @@ class SpaceGroup(GFlowNetEnv):
                 cls_point_symmetries
             )
 
-        # Update self.point_symmetries based on crystal lattice systems
+        # Update crystal lattice systems of remaining point symmetries
         crystal_lattice_systems = set(self.crystal_lattice_systems)
         for ps in self.point_symmetries:
             ps_crystal_lattice_systems = crystal_lattice_systems.intersection(

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -727,36 +727,24 @@ class SpaceGroup(GFlowNetEnv):
             del self.point_symmetries[ps]
 
         # Update self.crystal_lattice_systems based on point symmetries
-        cls_to_remove = []
         point_symmetries = set(self.point_symmetries)
         for cls in self.crystal_lattice_systems:
             cls_point_symmetries = point_symmetries.intersection(
                 set(self.crystal_lattice_systems[cls]["point_symmetries"])
             )
-            if len(cls_point_symmetries) == 0:
-                cls_to_remove.append(cls)
-            else:
-                self.crystal_lattice_systems[cls]["point_symmetries"] = list(
-                    cls_point_symmetries
-                )
-        for cls in cls_to_remove:
-            del self.crystal_lattice_systems[cls]
+            self.crystal_lattice_systems[cls]["point_symmetries"] = list(
+                cls_point_symmetries
+            )
 
-        # Update self.point_symmetries based on point symmetries
-        ps_to_remove = []
+        # Update self.point_symmetries based on crystal lattice systems
         crystal_lattice_systems = set(self.crystal_lattice_systems)
         for ps in self.point_symmetries:
             ps_crystal_lattice_systems = crystal_lattice_systems.intersection(
                 set(self.point_symmetries[ps]["crystal_lattice_systems"])
             )
-            if len(ps_crystal_lattice_systems) == 0:
-                ps_to_remove.append(ps)
-            else:
-                self.point_symmetries[ps]["crystal_lattice_systems"] = list(
-                    ps_crystal_lattice_systems
-                )
-        for ps in ps_to_remove:
-            del self.point_symmetries[ps]
+            self.point_symmetries[ps]["crystal_lattice_systems"] = list(
+                ps_crystal_lattice_systems
+            )
 
     def get_all_terminating_states(
         self, apply_stoichiometry_constraints: Optional[bool] = True

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -726,38 +726,6 @@ class SpaceGroup(GFlowNetEnv):
         for ps in ps_to_remove:
             del self.point_symmetries[ps]
 
-        # Update self.crystal_lattice_systems based on point symmetries
-        cls_to_remove = []
-        point_symmetries = set(self.point_symmetries)
-        for cls in self.crystal_lattice_systems:
-            cls_point_symmetries = point_symmetries.intersection(
-                set(self.crystal_lattice_systems[cls]["point_symmetries"])
-            )
-            if len(cls_point_symmetries) == 0:
-                cls_to_remove.append(cls)
-            else:
-                self.crystal_lattice_systems[cls]["point_symmetries"] = list(
-                    cls_point_symmetries
-                )
-        for cls in cls_to_remove:
-            del self.crystal_lattice_systems[cls]
-
-        # Update self.point_symmetries based on point symmetries
-        ps_to_remove = []
-        crystal_lattice_systems = set(self.crystal_lattice_systems)
-        for ps in self.point_symmetries:
-            ps_crystal_lattice_systems = crystal_lattice_systems.intersection(
-                set(self.point_symmetries[ps]["crystal_lattice_systems"])
-            )
-            if len(ps_crystal_lattice_systems) == 0:
-                ps_to_remove.append(ps)
-            else:
-                self.point_symmetries[ps]["crystal_lattice_systems"] = list(
-                    ps_crystal_lattice_systems
-                )
-        for ps in ps_to_remove:
-            del self.point_symmetries[ps]
-
     def get_all_terminating_states(
         self, apply_stoichiometry_constraints: Optional[bool] = True
     ) -> List[List]:

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -687,10 +687,7 @@ class SpaceGroup(GFlowNetEnv):
         sg_subset = set(sg_subset)
 
         # Update self.space_groups
-        self.space_groups = deepcopy(self.space_groups)
-        sg_to_remove = [sg for sg in self.space_groups if sg not in sg_subset]
-        for sg in sg_to_remove:
-            del self.space_groups[sg]
+        self.space_groups = [sg for sg in self.space_groups if sg in sg_subset]
 
         # Update self.crystal_lattice_systems based on space groups
         self.crystal_lattice_systems = deepcopy(self.crystal_lattice_systems)

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -726,6 +726,38 @@ class SpaceGroup(GFlowNetEnv):
         for ps in ps_to_remove:
             del self.point_symmetries[ps]
 
+        # Update self.crystal_lattice_systems based on point symmetries
+        cls_to_remove = []
+        point_symmetries = set(self.point_symmetries)
+        for cls in self.crystal_lattice_systems:
+            cls_point_symmetries = point_symmetries.intersection(
+                set(self.crystal_lattice_systems[cls]["point_symmetries"])
+            )
+            if len(cls_point_symmetries) == 0:
+                cls_to_remove.append(cls)
+            else:
+                self.crystal_lattice_systems[cls]["point_symmetries"] = list(
+                    cls_point_symmetries
+                )
+        for cls in cls_to_remove:
+            del self.crystal_lattice_systems[cls]
+
+        # Update self.point_symmetries based on point symmetries
+        ps_to_remove = []
+        crystal_lattice_systems = set(self.crystal_lattice_systems)
+        for ps in self.point_symmetries:
+            ps_crystal_lattice_systems = crystal_lattice_systems.intersection(
+                set(self.point_symmetries[ps]["crystal_lattice_systems"])
+            )
+            if len(ps_crystal_lattice_systems) == 0:
+                ps_to_remove.append(ps)
+            else:
+                self.point_symmetries[ps]["crystal_lattice_systems"] = list(
+                    ps_crystal_lattice_systems
+                )
+        for ps in ps_to_remove:
+            del self.point_symmetries[ps]
+
     def get_all_terminating_states(
         self, apply_stoichiometry_constraints: Optional[bool] = True
     ) -> List[List]:

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -97,6 +97,11 @@ class SpaceGroup(GFlowNetEnv):
         """
         Args
         ----
+        space_groups_subset : iterable
+            A subset of space group (international) numbers to which to restrict the
+            state space. If None (default), the entire set of 230 space groups is
+            considered.
+
         n_atoms : list of int (optional)
             A list with the number of atoms per element, used to compute constraints on
             the space group. 0's are removed from the list. If None, composition/space


### PR DESCRIPTION
This may become useful for practical applications, but it will be now immediately handy for debugging.

I have made other changes motivated or required by the inclusion of the restricted space groups. For example the enumeration with the properties.

- [x] Refactor rest of code by using `Prop` Enum. (done in a different PR https://github.com/alexhernandezgarcia/gflownet/pull/230 to facilitate reviewing)