### PR TITLE
Fix crystals setup

### DIFF
--- a/setup/crystals.sh
+++ b/setup/crystals.sh
@@ -5,7 +5,7 @@
 # $1: Environment name
 #
 module --force purge
-module load python/3.8
+module load python/3.9
 module load cuda/11.7
 python -m virtualenv $1
 source $1/bin/activate


### PR DESCRIPTION
The setup file for crystals didn't work because it used python 3.8 which is too old for DAVE (it requires >=3.9). I've updated it to 3.9 and now it works for me