### PR TITLE
Speedup neutral charge check

### DIFF
--- a/gflownet/envs/crystals/composition.py
+++ b/gflownet/envs/crystals/composition.py
@@ -617,16 +617,28 @@ class Composition(GFlowNetEnv):
             for i, num in enumerate(state)
             if num > 0
         ]
-        sum_diff_elem = []
 
-        for n, c in nums_charges:
-            charge_sums = []
-            for c_i in itertools.product(c, repeat=n):
-                charge_sums.append(sum(c_i))
-            sum_diff_elem.append(np.unique(charge_sums))
+        # Process all atoms one by one, gradually accumulating a set of all possible
+        # charge totals so far
+        poss_charge_sum = set([0])
+        while len(nums_charges) > 0:
+            num, charges = nums_charges[0]
 
-        poss_charge_sum = [
-            sum(combo) == 0 for combo in itertools.product(*sum_diff_elem)
-        ]
+            # Compute all possible charge totals that can be obtained by combining
+            # all the previous charge totals with all the possible charges for the
+            # current atom
+            new_poss_charge_sum = set()
+            for old_charge_sum in poss_charge_sum:
+                for element_charge in charges:
+                    new_poss_charge_sum.add(old_charge_sum + element_charge)
+            poss_charge_sum = new_poss_charge_sum
 
-        return any(poss_charge_sum)
+            # Remove the atom that was processed from nums_charges
+            if num == 1:
+                # Remove element from nums_charges
+                del nums_charges[0]
+            else:
+                # Remove one atom from this element
+                nums_charges[0] = (num - 1, charges)
+
+        return 0 in poss_charge_sum


### PR DESCRIPTION
This changes the algorithm used to validate that a composition can achieve a neutral charge.

The old algorithm would scale around `O(C**N)` with `N` the number of atoms and `C` the max number of possible charge values per atom. The proposed algorithm scales at about `O(N**2 * C**2)`.

I compared the two implementations using the same elements as in the current experiments ([1, 3, 6, 7, 8, 9, 12, 14, 15, 16, 17, 26]) and setting the numbers of atoms per element to [0, 0, 0, 0, 0, 0, 0, i, i, i, i, i] for various values of i.

Results (in seconds) : 

```
------
For i =  3
Old implementation :  0.002059459686279297
New implementation :  0.00014591217041015625
------
For i =  5
Old implementation :  0.011979341506958008
New implementation :  0.0001742839813232422
------
For i =  7
Old implementation :  0.04272580146789551
New implementation :  0.00034546852111816406
------
For i =  9
Old implementation :  0.610426664352417
New implementation :  0.0005359649658203125
------
For i =  11
Old implementation :  15.19710898399353
New implementation :  0.0007321834564208984
------
```
For i = 13, the old implementation gets killed
I've tested the new implementation until i = 39, at which it point takes 0.0078s to run.