### PR TITLE
Prevent unnecessary recalculation of proxy values

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -1178,17 +1178,17 @@ class GFlowNetAgent:
             # log-rewards, the latter are computed by taking the log of the rewards.
             # Numerical issues are not critical in this case, since the derived values
             # are only used for reporting purposes.
-            if batch.rewards_available:
+            if batch.rewards_available(log=False):
                 rewards = batch.get_terminating_rewards(sort_by="trajectory")
-            if batch.logrewards_available:
+            if batch.rewards_available(log=True):
                 logrewards = batch.get_terminating_rewards(
                     sort_by="trajectory", log=True
                 )
-            if not batch.rewards_available:
-                assert batch.logrewards_available
+            if not batch.rewards_available(log=False):
+                assert batch.rewards_available(log=True)
                 rewards = torch.exp(logrewards)
-            if not batch.logrewards_available:
-                assert batch.rewards_available
+            if not batch.rewards_available(log=True):
+                assert batch.rewards_available(log=False)
                 logrewards = torch.log(rewards)
             rewards = rewards.tolist()
             logrewards = logrewards.tolist()

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -1187,7 +1187,7 @@ class GFlowNetAgent:
             if not batch.rewards_available:
                 assert batch.logrewards_available
                 rewards = torch.exp(logrewards)
-            if batch.logrewards_available:
+            if not batch.logrewards_available:
                 assert batch.rewards_available
                 logrewards = torch.log(rewards)
             rewards = rewards.tolist()

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -1214,6 +1214,7 @@ class GFlowNetAgent:
                 self.logger.log_train(
                     losses=losses,
                     rewards=rewards,
+                    logrewards=logrewards,
                     proxy_vals=proxy_vals,
                     states_term=states_term,
                     batch_size=len(batch),

--- a/gflownet/proxy/base.py
+++ b/gflownet/proxy/base.py
@@ -105,8 +105,11 @@ class Proxy(ABC):
         pass
 
     def rewards(
-        self, states: Union[TensorType, List, npt.NDArray], log: bool = False
-    ) -> TensorType:
+        self,
+        states: Union[TensorType, List, npt.NDArray],
+        log: bool = False,
+        return_proxy: bool = False,
+    ) -> Union[TensorType, Tuple[TensorType, TensorType]]:
         """
         Computes the rewards of a batch of states.
 
@@ -120,16 +123,27 @@ class Proxy(ABC):
         log : bool
             If True, returns the logarithm of the rewards. If False (default), returns
             the natural rewards.
+        return_proxy : bool
+            If True, returns the proxy values, alongside the rewards, as the second
+            element in the returned tuple.
 
         Returns
         -------
-        tensor
-            The reward of all elements in the batch.
+        rewards
+            The reward or log-reward of all elements in the batch.
+        tensor (optional)
+            The proxy value of all elements in the batch. Included only if return_proxy
+            is True.
         """
+        proxy_values = self(states)
         if log:
-            return self.proxy2logreward(self(states))
+            rewards = self.proxy2logreward(proxy_values)
         else:
-            return self.proxy2reward(self(states))
+            rewards = self.proxy2reward(proxy_values)
+        if return_proxy:
+            return rewards, proxy_values
+        else:
+            return rewards
 
     def proxy2reward(self, proxy_values: TensorType) -> TensorType:
         """

--- a/gflownet/proxy/base.py
+++ b/gflownet/proxy/base.py
@@ -129,9 +129,9 @@ class Proxy(ABC):
 
         Returns
         -------
-        rewards
+        rewards : tensor
             The reward or log-reward of all elements in the batch.
-        tensor (optional)
+        proxy_values : tensor (optional)
             The proxy value of all elements in the batch. Included only if return_proxy
             is True.
         """

--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -94,18 +94,18 @@ class Batch:
         self.states_policy = None
         self.parents_policy = None
         # Flags for available items
-        self.parents_available = False
-        self.parents_policy_available = False
-        self.parents_all_available = False
-        self.masks_forward_available = False
-        self.masks_backward_available = False
+        self._parents_available = False
+        self._parents_policy_available = False
+        self._parents_all_available = False
+        self._masks_forward_available = False
+        self._masks_backward_available = False
         self._rewards_available = False
-        self.rewards_parents_available = False
-        self.rewards_source_available = False
+        self._rewards_parents_available = False
+        self._rewards_source_available = False
         self._logrewards_available = False
-        self.logrewards_parents_available = False
-        self.logrewards_source_available = False
-        self.proxy_values_available = False
+        self._logrewards_parents_available = False
+        self._logrewards_source_available = False
+        self._proxy_values_available = False
 
     def __len__(self):
         return self.size
@@ -158,6 +158,46 @@ class Batch:
             return self._logrewards_available
         else:
             return self._rewards_available
+
+    def rewards_parents_available(self, log: bool = False) -> bool:
+        """
+        Returns True if the (log)rewards of the parents are available.
+
+        Parameters
+        ----------
+        log : bool
+            If True, check self._logrewards_parents_available. Otherwise (default),
+            check self._rewards_parents_available.
+
+        Returns
+        -------
+        bool
+            True if the (log)rewards of the parents are available, False otherwise.
+        """
+        if log:
+            return self._logrewards_parents_available
+        else:
+            return self._rewards_parents_available
+
+    def rewards_source_available(self, log: bool = False) -> bool:
+        """
+        Returns True if the (log)rewards of the source are available.
+
+        Parameters
+        ----------
+        log : bool
+            If True, check self._logrewards_source_available. Otherwise (default),
+            check self._rewards_source_available.
+
+        Returns
+        -------
+        bool
+            True if the (log)rewards of the source are available, False otherwise.
+        """
+        if log:
+            return self._logrewards_source_available
+        else:
+            return self._rewards_source_available
 
     def set_env(self, env: GFlowNetEnv):
         """
@@ -272,10 +312,10 @@ class Batch:
             # Increment size of batch
             self.size += 1
         # Other variables are not available after new items were added to the batch
-        self.masks_forward_available = False
-        self.masks_backward_available = False
-        self.parents_policy_available = False
-        self.parents_all_available = False
+        self._masks_forward_available = False
+        self._masks_backward_available = False
+        self._parents_policy_available = False
+        self._parents_all_available = False
         self._rewards_available = False
         self._logrewards_available = False
 
@@ -546,10 +586,10 @@ class Batch:
         self.parents or self.parents_policy : torch.tensor
             The parent of all states in the batch.
         """
-        if self.parents_available is False or force_recompute is True:
+        if self._parents_available is False or force_recompute is True:
             self._compute_parents()
         if policy:
-            if self.parents_policy_available is False or force_recompute is True:
+            if self._parents_policy_available is False or force_recompute is True:
                 self._compute_parents_policy()
             return self.parents_policy
         else:
@@ -568,7 +608,7 @@ class Batch:
         self.parents_indices
             The indices in self.states of the parents of self.states.
         """
-        if self.parents_available is False:
+        if self._parents_available is False:
             self._compute_parents()
         return self.parents_indices
 
@@ -589,7 +629,7 @@ class Batch:
           parent is not present in self.states (i.e. it is source), the corresponding
           index is -1.
 
-        self.parents_available is set to True.
+        self._parents_available is set to True.
         """
         self.parents = []
         self.parents_indices = []
@@ -621,7 +661,7 @@ class Batch:
             [self.parents_indices[indices_dict[idx]] for idx in range(len(self))],
             device=self.device,
         )
-        self.parents_available = True
+        self._parents_available = True
 
     # TODO: consider converting directly from self.parents
     def _compute_parents_policy(self):
@@ -636,7 +676,7 @@ class Batch:
             Shape: [n_states, state_policy_dims]
 
         self.parents_policy is stored as a torch tensor and
-        self.parents_policy_available is set to True.
+        self._parents_policy_available is set to True.
         """
         self.states_policy = self.get_states(policy=True)
         self.parents_policy = torch.zeros_like(self.states_policy)
@@ -652,7 +692,7 @@ class Batch:
             self.parents_policy[batch_indices[1:]] = self.states_policy[
                 batch_indices[:-1]
             ]
-        self.parents_policy_available = True
+        self._parents_policy_available = True
 
     def get_parents_all(
         self, policy: bool = False, force_recompute: bool = False
@@ -664,7 +704,7 @@ class Batch:
         """
         Returns the whole set of parents, their corresponding actions and indices of
         all states in the batch. If the parents are not available
-        (self.parents_all_available is False) or if force_recompute is True, then
+        (self._parents_all_available is False) or if force_recompute is True, then
         self._compute_parents_all() is called to compute the required components.
 
         The parents are returned in "policy format" if policy is True, otherwise they
@@ -696,7 +736,7 @@ class Batch:
         """
         if self.continuous:
             raise Exception("get_parents() is ill-defined for continuous environments!")
-        if self.parents_all_available is False or force_recompute is True:
+        if self._parents_all_available is False or force_recompute is True:
             self._compute_parents_all()
         if policy:
             return (
@@ -726,7 +766,7 @@ class Batch:
             Shape: [n_parents, state_policy_dims]
 
         All the above components are stored as torch tensors and
-        self.parents_all_available is set to True.
+        self._parents_all_available is set to True.
         """
         # Iterate over the trajectories to obtain all parents
         self.parents_all = []
@@ -763,7 +803,7 @@ class Batch:
             device=self.device,
         )
         self.parents_all_policy = torch.cat(self.parents_all_policy)
-        self.parents_all_available = True
+        self._parents_all_available = True
 
     # TODO: opportunity to improve efficiency by caching.
     def get_masks_forward(
@@ -791,7 +831,7 @@ class Batch:
         self.masks_invalid_actions_forward : torch.tensor
             The forward mask of all states in the batch.
         """
-        if self.masks_forward_available is False or force_recompute is True:
+        if self._masks_forward_available is False or force_recompute is True:
             self._compute_masks_forward()
         # Make tensor
         masks_invalid_actions_forward = tbool(
@@ -826,8 +866,8 @@ class Batch:
     def _compute_masks_forward(self):
         """
         Computes the forward mask of invalid actions of all states in the batch, by
-        calling env.get_mask_invalid_actions_forward(). self.masks_forward_available is
-        set to True.
+        calling env.get_mask_invalid_actions_forward(). self._masks_forward_available
+        is set to True.
         """
         # Iterate over the trajectories to compute all forward masks
         for idx, mask in enumerate(self.masks_invalid_actions_forward):
@@ -839,7 +879,7 @@ class Batch:
             self.masks_invalid_actions_forward[idx] = self.envs[
                 traj_idx
             ].get_mask_invalid_actions_forward(state, done)
-        self.masks_forward_available = True
+        self._masks_forward_available = True
 
     # TODO: opportunity to improve efficiency by caching. Note that
     # env.get_masks_invalid_actions_backward() may be expensive because it calls
@@ -863,14 +903,14 @@ class Batch:
         self.masks_invalid_actions_backward : torch.tensor
             The backward mask of all states in the batch.
         """
-        if self.masks_backward_available is False or force_recompute is True:
+        if self._masks_backward_available is False or force_recompute is True:
             self._compute_masks_backward()
         return tbool(self.masks_invalid_actions_backward, device=self.device)
 
     def _compute_masks_backward(self):
         """
         Computes the backward mask of invalid actions of all states in the batch, by
-        calling env.get_mask_invalid_actions_backward(). self.masks_backward_available
+        calling env.get_mask_invalid_actions_backward(). self._masks_backward_available
         is set to True.
         """
         # Iterate over the trajectories to compute all backward masks
@@ -883,7 +923,7 @@ class Batch:
             self.masks_invalid_actions_backward[idx] = self.envs[
                 traj_idx
             ].get_mask_invalid_actions_backward(state, done)
-        self.masks_backward_available = True
+        self._masks_backward_available = True
 
     # TODO: better handling of availability of rewards, logrewards, proxy_values.
     def get_rewards(
@@ -928,7 +968,7 @@ class Batch:
             If True, return the actual proxy values of the non-terminating states. If
             False, non-terminating states will be assigned value inf.
         """
-        if self.proxy_values_available is False or force_recompute is True:
+        if self._proxy_values_available is False or force_recompute is True:
             self._compute_rewards(do_non_terminating=do_non_terminating)
         return self.proxy_values
 
@@ -965,7 +1005,7 @@ class Batch:
                 )
 
         self.proxy_values = proxy_values
-        self.proxy_values_available = True
+        self._proxy_values_available = True
         if log:
             self.logrewards = rewards
             self._logrewards_available = True
@@ -987,7 +1027,7 @@ class Batch:
         self.rewards_parents or self.logrewards_parents
             A tensor containing the rewards of the parents of self.states.
         """
-        if not self.rewards_parents_available:
+        if not self.rewards_parents_available(log):
             self._compute_rewards_parents(log)
         if log:
             return self.logrewards_parents
@@ -1019,10 +1059,10 @@ class Batch:
         rewards_parents[parent_is_source] = rewards_source[parent_is_source]
         if log:
             self.logrewards_parents = rewards_parents
-            self.logrewards_parents_available = True
+            self._logrewards_parents_available = True
         else:
             self.rewards_parents = rewards_parents
-            self.rewards_parents_available = True
+            self._rewards_parents_available = True
 
     def get_rewards_source(self, log: bool = False) -> TensorType["n_states"]:
         """
@@ -1038,7 +1078,7 @@ class Batch:
         self.rewards_source or self.logrewards_source
             A tensor containing the rewards the source states.
         """
-        if not self.rewards_source_available:
+        if not self.rewards_source_available(log):
             self._compute_rewards_source(log)
         if log:
             return self.logrewards_source
@@ -1066,10 +1106,10 @@ class Batch:
             raise NotImplementedError
         if log:
             self.logrewards_source = rewards_source
-            self.logrewards_source_available = True
+            self._logrewards_source_available = True
         else:
             self.rewards_source = rewards_source
-            self.rewards_source_available = True
+            self._rewards_source_available = True
 
     def get_terminating_states(
         self,
@@ -1202,7 +1242,7 @@ class Batch:
             indices = np.argsort(self.traj_indices)
         else:
             raise ValueError("sort_by must be either insert[ion] or traj[ectory]")
-        if self.proxy_values_available is False or force_recompute is True:
+        if self._proxy_values_available is False or force_recompute is True:
             self._compute_rewards(log, do_non_terminating=False)
         done = self.get_done()[indices]
         return self.proxy_values[indices][done]
@@ -1313,15 +1353,15 @@ class Batch:
                 self.states_policy = extend(self.states_policy, batch.states_policy)
             else:
                 self.states_policy = None
-            if self.parents_available and batch.parents_available:
+            if self._parents_available and batch._parents_available:
                 self.parents = extend(self.parents, batch.parents)
             else:
                 self.parents = None
-            if self.parents_policy_available and batch.parents_policy_available:
+            if self._parents_policy_available and batch._parents_policy_available:
                 self.parents_policy = extend(self.parents_policy, batch.parents_policy)
             else:
                 self.parents_policy = None
-            if self.parents_all_available and batch.parents_all_available:
+            if self._parents_all_available and batch._parents_all_available:
                 self.parents_all = extend(self.parents_all, batch.parents_all)
             else:
                 self.parents_all = None

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -36,13 +36,12 @@ class Buffer:
         self.env = env
         self.proxy = proxy
         self.replay_capacity = replay_capacity
-        self.main = pd.DataFrame(columns=["state", "traj", "reward", "energy", "iter"])
+        self.main = pd.DataFrame(columns=["state", "traj", "reward", "iter"])
         self.replay = pd.DataFrame(
             np.empty((self.replay_capacity, 5), dtype=object),
-            columns=["state", "traj", "reward", "energy", "iter"],
+            columns=["state", "traj", "reward", "iter"],
         )
         self.replay.reward = pd.to_numeric(self.replay.reward)
-        self.replay.energy = pd.to_numeric(self.replay.energy)
         self.replay.reward = [-1 for _ in range(self.replay_capacity)]
         self.replay_states = {}
         self.replay_trajs = {}
@@ -127,16 +126,7 @@ class Buffer:
                 f,
             )
 
-    def add(
-        self,
-        states,
-        trajs,
-        rewards,
-        energies,
-        it,
-        buffer="main",
-        criterion="greater",
-    ):
+    def add(self, states, trajs, rewards, it, buffer="main", criterion="greater"):
         if buffer == "main":
             self.main = pd.concat(
                 [
@@ -146,7 +136,6 @@ class Buffer:
                             "state": [self.env.state2readable(s) for s in states],
                             "traj": [self.env.traj2readable(p) for p in trajs],
                             "reward": rewards,
-                            "energy": energies,
                             "iter": it,
                         }
                     ),
@@ -156,20 +145,10 @@ class Buffer:
             )
         elif buffer == "replay" and self.replay_capacity > 0:
             if criterion == "greater":
-                self.replay = self._add_greater(states, trajs, rewards, energies, it)
+                self.replay = self._add_greater(states, trajs, rewards, it)
 
-    def _add_greater(
-        self,
-        states,
-        trajs,
-        rewards,
-        energies,
-        it,
-        allow_duplicate_states=False,
-    ):
-        for idx, (state, traj, reward, energy) in enumerate(
-            zip(states, trajs, rewards, energies)
-        ):
+    def _add_greater(self, states, trajs, rewards, it, allow_duplicate_states=False):
+        for idx, (state, traj, reward) in enumerate(zip(states, trajs, rewards)):
             if not allow_duplicate_states:
                 if isinstance(state, torch.Tensor):
                     is_duplicate = False
@@ -189,7 +168,6 @@ class Buffer:
                     "state": self.env.state2readable(state),
                     "traj": self.env.traj2readable(traj),
                     "reward": reward,
-                    "energy": energy,
                     "iter": it,
                 }
                 self.replay_states[(idx, it)] = state

--- a/gflownet/utils/buffer.py
+++ b/gflownet/utils/buffer.py
@@ -163,13 +163,15 @@ class Buffer:
                 axis=0,
                 join="outer",
             )
-        elif buffer == "replay" and self.replay_capacity > 0:
-            if criterion == "greater":
-                self.replay = self._add_greater(states, trajs, rewards, it)
-            else:
-                raise ValueError(
-                    f"Unknown criterion identifier. Received {buffer}, expected greater"
-                )
+        elif buffer == "replay":
+            if self.replay_capacity > 0:
+                if criterion == "greater":
+                    self.replay = self._add_greater(states, trajs, rewards, it)
+                else:
+                    raise ValueError(
+                        f"Unknown criterion identifier. Received {buffer}, "
+                        "expected greater"
+                    )
         else:
             raise ValueError(
                 f"Unknown buffer identifier. Received {buffer}, expected main or replay"

--- a/gflownet/utils/logger.py
+++ b/gflownet/utils/logger.py
@@ -193,6 +193,7 @@ class Logger:
         self,
         losses,
         rewards: list,
+        logrewards: list,
         proxy_vals: array,
         states_term: list,
         batch_size: int,
@@ -212,6 +213,8 @@ class Logger:
                 [
                     "mean_reward",
                     "max_reward",
+                    "mean_logreward",
+                    "max_logreward",
                     "mean_proxy",
                     "min_proxy",
                     "max_proxy",
@@ -225,6 +228,8 @@ class Logger:
                 [
                     np.mean(rewards),
                     np.max(rewards),
+                    np.mean(logrewards),
+                    np.max(logrewards),
                     np.mean(proxy_vals),
                     np.min(proxy_vals),
                     np.max(proxy_vals),


### PR DESCRIPTION
#### Context

While the Batch kept track of the availability of rewards and log-rewards, it did not store the proxy values, which are not needed for the computation of the loss. However, the proxy values were (re-)computed for logging purposes and for the Buffer. This was a waste of computation, especially if the proxy is expensive.

#### Main changes

- The call of `proxy.rewards()` now allows returning the proxy values, alongside the rewards, if `return_proxy` is True.
- After computing the rewards, the Batch now also stores the proxy values.
- The GFlowNet agent now retrieves the proxy values from the Batch, without recomputing them.
- The GFlowNet agent computes the (natural) rewards from the log-rewards and vice-versa.

#### Other changes

- The buffer does not store the proxy values, since they are unused.
- Some aspects of the Batch have been extended and refactored for better functionality and clarity.
- The logger now logs stats about the log-rewards too.
- Extended tests.
- Extended docstring. 