### PR TITLE
[👶 PR] Improve Launcher to handle SLURM_TMPDIR

### DIFF
--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -9,8 +9,8 @@ usage: launch.py [-h] [--help-md] [--job_name JOB_NAME] [--outdir OUTDIR]
                  [--cpus_per_task CPUS_PER_TASK] [--mem MEM] [--gres GRES]
                  [--partition PARTITION] [--modules MODULES]
                  [--conda_env CONDA_ENV] [--venv VENV] [--template TEMPLATE]
-                 [--code_dir CODE_DIR] [--jobs JOBS] [--dry-run] [--verbose]
-                 [--force]
+                 [--code_dir CODE_DIR] [--git_checkout GIT_CHECKOUT]
+                 [--jobs JOBS] [--dry-run] [--verbose] [--force]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -35,6 +35,11 @@ optional arguments:
                         $root/mila/sbatch/template-conda.sh
   --code_dir CODE_DIR   cd before running main.py (defaults to here). Defaults
                         to $root
+  --git_checkout GIT_CHECKOUT
+                        Branch or commit to checkout before running the code.
+                        This is only used if --code_dir='$SLURM_TMPDIR'. If
+                        not specified, the current branch is used. Defaults to
+                        None
   --jobs JOBS           jobs (nested) file name in external/jobs (with or
                         without .yaml). Or an absolute path to a yaml file
                         anywhere Defaults to None
@@ -54,6 +59,7 @@ conda_env     : gflownet
 cpus_per_task : 2
 dry-run       : False
 force         : False
+git_checkout  : None
 gres          : gpu:1
 job_name      : gflownet
 jobs          : None

--- a/mila/launch.py
+++ b/mila/launch.py
@@ -607,7 +607,7 @@ if __name__ == "__main__":
             sbatch_path.parent.mkdir(parents=True, exist_ok=True)
             # write template
             sbatch_path.write_text(templated)
-            print(f"  🏷  Created ./{sbatch_path.relative_to(Path.cwd())}")
+            print(f"\n  🏷  Created ./{sbatch_path.relative_to(Path.cwd())}")
             # Submit job to SLURM
             out = popen(f"sbatch {sbatch_path}").read()
             # Identify printed-out job id

--- a/mila/launch.py
+++ b/mila/launch.py
@@ -13,7 +13,7 @@ from yaml import safe_load
 
 ROOT = Path(__file__).resolve().parent.parent
 
-DIRTY_REPO_OK = False
+GIT_WARNING = False
 
 HELP = dedent(
     """
@@ -341,31 +341,26 @@ def print_md_help(parser, defaults):
 
 
 def code_dir_for_slurm_tmp_dir_checkout(git_checkout):
-    global DIRTY_REPO_OK
+    global GIT_WARNING
 
     repo = Repo(ROOT)
     if git_checkout is None:
         git_checkout = repo.active_branch.name
-        if not DIRTY_REPO_OK:
+        if not GIT_WARNING:
             print("💥 Git warnings:")
             print(
                 f"  • `git_checkout` not provided. Using current branch: {git_checkout}"
             )
         # warn for uncommitted changes
-        if repo.is_dirty() and not DIRTY_REPO_OK:
+        if repo.is_dirty() and not GIT_WARNING:
             print(
                 "  • Your repo contains uncommitted changes. "
                 + "They will *not* be available when cloning happens within the job."
             )
-            if (
-                "y"
-                not in input(
-                    "Continue anyway, ignoring current changes? [y/N] "
-                ).lower()
-            ):
-                print("🛑 Aborted")
-                sys.exit(0)
-            DIRTY_REPO_OK = True
+        if "y" not in input("Continue anyway? [y/N] ").lower():
+            print("🛑 Aborted")
+            sys.exit(0)
+        GIT_WARNING = True
 
     return dedent(
         """\

--- a/mila/launch.py
+++ b/mila/launch.py
@@ -13,7 +13,7 @@ from yaml import safe_load
 
 ROOT = Path(__file__).resolve().parent.parent
 
-GIT_WARNING = False
+GIT_WARNING = True
 
 HELP = dedent(
     """
@@ -346,21 +346,21 @@ def code_dir_for_slurm_tmp_dir_checkout(git_checkout):
     repo = Repo(ROOT)
     if git_checkout is None:
         git_checkout = repo.active_branch.name
-        if not GIT_WARNING:
+        if GIT_WARNING:
             print("💥 Git warnings:")
             print(
                 f"  • `git_checkout` not provided. Using current branch: {git_checkout}"
             )
         # warn for uncommitted changes
-        if repo.is_dirty() and not GIT_WARNING:
+        if repo.is_dirty() and GIT_WARNING:
             print(
                 "  • Your repo contains uncommitted changes. "
                 + "They will *not* be available when cloning happens within the job."
             )
-        if "y" not in input("Continue anyway? [y/N] ").lower():
+        if GIT_WARNING and "y" not in input("Continue anyway? [y/N] ").lower():
             print("🛑 Aborted")
             sys.exit(0)
-        GIT_WARNING = True
+        GIT_WARNING = False
 
     return dedent(
         """\
@@ -368,6 +368,7 @@ def code_dir_for_slurm_tmp_dir_checkout(git_checkout):
         git clone {git_url} tpm-gflownet
         cd tpm-gflownet
         {git_checkout}
+        echo "Current commit: $(git rev-parse HEAD)"
     """
     ).format(
         git_url=repo.remotes.origin.url,

--- a/mila/launch.py
+++ b/mila/launch.py
@@ -340,6 +340,19 @@ def print_md_help(parser, defaults):
     print(HELP, end="")
 
 
+def ssh_to_https(url):
+    """
+    Converts a ssh git url to https.
+    Eg:
+    """
+    if "https://" in url:
+        return url
+    if "git@" in url:
+        path = url.split(":")[1]
+        return f"https://github.com/{path}"
+    raise ValueError(f"Could not convert {url} to https")
+
+
 def code_dir_for_slurm_tmp_dir_checkout(git_checkout):
     global GIT_WARNING
 
@@ -371,7 +384,7 @@ def code_dir_for_slurm_tmp_dir_checkout(git_checkout):
         echo "Current commit: $(git rev-parse HEAD)"
     """
     ).format(
-        git_url=repo.remotes.origin.url,
+        git_url=ssh_to_https(repo.remotes.origin.url),
         git_checkout=f"git checkout {git_checkout}" if git_checkout else "",
     )
 


### PR DESCRIPTION
`launch.py` now handles `code_dir: $SLURM_TMPDIR` or `--code_dir='$SLURM_TMPDIR'`

If this is used, the sbatch script will:
	1. `git clone` the repo
	2. `git checkout` whatever value is in `git_checkout:` or `--git_checkout=`. If `git_checkout` is empty, the current branch name is used


💥 **Warning:** from the command-line, **single quotes** are mandatory around `'$SLURM_TMPDIR'` otherwise bash will try to evaluate it instead of giving the raw string to Python

(From #224)