### PR TITLE
[Tiny] Fix scrabble test

### DIFF
--- a/tests/gflownet/envs/common.py
+++ b/tests/gflownet/envs/common.py
@@ -253,6 +253,7 @@ class BaseTestsCommon:
             while not self.env.done:
                 state, action, valid = self.env.step_random(backward=False)
                 if valid:
+                    # Copy prevents mutation by next step.
                     states_trajectory_fw.append(copy(state))
                     actions_trajectory_fw.append(action)
 
@@ -265,6 +266,7 @@ class BaseTestsCommon:
                     actions_trajectory_fw_copy.pop()
                 )
                 if valid:
+                    # Copy prevents mutation by next step.
                     states_trajectory_bw.append(copy(state))
                     actions_trajectory_bw.append(action)
 

--- a/tests/gflownet/envs/common.py
+++ b/tests/gflownet/envs/common.py
@@ -244,7 +244,7 @@ class BaseTestsCommon:
             while not self.env.done:
                 state, action, valid = self.env.step_random(backward=False)
                 if valid:
-                    states_trajectory_fw.append(state)
+                    states_trajectory_fw.append(copy(state))
                     actions_trajectory_fw.append(action)
 
             # Sample backward trajectory with actions in forward trajectory
@@ -256,7 +256,7 @@ class BaseTestsCommon:
                     actions_trajectory_fw_copy.pop()
                 )
                 if valid:
-                    states_trajectory_bw.append(state)
+                    states_trajectory_bw.append(copy(state))
                     actions_trajectory_bw.append(action)
 
             assert all(

--- a/tests/gflownet/envs/common.py
+++ b/tests/gflownet/envs/common.py
@@ -1,3 +1,12 @@
+"""
+Tests common to all environments.
+
+Note that copying the state is necessary in some tests to preserve specific values of
+the state. This is necessary because in some environments the state is a list which is
+updated when an action is applied. Therefore, if the tests needs to keep older values
+of the state, for example in test__trajectories_are_reversible(), a copy is needed.
+"""
+
 import inspect
 import warnings
 

--- a/tests/gflownet/envs/test_scrabble.py
+++ b/tests/gflownet/envs/test_scrabble.py
@@ -143,6 +143,5 @@ class TestScrabbleCommon(common.BaseTestsDiscrete):
         self.env = env
         self.repeats = {
             "test__reset__state_is_source": 10,
-            "test__trajectories_are_reversible": 0,  # TODO: failing.
         }
         self.n_states = {}  # TODO: Populate.


### PR DESCRIPTION
One of the Scrabble tests was disabled in a previous PR because it was failing. This PR fixes it. The reason for the fail was that the state had to be copied because the method `step()` of the Scrabble env does not copy the state unlike other envs.