### PR TITLE
Fix and improve backward sampling from data set and replay buffer

### DIFF
--- a/config/gflownet/gflownet.yaml
+++ b/config/gflownet/gflownet.yaml
@@ -49,6 +49,8 @@ pct_offline: 0.0
 # Replay buffer
 replay_capacity: 0
 replay_sampling: permutation
+# Train data set backward sampling
+train_sampling: permutation
 num_empirical_loss: 200000
 oracle:
     # Number of samples for oracle metrics

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -273,8 +273,11 @@ class Buffer:
     def select(data_dict: dict, n: int, mode: str = "permutation", rng=None):
         if n == 0:
             return []
-        # TODO: need list()?
         samples = data_dict["x"]
+        # If the data_dict comes from the replay buffer, then samples is a dict and we
+        # need to keep its values only
+        if isinstance(samples, dict):
+            samples = list(samples.values())
         if mode == "permutation":
             assert rng is not None
             samples = [samples[idx] for idx in rng.permutation(n)]
@@ -285,8 +288,11 @@ class Buffer:
                 score = "energy"
             else:
                 raise ValueError(f"Data set does not contain reward or energy key.")
-            # TODO: need fromiter()?
-            scores = np.fromiter(data_dict[score], dtype=float)
+            scores = data_dict[score]
+            # If the data_dict comes from the replay buffer, then scores is a dict and we
+            # need to keep its values only
+            if isinstance(scores, dict):
+                scores = np.fromiter(scores.values(), dtype=float)
             indices = np.random.choice(
                 len(samples),
                 size=n,

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -271,14 +271,22 @@ class Buffer:
 
     @staticmethod
     def select(data_dict: dict, n: int, mode: str = "permutation", rng=None):
+        if n == 0:
+            return []
         # TODO: need list()?
         samples = data_dict["x"]
         if mode == "permutation":
             assert rng is not None
             samples = [samples[idx] for idx in rng.permutation(n)]
-        elif mode in ["energy", "rewards"]:
+        elif mode == "weighted":
+            if "rewards" in data_dict:
+                score = "rewards"
+            elif "energy" in data_dict:
+                score = "energy"
+            else:
+                raise ValueError(f"Data set does not contain reward or energy key.")
             # TODO: need fromiter()?
-            scores = np.fromiter(data_dict[mode], dtype=float)
+            scores = np.fromiter(data_dict[score], dtype=float)
             indices = np.random.choice(
                 len(samples),
                 size=n,

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -1,6 +1,7 @@
 """
 Buffer class to handle train and test data sets, reply buffer, etc.
 """
+
 import pickle
 
 import numpy as np
@@ -270,7 +271,39 @@ class Buffer:
         return mean_data, std_data, min_data, max_data, max_norm_data
 
     @staticmethod
-    def select(data_dict: dict, n: int, mode: str = "permutation", rng=None):
+    def select(
+        data_dict: dict,
+        n: int,
+        mode: str = "permutation",
+        rng: np.random.Generator = None,
+    ):
+        """
+        Selects a subset of n data points from data_dict, according to the criterion
+        indicated by mode.
+
+        The data dict may be a training set or a replay buffer.
+
+        The mode argument can be one of the following:
+            - permutation: data points are sampled uniformly from the dictionary, using
+              the random generator rng.
+            - weighted: data points are sampled with probability proportional to their
+              score.
+
+        Args
+        ----
+        data_dict : dict
+            A dictionary with samples (key "x") and scores (key "energy" or "rewards").
+
+        n : int
+            The number of samples to select from the dictionary.
+
+        mode : str
+            Sampling mode. Options: permutation, weighted.
+
+        rng : np.random.Generator
+            A numpy random number generator, used for the permutation mode. Ignored
+            otherwise.
+        """
         if n == 0:
             return []
         samples = data_dict["x"]

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -276,7 +276,7 @@ class Buffer:
         n: int,
         mode: str = "permutation",
         rng: np.random.Generator = None,
-    ):
+    ) -> List:
         """
         Selects a subset of n data points from data_dict, according to the criterion
         indicated by mode.

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -303,6 +303,11 @@ class Buffer:
         rng : np.random.Generator
             A numpy random number generator, used for the permutation mode. Ignored
             otherwise.
+
+        Returns
+        -------
+        list
+            A batch of n samples, selected from data_dict.
         """
         if n == 0:
             return []


### PR DESCRIPTION
This PR unifies the functionality to sample and construct a batch from a buffer (replay buffer or training data set) into a common Buffer method, `select()`.

### Tests
- [x] `python -m pytest ./tests/`