### PR TITLE
[Small PR] Logging dir and buffer outputs: fix issue and improvements

### DIFF
--- a/config/env/alaninedipeptide.yaml
+++ b/config/env/alaninedipeptide.yaml
@@ -26,5 +26,3 @@ buffer:
   test:
     type: grid
     n: 1000
-    output_csv: alaninedipeptide_test.csv
-    output_pkl: alaninedipeptide_test.pkl

--- a/config/env/ccube.yaml
+++ b/config/env/ccube.yaml
@@ -35,5 +35,3 @@ buffer:
   test:
     type: grid
     n: 900
-    output_csv: ccube_test.csv
-    output_pkl: ccube_test.pkl

--- a/config/env/crystals/composition.yaml
+++ b/config/env/crystals/composition.yaml
@@ -20,7 +20,5 @@ buffer:
   data_path: null
   train:
     type: all
-    output_csv: composition_train.csv
   test:
     type: all
-    output_csv: composition_test.csv

--- a/config/env/crystals/lattice_parameters.yaml
+++ b/config/env/crystals/lattice_parameters.yaml
@@ -39,5 +39,3 @@ buffer:
   test:
     type: grid
     n: 900
-    output_csv: clp_test.csv
-    output_pkl: clp_test.pkl

--- a/config/env/crystals/spacegroup.yaml
+++ b/config/env/crystals/spacegroup.yaml
@@ -15,9 +15,5 @@ buffer:
   data_path: null
   train:
     type: all
-    output_csv: spacegroup_train.csv
-    output_pkl: spacegroup_train.pkl
   test:
     type: all
-    output_csv: spacegroup_test.csv
-    output_pkl: spacegroup_test.pkl

--- a/config/env/ctorus.yaml
+++ b/config/env/ctorus.yaml
@@ -27,5 +27,3 @@ buffer:
   test:
     type: grid
     n: 1000
-    output_csv: ctorus_test.csv
-    output_pkl: ctorus_test.pkl

--- a/config/env/grid.yaml
+++ b/config/env/grid.yaml
@@ -22,5 +22,3 @@ buffer:
   train: null
   test:
     type: all
-    output_csv: grid_test.csv
-    output_pkl: grid_test.pkl

--- a/config/env/htorus.yaml
+++ b/config/env/htorus.yaml
@@ -27,5 +27,3 @@ buffer:
   test:
     type: grid
     n: 1000
-    output_csv: htorus_test.csv
-    output_pkl: htorus_test.pkl

--- a/config/env/scrabble.yaml
+++ b/config/env/scrabble.yaml
@@ -11,5 +11,3 @@ buffer:
   test:
     type: uniform
     n: 10
-    output_csv: scrabble_test.csv
-    output_pkl: scrabble_test.pkl

--- a/config/env/tetris.yaml
+++ b/config/env/tetris.yaml
@@ -20,6 +20,3 @@ buffer:
   test:
     type: random
     n: 10
-    output_csv: tetris_test.csv
-    output_pkl: tetris_test.pkl
-

--- a/config/env/torus.yaml
+++ b/config/env/torus.yaml
@@ -20,8 +20,5 @@ buffer:
   data_path: null
   train:
     type: all
-    output_csv: torus_train.csv
   test:
     type: all
-    output_csv: torus_test.csv
-    output_pkl: torus_test.pkl

--- a/config/env/tree.yaml
+++ b/config/env/tree.yaml
@@ -35,5 +35,3 @@ buffer:
   test:
     type: random
     n: 1000
-    output_csv: tree_test.csv
-    output_pkl: tree_test.pkl

--- a/config/experiments/ccube/hyperparams_search_20230920_batch1.yaml
+++ b/config/experiments/ccube/hyperparams_search_20230920_batch1.yaml
@@ -24,8 +24,6 @@ shared:
         test:
           type: grid
           n: 1000
-          output_csv: ccube_test.csv
-          output_pkl: ccube_test.pkl
     # Proxy
     proxy: corners
     # GFlowNet config

--- a/config/experiments/ccube/hyperparams_search_20230920_batch2.yaml
+++ b/config/experiments/ccube/hyperparams_search_20230920_batch2.yaml
@@ -24,8 +24,6 @@ shared:
         test:
           type: grid
           n: 1000
-          output_csv: ccube_test.csv
-          output_pkl: ccube_test.pkl
     # Proxy
     proxy: corners
     # GFlowNet config

--- a/config/experiments/ccube/hyperparams_search_20230920_batch3.yaml
+++ b/config/experiments/ccube/hyperparams_search_20230920_batch3.yaml
@@ -24,8 +24,6 @@ shared:
         test:
           type: grid
           n: 1000
-          output_csv: ccube_test.csv
-          output_pkl: ccube_test.pkl
     # Proxy
     proxy: corners
     # GFlowNet config

--- a/config/experiments/ccube/hyperparams_search_20230920_batch4.yaml
+++ b/config/experiments/ccube/hyperparams_search_20230920_batch4.yaml
@@ -24,8 +24,6 @@ shared:
         test:
           type: grid
           n: 1000
-          output_csv: ccube_test.csv
-          output_pkl: ccube_test.pkl
     # Proxy
     proxy: corners
     # GFlowNet config

--- a/config/experiments/crystals/starling_bg.yaml
+++ b/config/experiments/crystals/starling_bg.yaml
@@ -55,13 +55,9 @@ env:
     train:
       type: csv
       path: /network/projects/crystalgfn/data/bandgap/train.csv
-      output_csv: crystal_train.csv
-      output_pkl: crystal_train.pkl
     test:
       type: csv
       path: /network/projects/crystalgfn/data/bandgap/val.csv
-      output_csv: crystal_val.csv
-      output_pkl: crystal_val.pkl
 
 # GFlowNet hyperparameters
 gflownet:

--- a/config/experiments/crystals/starling_bg_no_constraints.yaml
+++ b/config/experiments/crystals/starling_bg_no_constraints.yaml
@@ -55,13 +55,9 @@ env:
     train:
       type: csv
       path: /network/projects/crystalgfn/data/bandgap/train.csv
-      output_csv: crystal_train.csv
-      output_pkl: crystal_train.pkl
     test:
       type: csv
       path: /network/projects/crystalgfn/data/bandgap/val.csv
-      output_csv: crystal_val.csv
-      output_pkl: crystal_val.pkl
 
 # GFlowNet hyperparameters
 gflownet:

--- a/config/experiments/crystals/starling_density.yaml
+++ b/config/experiments/crystals/starling_density.yaml
@@ -54,13 +54,9 @@ env:
     train:
       type: csv
       path: /network/projects/crystalgfn/data/eform/train.csv
-      output_csv: crystal_train.csv
-      output_pkl: crystal_train.pkl
     test:
       type: csv
       path: /network/projects/crystalgfn/data/eform/val.csv
-      output_csv: crystal_val.csv
-      output_pkl: crystal_val.pkl
 
 # GFlowNet hyperparameters
 gflownet:

--- a/config/experiments/crystals/starling_density_no_constraints.yaml
+++ b/config/experiments/crystals/starling_density_no_constraints.yaml
@@ -54,13 +54,9 @@ env:
     train:
       type: csv
       path: /network/projects/crystalgfn/data/eform/train.csv
-      output_csv: crystal_train.csv
-      output_pkl: crystal_train.pkl
     test:
       type: csv
       path: /network/projects/crystalgfn/data/eform/val.csv
-      output_csv: crystal_val.csv
-      output_pkl: crystal_val.pkl
 
 # GFlowNet hyperparameters
 gflownet:

--- a/config/experiments/crystals/starling_fe.yaml
+++ b/config/experiments/crystals/starling_fe.yaml
@@ -54,13 +54,9 @@ env:
     train:
       type: csv
       path: /network/projects/crystalgfn/data/eform/train.csv
-      output_csv: crystal_train.csv
-      output_pkl: crystal_train.pkl
     test:
       type: csv
       path: /network/projects/crystalgfn/data/eform/val.csv
-      output_csv: crystal_val.csv
-      output_pkl: crystal_val.pkl
 
 # GFlowNet hyperparameters
 gflownet:

--- a/config/experiments/crystals/starling_fe_no_constraints.yaml
+++ b/config/experiments/crystals/starling_fe_no_constraints.yaml
@@ -54,13 +54,9 @@ env:
     train:
       type: csv
       path: /network/projects/crystalgfn/data/eform/train.csv
-      output_csv: crystal_train.csv
-      output_pkl: crystal_train.pkl
     test:
       type: csv
       path: /network/projects/crystalgfn/data/eform/val.csv
-      output_csv: crystal_val.csv
-      output_pkl: crystal_val.pkl
 
 # GFlowNet hyperparameters
 gflownet:

--- a/config/experiments/scrabble/jay.yaml
+++ b/config/experiments/scrabble/jay.yaml
@@ -18,8 +18,6 @@ env:
     test:
       type: random
       n: 1000
-      output_csv: scrabble_test.csv
-      output_pkl: scrabble_test.pkl
 
 # Proxy
 proxy:

--- a/config/experiments/scrabble/penguin.yaml
+++ b/config/experiments/scrabble/penguin.yaml
@@ -17,8 +17,6 @@ env:
     test:
       type: random
       n: 1000
-      output_csv: scrabble_test.csv
-      output_pkl: scrabble_test.pkl
 
 # Proxy
 proxy:

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -22,7 +22,6 @@ class Buffer:
         env,
         proxy,
         replay_capacity=0,
-        output_csv=None,
         data_path=None,
         train=None,
         test=None,
@@ -59,19 +58,11 @@ class Buffer:
         else:
             self.train_type = None
         self.train, dict_tr = self.make_data_set(train)
-        if (
-            self.train is not None
-            and "output_csv" in train
-            and train.output_csv is not None
-        ):
-            self.train_csv = self.datadir / train.output_csv
+        if self.train is not None:
+            self.train_csv = self.datadir / "train.csv"
             self.train.to_csv(self.train_csv)
-        if (
-            dict_tr is not None
-            and "output_pkl" in train
-            and train.output_pkl is not None
-        ):
-            self.train_pkl = self.datadir / train.output_pkl
+        if dict_tr is not None:
+            self.train_pkl = self.datadir / "train.pkl"
             with open(self.train_pkl, "wb") as f:
                 pickle.dump(dict_tr, f)
         else:
@@ -79,8 +70,7 @@ class Buffer:
                 """
             Important: offline trajectories will NOT be sampled. In order to sample
             offline trajectories, the train configuration of the buffer should be
-            complete and feasible and an output pkl file should be defined in
-            env.buffer.train.output_pkl.
+            complete and feasible. It should at least specify env.buffer.train.type.
             """
             )
             self.train_pkl = None
@@ -91,15 +81,11 @@ class Buffer:
         else:
             self.train_type = None
         self.test, dict_tt = self.make_data_set(test)
-        if (
-            self.test is not None
-            and "output_csv" in test
-            and test.output_csv is not None
-        ):
-            self.test_csv = self.datadir / test.output_csv
+        if self.test is not None:
+            self.test_csv = self.datadir / "test.csv"
             self.test.to_csv(self.test_csv)
-        if dict_tt is not None and "output_pkl" in test and test.output_pkl is not None:
-            self.test_pkl = self.datadir / test.output_pkl
+        if dict_tt is not None:
+            self.test_pkl = self.datadir / "test.pkl"
             with open(self.test_pkl, "wb") as f:
                 pickle.dump(dict_tt, f)
         else:
@@ -107,8 +93,7 @@ class Buffer:
                 """
             Important: test metrics will NOT be computed. In order to compute
             test metrics the test configuration of the buffer should be complete and
-            feasible and an output pkl file should be defined in
-            env.buffer.test.output_pkl.
+            feasible. It should at least specify env.buffer.test.type.
             """
             )
             self.test_pkl = None

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -3,6 +3,7 @@ Buffer class to handle train and test data sets, reply buffer, etc.
 """
 
 import pickle
+from pathlib import Path
 from typing import List
 
 import numpy as np
@@ -28,7 +29,7 @@ class Buffer:
         logger=None,
         **kwargs,
     ):
-        self.logger = logger
+        self.datadir = logger.datadir
         self.env = env
         self.proxy = proxy
         self.replay_capacity = replay_capacity
@@ -43,7 +44,7 @@ class Buffer:
         self.replay_states = {}
         self.replay_trajs = {}
         self.replay_rewards = {}
-        self.replay_pkl = "replay.pkl"
+        self.replay_pkl = self.datadir / "replay.pkl"
 
         self.train_csv = None
         self.train_pkl = None
@@ -63,16 +64,16 @@ class Buffer:
             and "output_csv" in train
             and train.output_csv is not None
         ):
-            self.train.to_csv(train.output_csv)
-            self.train_csv = train.output_csv
+            self.train_csv = self.datadir / train.output_csv
+            self.train.to_csv(self.train_csv)
         if (
             dict_tr is not None
             and "output_pkl" in train
             and train.output_pkl is not None
         ):
-            with open(train.output_pkl, "wb") as f:
+            self.train_pkl = self.datadir / train.output_pkl
+            with open(self.train_pkl, "wb") as f:
                 pickle.dump(dict_tr, f)
-                self.train_pkl = train.output_pkl
         else:
             print(
                 """
@@ -95,12 +96,12 @@ class Buffer:
             and "output_csv" in test
             and test.output_csv is not None
         ):
-            self.test_csv = test.output_csv
-            self.test.to_csv(test.output_csv)
+            self.test_csv = self.datadir / test.output_csv
+            self.test.to_csv(self.test_csv)
         if dict_tt is not None and "output_pkl" in test and test.output_pkl is not None:
-            with open(test.output_pkl, "wb") as f:
+            self.test_pkl = self.datadir / test.output_pkl
+            with open(self.test_pkl, "wb") as f:
                 pickle.dump(dict_tt, f)
-                self.test_pkl = test.output_pkl
         else:
             print(
                 """

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -28,7 +28,11 @@ class Buffer:
         logger=None,
         **kwargs,
     ):
-        self.datadir = logger.datadir
+        if logger is not None:
+            self.datadir = logger.datadir
+        else:
+            self.datadir = Path("./logs")
+            self.datadir.mkdir(parents=True, exist_ok=True)
         self.env = env
         self.proxy = proxy
         self.replay_capacity = replay_capacity

--- a/gflownet/utils/logger.py
+++ b/gflownet/utils/logger.py
@@ -71,14 +71,21 @@ class Logger:
         self.lightweight = lightweight
         self.debug = debug
         # Log directory
-        self.logdir = Path(logdir.root)
+        if "path" in logdir:
+            self.logdir = Path(logdir.path)
+        else:
+            self.logdir = Path(logdir.root)
         if not self.logdir.exists() or logdir.overwrite:
             self.logdir.mkdir(parents=True, exist_ok=True)
         else:
             print(f"logdir {logdir} already exists! - Ending run...")
             sys.exit(1)
+        # Checkpoints directory
         self.ckpts_dir = self.logdir / logdir.ckpts
         self.ckpts_dir.mkdir(parents=True, exist_ok=True)
+        # Data directory
+        self.datadir = self.logdir / "data"
+        self.datadir.mkdir(parents=True, exist_ok=True)
         # Write wandb URL
         self.write_url_file()
 

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import sys
 
 import hydra
 import pandas as pd
+from omegaconf import open_dict
 
 from gflownet.utils.policy import parse_policy_config
 
@@ -16,12 +17,13 @@ from gflownet.utils.policy import parse_policy_config
 @hydra.main(config_path="./config", config_name="main", version_base="1.1")
 def main(config):
 
-    # Print working and logging directory
+    # Set and print working and logging directory
+    with open_dict(config):
+        config.logger.logdir.path = (
+            hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
+        )
     print(f"\nWorking directory of this run: {os.getcwd()}")
-    print(
-        "Logging directory of this run: "
-        f"{hydra.core.hydra_config.HydraConfig.get().runtime.output_dir}"
-    )
+    print(f"Logging directory of this run: {config.logger.logdir.path}\n")
 
     # Reset seed for job-name generation in multirun jobs
     random.seed(None)
@@ -48,7 +50,7 @@ def main(config):
         _partial_=True,
     )
     env = env_maker()
-    
+
     # The evaluator is used to compute metrics and plots
     evaluator = hydra.utils.instantiate(config.evaluator)
 

--- a/tests/gflownet/evaluator/test_base.py
+++ b/tests/gflownet/evaluator/test_base.py
@@ -221,7 +221,7 @@ def test__should_eval_top_k(constant_evaluator, period, step, target, first_it, 
     ],
 )
 def test__eval(gflownet_for_tests, parameterization):
-    assert Path("./replay.pkl").exists()
+    assert gflownet_for_tests.buffer.replay_pkl.exists()
     # results: {"metrics": dict[str, float], "figs": list[plt.Figure]}
     results = gflownet_for_tests.evaluator.eval()
     figs = gflownet_for_tests.evaluator.plot(**results["data"])


### PR DESCRIPTION
Note for reviewers: There are many files changed but it's mostly the same change applied to many config files.

This PR fixes an issue introduced in a recent PR and makes various changes to hopefully improve the handling of the logging directory and the buffer output files:
- Now Hydra does not change to the output directory by default, so I had to add a couple of lines in `main.py` to make the actual logging directory be Hydra's output directory. Let's call this directory `/log/dir/`, which will be stored in `config.logger.logdir.path`
- The Logger now creates a data directory in `/log/dir/data/` (as well as a /log/dir/ckpts/`) meant to store the replay buffer, the train data and the test data.
- The Buffer will thus not create files anymore in the source code directory.
- I have removed the need to specify `env.buffer.train.output_csv` and `env.buffer.train.output_pkl` (and the test counterparts) in order to make use of the buffer. This simplifies its use and the code. And the replay, train and test output files will always be stored simply as `/log/dir/data/replay.pkl`, `/log/dir/data/train.csv`, `/log/dir/data/train.pkl`, etc.