### PR TITLE
[👶 PR] Batched eval sampling

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -737,7 +737,7 @@ class GFlowNetAgent:
         # Create an environment for each data point and trajectory and set the state
         envs = []
         mult_indices = max(n_states, n_trajectories)
-        for state_idx, x in tqdm(enumerate(states_term)):
+        for state_idx, x in enumerate(tqdm(states_term)):
             for traj_idx in range(n_trajectories):
                 idx = int(mult_indices * state_idx + traj_idx)
                 env = self.env.copy().reset(idx)

--- a/gflownet/utils/common.py
+++ b/gflownet/utils/common.py
@@ -11,6 +11,8 @@ from hydra.utils import get_original_cwd, instantiate
 from omegaconf import OmegaConf
 from torchtyping import TensorType
 
+from gflownet.utils.policy import parse_policy_config
+
 
 def set_device(device: Union[str, torch.device]):
     if isinstance(device, torch.device):
@@ -102,58 +104,81 @@ def find_latest_checkpoint(ckpt_dir, pattern):
     return sorted(ckpts, key=lambda f: float(f.stem.split("iter")[1]))[-1]
 
 
-def load_gflow_net_from_run_path(run_path, device="cuda"):
-    device = str(device)
+def load_gflow_net_from_run_path(
+    run_path, no_wandb=True, print_config=False, device="cuda"
+):
     run_path = resolve_path(run_path)
     hydra_dir = run_path / ".hydra"
+
     with initialize_config_dir(
         version_base=None, config_dir=str(hydra_dir), job_name="xxx"
     ):
         config = compose(config_name="config")
+
+    if print_config:
         print(OmegaConf.to_yaml(config))
-    # Disable wandb
-    config.logger.do.online = False
+
+    if no_wandb:
+        # Disable wandb
+        config.logger.do.online = False
+
     # Logger
     logger = instantiate(config.logger, config, _recursive_=False)
     # The proxy is required in the env for scoring: might be an oracle or a model
     proxy = instantiate(
         config.proxy,
-        device=device,
+        device=config.device,
         float_precision=config.float_precision,
     )
     # The proxy is passed to env and used for computing rewards
     env = instantiate(
         config.env,
         proxy=proxy,
-        device=device,
+        device=config.device,
         float_precision=config.float_precision,
+    )
+    forward_config = parse_policy_config(config, kind="forward")
+    backward_config = parse_policy_config(config, kind="backward")
+    forward_policy = instantiate(
+        forward_config,
+        env=env,
+        device=config.device,
+        float_precision=config.float_precision,
+    )
+    backward_policy = instantiate(
+        backward_config,
+        env=env,
+        device=config.device,
+        float_precision=config.float_precision,
+        base=forward_policy,
     )
     gflownet = instantiate(
         config.gflownet,
-        device=device,
+        device=config.device,
         float_precision=config.float_precision,
         env=env,
         buffer=config.env.buffer,
+        forward_policy=forward_policy,
+        backward_policy=backward_policy,
         logger=logger,
     )
-    # Load final models
-    ckpt_dir = Path(run_path) / config.logger.logdir.ckpts
-    forward_latest = find_latest_checkpoint(
-        ckpt_dir, config.gflownet.policy.forward.checkpoint
-    )
+
+    # -------------------------------
+    # -----  Load final models  -----
+    # -------------------------------
+
+    ckpt = [f for f in run_path.rglob(config.logger.logdir.ckpts) if f.is_dir()][0]
+    forward_final = find_latest_checkpoint(ckpt, "pf")
     gflownet.forward_policy.model.load_state_dict(
-        torch.load(forward_latest, map_location=device)
+        torch.load(forward_final, map_location=set_device(device))
     )
     try:
-        backward_latest = find_latest_checkpoint(
-            ckpt_dir, config.gflownet.policy.backward.checkpoint
-        )
+        backward_final = find_latest_checkpoint(ckpt, "pb")
         gflownet.backward_policy.model.load_state_dict(
-            torch.load(backward_latest, map_location=device)
+            torch.load(backward_final, map_location=set_device(device))
         )
-    except AttributeError:
+    except ValueError:
         print("No backward policy found")
-
     return gflownet
 
 

--- a/scripts/eval_gflownet.py
+++ b/scripts/eval_gflownet.py
@@ -202,6 +202,8 @@ if __name__ == "__main__":
     _, override_args = parser.parse_known_args()
     parser = add_args(parser)
     args = parser.parse_args()
+    torch.set_grad_enabled(False)
     torch.set_num_threads(1)
+    print_args(args)
     main(args)
     sys.exit()

--- a/scripts/eval_gflownet.py
+++ b/scripts/eval_gflownet.py
@@ -65,6 +65,38 @@ def add_args(parser):
     return parser
 
 
+def get_batch_sizes(total, b=1):
+    """
+    Batches an iterable into chunks of size n and returns their expected lengths
+
+    Args:
+        total (int): total samples to produce
+        b (int): the batch size
+
+    Returns:
+        list: list of batch sizes
+    """
+    n = total // b
+    chunks = [b] * n
+    if total % b != 0:
+        chunks += [total % b]
+    return chunks
+
+
+def print_args(args):
+    """
+    Prints the arguments
+
+    Args:
+        args (argparse.Namespace): the parsed arguments
+    """
+    print("Arguments:")
+    darg = vars(args)
+    max_k = max([len(k) for k in darg])
+    for k in darg:
+        print(f"\t{k:{max_k}}: {darg[k]}")
+
+
 def set_device(device: str):
     if device.lower() == "cuda" and torch.cuda.is_available():
         return torch.device("cuda")

--- a/scripts/eval_gflownet.py
+++ b/scripts/eval_gflownet.py
@@ -36,6 +36,31 @@ def add_args(parser):
         type=int,
         help="Number of sequences to sample",
     )
+    parser.add_argument(
+        "--sampling_batch_size",
+        default=100,
+        type=int,
+        help="Number of samples to generate at a time to "
+        + "avoid memory issues. Will sum to n_samples.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        default=None,
+        type=str,
+        help="Path to output directory. If not provided, will use run_path.",
+    )
+    parser.add_argument(
+        "--print_config",
+        default=False,
+        action="store_true",
+        help="Print the config file",
+    )
+    parser.add_argument(
+        "--samples_only",
+        default=False,
+        action="store_true",
+        help="Only sample from the model, do not compute metrics",
+    )
     parser.add_argument("--device", default="cpu", type=str)
     return parser
 

--- a/scripts/eval_gflownet.py
+++ b/scripts/eval_gflownet.py
@@ -2,19 +2,18 @@
 Computes evaluation metrics and plots from a pre-trained GFlowNet model.
 """
 import pickle
+import shutil
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
 
-import hydra
-import torch
-from hydra import compose, initialize, initialize_config_dir
 import pandas as pd
-from omegaconf import OmegaConf
-from torch.distributions.categorical import Categorical
+import torch
+from tqdm import tqdm
 
-from gflownet.gflownet import GFlowNetAgent
-from gflownet.utils.policy import parse_policy_config
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from gflownet.utils.common import load_gflow_net_from_run_path
 
 
 def add_args(parser):
@@ -105,6 +104,14 @@ def set_device(device: str):
 
 
 def main(args):
+    gflownet = load_gflow_net_from_run_path(
+        run_path=args.run_path,
+        device=args.device,
+        no_wandb=True,
+        print_config=args.print_config,
+    )
+    env = gflownet.env
+
     base_dir = Path(args.output_dir or args.run_path)
 
     # ---------------------------------


### PR DESCRIPTION
* Move loading logic to pre-existing `gflownet.utils.common.load_gflow_net_from_run_path`
* batch sampling process using `tmp/` files

```
python scripts/eval_gflownet.py \
  --run_path /network/scratch/h/hernanga/logs/gflownet/workshop23/discrete-matbench/3682295/2023-09-28_00-25-46/ \
  --n_samples 10000 \
  --output_dir=/network/scratch/s/schmidtv/crystals/debug/3682295 \
  --sampling_batch_size=50 \
  --samples_only
```

Small detail in `gflownet.py`: `enumerate` is a generator so `tqdm(enumerate(...))` does not print a full-width progress bar as `tqdm` is not aware of the length of `enumerate(...)`. Simple fix: `enumerate(tqdm(...))` 😄

**Issue**

Not sure you want to fix this in this PR but testing a gflownet creates files (like `replay.pkl`) in the _current working directory_ and pollutes it, particularly dangerous when it's tracked by git.