### PR TITLE
Improvements to MillerIndices environment

### DIFF
--- a/gflownet/envs/crystals/miller.py
+++ b/gflownet/envs/crystals/miller.py
@@ -61,7 +61,7 @@ class MillerIndices(Grid):
         # on the mask to ensure that the trajectory doesn't end in an invalid state.
         if self.is_hexagonal_rhombohedral:
             # Extract the miller indices from the state
-            h, k, l = self.state2oracle(state)
+            h, k, l = [self.cells[s] for s in state]
 
             # Enforce that the trajectory ends in a state satisfying -2 <= h + k.
             # This requirement won't be satisfied at the beginning of the trajectory

--- a/gflownet/envs/crystals/miller.py
+++ b/gflownet/envs/crystals/miller.py
@@ -51,10 +51,8 @@ class MillerIndices(Grid):
             - True if the forward action is invalid from the current state.
             - False otherwise.
         """
-        if state is None:
-            state = self.state.copy()
-        if done is None:
-            done = self.done
+        state = self._get_state(state)
+        done = self._get_done(done)
 
         mask = super().get_mask_invalid_actions_forward(state, done)
 

--- a/gflownet/envs/crystals/miller.py
+++ b/gflownet/envs/crystals/miller.py
@@ -8,12 +8,12 @@ from gflownet.envs.grid import Grid
 
 class MillerIndices(Grid):
     """
-    The Miller indices are represented by either 3 parameters (h, k, l) if the
-    structure is cubic, or by 4 parameters (h, k, i, l) if the structure is hexagonal
-    or rhombohedral. However, for hexagonal and rhombohedral structures, there is
-    redundancy in the parameters. h, k and i are united by h + k + i = 0. As such,
-    even for hexagonal and rhombohedral structures, we only need to model 3 free
-    dimensions.
+    The Miller indices are represented by either 3 parameters (h, k, l) in general, or
+    by 4 parameters (h, k, i, l) if the structure is hexagonal or rhombohedral.
+    However, for hexagonal and rhombohedral structures, there is redundancy in the
+    parameters. h, k and i are united by h + k + i = 0. As such, even for hexagonal and
+    rhombohedral structures, we only need to model 3 free dimensions.
+
     Each parameter can take values in the set {-2, -1, 0, 1, 2}.
     Therefore, we can represent the Miller indices environment by a hyper cube of
     length 5, with dimensionality 3.

--- a/gflownet/envs/crystals/miller.py
+++ b/gflownet/envs/crystals/miller.py
@@ -1,6 +1,8 @@
 """
 Class to represent an environment to sample Miller indices (hkl).
 """
+from typing import List, Optional
+
 from gflownet.envs.grid import Grid
 
 
@@ -8,15 +10,18 @@ class MillerIndices(Grid):
     """
     The Miller indices are represented by either 3 parameters (h, k, l) if the
     structure is cubic, or by 4 parameters (h, k, i, l) if the structure is hexagonal
-    or rhombohedral. Each parameter can take values in the set {-2, -1, 0, 1, 2}.
+    or rhombohedral. However, for hexagonal and rhombohedral structures, there is
+    redundancy in the parameters. h, k and i are united by h + k + i = 0. As such,
+    even for hexagonal and rhombohedral structures, we only need to model 3 free
+    dimensions.
+    Each parameter can take values in the set {-2, -1, 0, 1, 2}.
     Therefore, we can represent the Miller indices environment by a hyper cube of
-    length 5, with dimensionality 3 or 4 depending on the structure.
+    length 5, with dimensionality 3.
 
     Attributes
     ----------
-    is_cubic : bool
-        True if the structure is cubic, False if the structure is hexagonal or
-        rhombohedral.
+    is_hexagonal_rhombohedral : bool
+        True if the structure is hexagonal or rhombohedral.
 
     max_increment : int
         Maximum increment of each dimension by the actions.
@@ -28,13 +33,58 @@ class MillerIndices(Grid):
 
     def __init__(
         self,
-        is_cubic: bool,
+        is_hexagonal_rhombohedral: bool,
         max_increment: int = 1,
         max_dim_per_action: int = 1,
         **kwargs,
     ):
-        if is_cubic:
-            n_dim = 3
-        else:
-            n_dim = 4
-        super().__init__(n_dim=n_dim, length=5, cell_min=-2, cell_max=2, **kwargs)
+        self.is_hexagonal_rhombohedral = is_hexagonal_rhombohedral
+        super().__init__(n_dim=3, length=5, cell_min=-2, cell_max=2, **kwargs)
+
+    def get_mask_invalid_actions_forward(
+        self,
+        state: Optional[List] = None,
+        done: Optional[bool] = None,
+    ) -> List:
+        """
+        Returns a list of length the action space with values:
+            - True if the forward action is invalid from the current state.
+            - False otherwise.
+        """
+        if state is None:
+            state = self.state.copy()
+        if done is None:
+            done = self.done
+
+        mask = super().get_mask_invalid_actions_forward(state, done)
+
+        # If the structure is hexagonal or rhombohedral, we need -2 <= h + k <= 2
+        # for the state to be valid. This means that we have to enforce constraints
+        # on the mask to ensure that the trajectory doesn't end in an invalid state.
+        if self.is_hexagonal_rhombohedral:
+            # Extract the miller indices from the state
+            h, k, l = self.state2oracle(state)
+
+            # Enforce that the trajectory ends in a state satisfying -2 <= h + k.
+            # This requirement won't be satisfied at the beginning of the trajectory
+            # so we enforce it by disabling the EOS action until the condition is
+            # met. This will force the agent to increment h and/or k until the
+            # condition is, inevitably, satisfied.
+            if h + k < -2:
+                index_eos = self.action_space.index(self.eos)
+                mask[index_eos] = True
+
+            # Enforce that the trajectory ends in a state satisfying h + k <= 2.
+            # This condition is satisfied at the environment's initial state. And
+            # since the environment only offers actions that increment the miller
+            # indices, it means that if the environment ever gets to a state that
+            # DOESN'T satisfy this condition, there is no way to go back to a state
+            # that does. Therefore we enforce this constraint by disabling the
+            # actions that would lead to states that don't satisfy this condition.
+            for action_idx, action in enumerate(self.action_space):
+                increment_h, increment_k, increment_l = action
+                new_sum_h_k = h + increment_h + k + increment_k
+                if new_sum_h_k > 2:
+                    mask[action_idx] = True
+
+        return mask

--- a/tests/gflownet/envs/test_miller.py
+++ b/tests/gflownet/envs/test_miller.py
@@ -5,13 +5,13 @@ from gflownet.envs.crystals.miller import MillerIndices
 
 
 @pytest.fixture
-def cubic():
-    return MillerIndices(is_cubic=True)
+def hexa_rhombo():
+    return MillerIndices(is_hexagonal_rhombohedral=True)
 
 
 @pytest.fixture
-def nocubic():
-    return MillerIndices(is_cubic=False)
+def no_hexa_rhombo():
+    return MillerIndices(is_hexagonal_rhombohedral=False)
 
 
 @pytest.mark.parametrize(
@@ -39,46 +39,44 @@ def nocubic():
         ),
     ],
 )
-def test__state2oracle__cubic__returns_expected(cubic, state, state2oracle):
-    env = cubic
-    assert state2oracle == env.state2oracle(state)
+def test__state2oracle__returns_expected(
+    hexa_rhombo, no_hexa_rhombo, state, state2oracle
+):
+    assert state2oracle == hexa_rhombo.state2oracle(state)
+    assert state2oracle == no_hexa_rhombo.state2oracle(state)
 
 
 @pytest.mark.parametrize(
-    "state, state2oracle",
+    "env_input, state, action, is_action_valid",
     [
-        (
-            [0, 0, 0, 0],
-            [-2.0, -2.0, -2.0, -2.0],
-        ),
-        (
-            [4, 4, 4, 4],
-            [2.0, 2.0, 2.0, 2.0],
-        ),
-        (
-            [2, 2, 2, 2],
-            [0.0, 0.0, 0.0, 0.0],
-        ),
-        (
-            [0, 2, 0, 2],
-            [-2.0, 0.0, -2.0, 0.0],
-        ),
-        (
-            [2, 1, 3, 0],
-            [0.0, -1.0, 1.0, -2.0],
-        ),
+        ("no_hexa_rhombo", [0, 0, 0], (0, 0, 0), True),
+        ("no_hexa_rhombo", [2, 2, 2], (0, 0, 0), True),
+        ("no_hexa_rhombo", [4, 4, 4], (0, 0, 0), True),
+        ("no_hexa_rhombo", [3, 3, 2], (1, 0, 0), True),
+        ("no_hexa_rhombo", [3, 3, 2], (0, 1, 0), True),
+        ("no_hexa_rhombo", [3, 3, 2], (0, 0, 1), True),
+        ("hexa_rhombo", [0, 0, 0], (0, 0, 0), False),
+        ("hexa_rhombo", [2, 2, 2], (0, 0, 0), True),
+        ("hexa_rhombo", [4, 4, 4], (0, 0, 0), False),
+        ("hexa_rhombo", [3, 3, 2], (1, 0, 0), False),
+        ("hexa_rhombo", [3, 3, 2], (0, 1, 0), False),
+        ("hexa_rhombo", [3, 3, 2], (0, 0, 1), True),
     ],
 )
-def test__state2oracle__nocubic__returns_expected(nocubic, state, state2oracle):
-    env = nocubic
-    assert state2oracle == env.state2oracle(state)
+def test_get_mask_invalid_actions_forward__masks_expected_actions(
+    env_input, state, action, is_action_valid, request
+):
+    env = request.getfixturevalue(env_input)
+    env.set_state(state, done=False)
+    _, _, valid = env.step(action)
+    assert is_action_valid == valid
 
 
-def test__all_env_common__cubic(cubic):
-    print("\n\nCommon tests for cubic Miller indices\n")
-    return common.test__all_env_common(cubic)
-
-
-def test__all_env_common__nocubic(nocubic):
+def test__all_env_common__hexagonal_rhombohedral(hexa_rhombo):
     print("\n\nCommon tests for hexagonal or rhombohedral Miller indices\n")
-    return common.test__all_env_common(nocubic)
+    return common.test__all_env_common(hexa_rhombo)
+
+
+def test__all_env_common__no_hexagonal_rhombohedral(no_hexa_rhombo):
+    print("\n\nCommon tests for non-{hexagonal, rhombohedral} Miller indices\n")
+    return common.test__all_env_common(no_hexa_rhombo)


### PR DESCRIPTION
This PR aims to implement the improvements mentioned in #207. It does the following : 
- [x] Renames the `is_cubic` argument of the MillerIndices class to something more meaningful
- [x] Make the number of dimensions equal to 3 whatever the structure type. For non-{hexagonal, rhombohedral} structures, the dimensions correspond to miller indices `h`, `k` and `i`. For {hexagonal, rhombohedral} structures, there are 4 miller indices (`h`, `k`, `i` and `l`) but there is redundancy between the first three so we only need to pick  `h`, `k` and `l`.
- [x] Adds some constraints to the mask for forward actions to prevent a trajectory ending in a state that would be invalid (for hexagonal and rhombohedral structures only)
- [x] Adapts the existing unit tests for the MillerIndices class and adds some new one to validate the new constraints 


The state constraints for hexagonal and rhombohedral structures are derived from the following relationship : `h + k + i = 0`. And since `i` can only take a value in {-2, -1, 0, 1, 2}, this implies the following constraints on `h` and `k` : `-2 <= h + k` and `h + k <= 2`.

- The first constraint is implemented by preventing the EOS action if `-2 <= h + k` is not satisfied. Since the agent can only increment (not decrement) the dimensions of the state, it will eventually land in a state that will satisfy this constraint.
- The second constraint is implemented by preventing actions that will lead to a state where `h + k <= 2` is not true. Since it is only possible to increment one dimension at a time and only by 1 at a time, the agent is guaranteed to be in a valid state when this constraint kicks in and starts preventing certain actions. Therefore, the EOS action will be available for the agent to take.


```
Whether or not a state satisfies both constraints based only on the values of h and k : 
   2   .   .   .   x   x
   1   .   .   .   .   x
h  0   .   .   .   .   .
  -1   x   .   .   .   .
  -2   x   x   .   .   .
k     -2  -1   0   1   2
```
