### PR TITLE
Speedup batch _compute_parents()

### DIFF
--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -556,7 +556,10 @@ class Batch:
         """
         self.parents = []
         self.parents_indices = []
-        indices = []
+
+        indices_dict = {}
+        indices_next = 0
+
         # Iterate over the trajectories to obtain the parents from the states
         for traj_idx, batch_indices in self.trajectories.items():
             # parent is source
@@ -567,12 +570,18 @@ class Batch:
             # TODO: check if tensor and sort without iter
             self.parents.extend([self.states[idx] for idx in batch_indices[:-1]])
             self.parents_indices.extend(batch_indices[:-1])
-            indices.extend(batch_indices)
+
+            # Store the indices required to reorder the parents lists in the same
+            # order as the states
+            for b_idx in batch_indices:
+                indices_dict[b_idx] = indices_next
+                indices_next += 1
+
         # Sort parents list in the same order as states
         # TODO: check if tensor and sort without iter
-        self.parents = [self.parents[indices.index(idx)] for idx in range(len(self))]
+        self.parents = [self.parents[indices_dict[idx]] for idx in range(len(self))]
         self.parents_indices = tlong(
-            [self.parents_indices[indices.index(idx)] for idx in range(len(self))],
+            [self.parents_indices[indices_dict[idx]] for idx in range(len(self))],
             device=self.device,
         )
         self.parents_available = True

--- a/tests/gflownet/envs/common.py
+++ b/tests/gflownet/envs/common.py
@@ -66,7 +66,6 @@ class BaseTestsCommon:
     def test__sample_actions__backward__returns_eos_if_done(
         self, n_repeat=1, n_states=5
     ):
-
         if _get_current_method_name() in self.n_states:
             n_states = self.n_states[_get_current_method_name()]
 
@@ -96,7 +95,6 @@ class BaseTestsCommon:
     def test__get_logprobs__backward__returns_zero_if_done(
         self, n_repeat=1, n_states=5
     ):
-
         if _get_current_method_name() in self.n_states:
             n_states = self.n_states[_get_current_method_name()]
 
@@ -161,7 +159,6 @@ class BaseTestsCommon:
     def test__backward_actions_have_nonzero_forward_prob(
         self, n_repeat=1, n_states=100
     ):
-
         if _get_current_method_name() in self.n_states:
             n_states = self.n_states[_get_current_method_name()]
 
@@ -398,7 +395,6 @@ class BaseTestsDiscrete(BaseTestsCommon):
     def test__get_parents__returns_same_state_and_eos_if_done(
         self, n_repeat=1, n_states=10
     ):
-
         if _get_current_method_name() in self.n_states:
             n_states = self.n_states[_get_current_method_name()]
 


### PR DESCRIPTION
This PR speeds up the way the parents lists are reordered in Batch._compute_parents()

This is done by accumulating the indices needed for reordering in a dictionary rather than a list. This makes the reordering operations scale in O(N) instead of O(N^2) which is much more efficient for very large batches.

For the hcube/corners.yaml experiment (after the speedups to the Set environment in a different PR), it's about a 15-20% speedup and it's likely to be more for environments with longer sequences like the crystal env.