### PR TITLE
Changes to handling of log directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ python main.py gflownet=trajectorybalance env=ctorus proxy=torus
 
 The above command will overwrite the `env` and `proxy` default configuration with the configuration files in `config/env/ctorus.yaml` and `config/proxy/torus.yaml` respectively.
 
+Note that by default, PyTorch will operate on the CPU because we have not observed performance improvements by running on the GPU. You may run on GPU with `device=cuda`.
+
 Hydra configuration is hierarchical. For instance, a handy variable to change while debugging our code is to avoid logging to wandb. You can do this by setting `logger.do.online=False`.
 
 ## GFlowNet loss functions

--- a/config/experiments/ccube/corners.yaml
+++ b/config/experiments/ccube/corners.yaml
@@ -7,7 +7,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: corners
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:
@@ -68,4 +67,4 @@ logger:
 # Hydra
 hydra:
   run:
-    dir: ${user.logdir.root}/debug/ccube/${now:%Y-%m-%d_%H-%M-%S}
+    dir: ${user.logdir.root}/ccube/${now:%Y-%m-%d_%H-%M-%S}

--- a/config/experiments/ccube/uniform.yaml
+++ b/config/experiments/ccube/uniform.yaml
@@ -7,7 +7,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: uniform
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:

--- a/config/experiments/clatticeparams/clatticeparams_owl.yaml
+++ b/config/experiments/clatticeparams/clatticeparams_owl.yaml
@@ -5,7 +5,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: corners
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:
@@ -76,4 +75,4 @@ logger:
 # Hydra
 hydra:
   run:
-    dir: ${user.logdir.root}/debug/ccube/${now:%Y-%m-%d_%H-%M-%S}
+    dir: ${user.logdir.root}/latticeparameters/${now:%Y-%m-%d_%H-%M-%S}

--- a/config/experiments/icml23/ctorus.yaml
+++ b/config/experiments/icml23/ctorus.yaml
@@ -5,7 +5,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: torus
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:

--- a/config/experiments/icml23/dtorus.yaml
+++ b/config/experiments/icml23/dtorus.yaml
@@ -5,7 +5,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: torus
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:

--- a/config/experiments/icml23/htorus.dryrun.yaml
+++ b/config/experiments/icml23/htorus.dryrun.yaml
@@ -5,7 +5,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: torus
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:

--- a/config/experiments/icml23/htorus.yaml
+++ b/config/experiments/icml23/htorus.yaml
@@ -5,7 +5,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: torus
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:

--- a/config/experiments/scrabble/jay.yaml
+++ b/config/experiments/scrabble/jay.yaml
@@ -7,7 +7,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: scrabble
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:
@@ -69,4 +68,4 @@ logger:
 # Hydra
 hydra:
   run:
-    dir: ${user.logdir.root}/debug/ccube/${now:%Y-%m-%d_%H-%M-%S}
+    dir: ${user.logdir.root}/ccube/${now:%Y-%m-%d_%H-%M-%S}

--- a/config/experiments/scrabble/penguin.yaml
+++ b/config/experiments/scrabble/penguin.yaml
@@ -7,7 +7,6 @@ defaults:
    - override /gflownet: trajectorybalance
    - override /proxy: scrabble
    - override /logger: wandb
-   - override /user: alex
 
 # Environment
 env:
@@ -69,4 +68,4 @@ logger:
 # Hydra
 hydra:
   run:
-    dir: ${user.logdir.root}/debug/ccube/${now:%Y-%m-%d_%H-%M-%S}
+    dir: ${user.logdir.root}/ccube/${now:%Y-%m-%d_%H-%M-%S}

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -1,14 +1,14 @@
 defaults:
   - _self_
   - env: grid
-  - gflownet: flowmatch
+  - gflownet: trajectorybalance
   - policy: mlp_${gflownet}
-  - proxy: corners
+  - proxy: uniform
   - logger: wandb
   - user: default
 
 # Device
-device: cuda
+device: cpu
 # Float precision
 float_precision: 32
 # Number of objects to sample at the end of training
@@ -19,11 +19,12 @@ seed: 0
 # Hydra config
 hydra:
   # See: https://hydra.cc/docs/configure_hydra/workdir/
+  # See: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
   run:
-    dir: ${user.logdir.root}/${now:%Y-%m-%d_%H-%M-%S}
+    dir: ${user.logdir.root}/${oc.env:SLURM_JOB_ID,local}/${now:%Y-%m-%d_%H-%M-%S_%f}
   sweep:
-    dir: ${user.logdir.root}/multirun/${now:%Y-%m-%d_%H-%M-%S}
+    dir: ${user.logdir.root}/${oc.env:SLURM_JOB_ID,local}/multirun/${now:%Y-%m-%d_%H-%M-%S_%f}
   job:
     # See: https://hydra.cc/docs/upgrades/1.1_to_1.2/changes_to_job_working_dir/
     # See: https://hydra.cc/docs/tutorials/basic/running_your_app/working_directory/#disable-changing-current-working-dir-to-jobs-output-dir
-    chdir: True
+    chdir: False

--- a/config/user/default.yaml
+++ b/config/user/default.yaml
@@ -1,5 +1,5 @@
 logdir:
-  root: ~/gflownet/logs
+  root: ./logs
 data:
-  root: ~/gflownet/data
+  root: ./data
   alanine_dipeptide: ~/gflownet/data/alanine_dipeptide_conformers_1.npy

--- a/gflownet/utils/common.py
+++ b/gflownet/utils/common.py
@@ -276,22 +276,6 @@ def copy(x: Union[List, TensorType["..."]]):
         return x.copy()
 
 
-def chdir_random_subdir():
-    """
-    Creates a directory with random name and changes current working directory to it.
-
-    Aimed as a hotfix for race conditions: currently, by default, the directory in
-    which the experiment will be logged is named based on the current timestamp. If
-    multiple jobs start at exactly the same time, they can be trying to log to
-    the same directory. In particular, this causes issues when using dataset
-    evaluation (e.g., JSD computation).
-    """
-    cwd = os.getcwd()
-    cwd += "/%08x" % random.getrandbits(32)
-    os.mkdir(cwd)
-    os.chdir(cwd)
-
-
 def bootstrap_samples(tensor, num_samples):
     """
     Bootstraps tensor along the last dimention

--- a/main.py
+++ b/main.py
@@ -10,19 +10,18 @@ import sys
 import hydra
 import pandas as pd
 
-from gflownet.utils.common import chdir_random_subdir
 from gflownet.utils.policy import parse_policy_config
 
 
 @hydra.main(config_path="./config", config_name="main", version_base="1.1")
 def main(config):
-    # TODO: fix race condition in a more elegant way
-    chdir_random_subdir()
 
-    # Get current directory and set it as root log dir for Logger
-    cwd = os.getcwd()
-    config.logger.logdir.root = cwd
-    print(f"\nLogging directory of this run:  {cwd}\n")
+    # Print working and logging directory
+    print(f"\nWorking directory of this run: {os.getcwd()}")
+    print(
+        "Logging directory of this run: "
+        f"{hydra.core.hydra_config.HydraConfig.get().runtime.output_dir}"
+    )
 
     # Reset seed for job-name generation in multirun jobs
     random.seed(None)


### PR DESCRIPTION
Summary of changes
- Removal of quick fix about race conditions: before, a random directory was created for each run. Now, by default, the directory created by Hydra with the date and time in the name contains the microseconds, which would prevent the potential issues with race conditions.
- A few default configurations have been changed:
  - TB loss instead of FM (because FM does not work for cont. environments)
  - Uniform proxy by default (because it works for all environments)
  - Hydra will not change directory by default.
- I have remove "alex" as the default user in the experiment config files and removed "debug" from the logdir path.