### PR TITLE
Fix issues from merge of PR #254

### DIFF
--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -939,7 +939,7 @@ class Batch:
         """
         # This will not work if source is randomised
         if not self.conditional:
-            source_proxy = self.env.state2proxy(self.env.source)
+            source_proxy = torch.unsqueeze(self.env.state2proxy(self.env.source), dim=0)
             reward_source = self.env.proxy2reward(self.env.proxy(source_proxy))
             self.rewards_source = reward_source.expand(len(self))
         else:

--- a/tests/gflownet/utils/test_batch.py
+++ b/tests/gflownet/utils/test_batch.py
@@ -1274,7 +1274,9 @@ def test__get_rewards_multiple_env_returns_expected_non_zero_non_terminating(
                 actions_iter.append(action)
                 valids_iter.append(valid)
                 rewards.append(env.reward(do_non_terminating=True))
-                proxy_values.append(env.proxy(env.state2proxy(env.state))[0])
+                proxy_values.append(
+                    env.proxy(torch.unsqueeze(env.state2proxy(env.state), dim=0))[0]
+                )
         # Add all envs, actions and valids to batch
         batch.add_to_batch(envs, actions_iter, valids_iter)
         # Remove done envs

--- a/tests/gflownet/utils/test_batch.py
+++ b/tests/gflownet/utils/test_batch.py
@@ -1354,12 +1354,16 @@ def test__get_rewards_parents_multiple_env_returns_expected_non_terminating(
     rewards_batch = batch.get_rewards(do_non_terminating=True)
     rewards = torch.stack(rewards)
 
-    assert torch.equal(
-        rewards_parents_batch,
-        tfloat(rewards_parents, device=batch.device, float_type=batch.float),
+    assert torch.all(
+        torch.isclose(
+            rewards_parents_batch,
+            tfloat(rewards_parents, device=batch.device, float_type=batch.float),
+        )
     ), (rewards_parents, rewards_parents_batch)
 
-    assert torch.equal(
-        rewards_batch,
-        tfloat(rewards, device=batch.device, float_type=batch.float),
+    assert torch.all(
+        torch.isclose(
+            rewards_batch,
+            tfloat(rewards, device=batch.device, float_type=batch.float),
+        )
     ), (rewards, rewards_batch)


### PR DESCRIPTION
Fixes two issues from the merge of PR https://github.com/alexhernandezgarcia/gflownet/pull/253:
- The input to the proxy must, in general, be a batch tensor, not a single state.
- One test used `torch.equal` but did fail most times. Changed to `torch.all(torch.isclose(...))`.