### PR TITLE
Speedup spacegroup checks

### DIFF
--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -15,6 +15,7 @@ from torch import Tensor
 from torchtyping import TensorType
 
 from gflownet.envs.base import GFlowNetEnv
+from gflownet.utils.crystals.pyxtal_cache import space_group_check_compatible
 
 CRYSTAL_LATTICE_SYSTEMS = None
 POINT_SYMMETRIES = None
@@ -676,7 +677,7 @@ class SpaceGroup(GFlowNetEnv):
         n_atoms = [n for n in n_atoms if n > 0]
         assert all([n > 0 for n in n_atoms])
         assert all([sg > 0 and sg <= 230 for sg in space_groups])
-        return {sg: Group(sg).check_compatible(n_atoms)[0] for sg in space_groups}
+        return {sg: space_group_check_compatible(sg, n_atoms) for sg in space_groups}
 
     def _restrict_space_groups(self, sg_subset: Optional[Iterable] = None):
         """

--- a/gflownet/envs/crystals/spacegroup.py
+++ b/gflownet/envs/crystals/spacegroup.py
@@ -10,7 +10,6 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 import numpy as np
 import torch
 import yaml
-from pyxtal.symmetry import Group
 from torch import Tensor
 from torchtyping import TensorType
 
@@ -643,18 +642,17 @@ class SpaceGroup(GFlowNetEnv):
 
         return len(space_groups) > 0
 
-    # TODO: this method is quite slow, consider improving efficiency.
     @staticmethod
     def build_n_atoms_compatibility_dict(
         n_atoms: List[int], space_groups: Iterable[int]
     ):
         """
         Obtains which space groups are compatible with the stoichiometry given as
-        argument (n_atoms). It relies on pyxtal's
-        pyxtal.symmetry.Group.check_compatible(). Note that True is stored only if both
-        is_compatible and has_freedom are True.
+        argument (n_atoms).
 
-        See: https://pyxtal.readthedocs.io/en/latest/pyxtal.symmetry.html
+        It relies on a function which, internally, calls pyxtal's
+        pyxtal.symmetry.Group.check_compatible(). Note that sometimes that pyxtal
+        is known to return invalid results.
 
         Args
         ----


### PR DESCRIPTION
This PR reuses the caching mechanism used by the composition environment to implement spacegroup checks and integrates it into the spacegroup environment to implement composition checks.

On a compute node, I get a speedup from 15s/itt to about 1.2s/itt so about a 12x speedup.