### PR TITLE
Fix: get_logprobs of base env (reason why TB was not training well)

### DIFF
--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -546,7 +546,7 @@ class GFlowNetEnv:
         """
         device = policy_outputs.device
         ns_range = torch.arange(policy_outputs.shape[0]).to(device)
-        logits = policy_outputs.clone().detach()
+        logits = policy_outputs.clone()
         if mask is not None:
             logits[mask] = -torch.inf
         action_indices = (


### PR DESCRIPTION
The clone of `policy_outputs` into `logits` in `get_logprobs()` of the base environment was incorrectly detached, preventing the correct propagation of gradients.

Sanity checks seem fine now: https://wandb.ai/alexhg/gfn_sanity_checks

---

This was the commit to blame: https://github.com/alexhernandezgarcia/gflownet/pull/221/commits/67a8bc3128a5784f46f53b9e9c01f4bab5617672