### PR TITLE
pyshtools==4.10.3 in toml to fix BLAS issue in installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ pyxtal = {version = ">=0.6.1", optional = true }
 # This really should be named activelearningproxy
 dave = { git = "https://github.com/sh-divya/ActiveLearningMaterials.git", rev = "0.3.4", optional = true }
 # TODO: Fails due to BLAS error.. why?
-pyshtools = {version = ">=4.10.3", optional = true }
+pyshtools = {version = "==4.10.3", optional = true }
 
 # Molecules.
 # TODO: Remove Handled (for now) via a specialized script.


### PR DESCRIPTION
The following commands, in the present branch, seem to install the Python environment in the Mila cluster without issues:
```
module --force purge
module load python/3.10
module load cuda/11.8
python -m virtualenv ~/tmpenv
source ~/tmpenv/bin/activate
source ./prereq_python.sh
source ./prereq_geometric.sh
python -m pip install -e .[all]
```