### PR TITLE
Fix CI crashing with test_spacegroup

### DIFF
--- a/gflownet/envs/crystals/space_groups.yaml
+++ b/gflownet/envs/crystals/space_groups.yaml
@@ -182,12 +182,12 @@
   crystal_class: rhombic-disphenoidal
   crystal_lattice_system_idx: 3
   crystal_system: orthorhombic
-  full_symbol: P2_12_121
+  full_symbol: P2_12_12_1
   lattice_system: orthorhombic
   point_group: '222'
   point_symmetry: enantiomorphic
   point_symmetry_idx: 4
-  symbol: P2_12_121
+  symbol: P2_12_12_1
 20:
   crystal_class: rhombic-disphenoidal
   crystal_lattice_system_idx: 3
@@ -232,12 +232,12 @@
   crystal_class: rhombic-disphenoidal
   crystal_lattice_system_idx: 3
   crystal_system: orthorhombic
-  full_symbol: I2_12_121
+  full_symbol: I2_12_12_1
   lattice_system: orthorhombic
   point_group: '222'
   point_symmetry: enantiomorphic
   point_symmetry_idx: 4
-  symbol: I2_12_121
+  symbol: I2_12_12_1
 25:
   crystal_class: rhombic-pyramidal
   crystal_lattice_system_idx: 3
@@ -472,7 +472,7 @@
   crystal_class: rhombic-dipyramidal
   crystal_lattice_system_idx: 3
   crystal_system: orthorhombic
-  full_symbol: Pnnn1
+  full_symbol: Pnnn
   lattice_system: orthorhombic
   point_group: mmm
   point_symmetry: centrosymmetric
@@ -492,7 +492,7 @@
   crystal_class: rhombic-dipyramidal
   crystal_lattice_system_idx: 3
   crystal_system: orthorhombic
-  full_symbol: Pban1
+  full_symbol: Pban
   lattice_system: orthorhombic
   point_group: mmm
   point_symmetry: centrosymmetric
@@ -582,7 +582,7 @@
   crystal_class: rhombic-dipyramidal
   crystal_lattice_system_idx: 3
   crystal_system: orthorhombic
-  full_symbol: Pmmn1
+  full_symbol: Pmmn
   lattice_system: orthorhombic
   point_group: mmm
   point_symmetry: centrosymmetric
@@ -672,7 +672,7 @@
   crystal_class: rhombic-dipyramidal
   crystal_lattice_system_idx: 3
   crystal_system: orthorhombic
-  full_symbol: Ccce1
+  full_symbol: Ccce
   lattice_system: orthorhombic
   point_group: mmm
   point_symmetry: centrosymmetric
@@ -692,7 +692,7 @@
   crystal_class: rhombic-dipyramidal
   crystal_lattice_system_idx: 3
   crystal_system: orthorhombic
-  full_symbol: Fddd1
+  full_symbol: Fddd
   lattice_system: orthorhombic
   point_group: mmm
   point_symmetry: centrosymmetric
@@ -842,7 +842,7 @@
   crystal_class: tetragonal-dipyramidal
   crystal_lattice_system_idx: 4
   crystal_system: tetragonal
-  full_symbol: P4/n1
+  full_symbol: P4/n
   lattice_system: tetragonal
   point_group: 4/m
   point_symmetry: centrosymmetric
@@ -1242,7 +1242,7 @@
   crystal_class: ditetragonal-dipyramidal
   crystal_lattice_system_idx: 4
   crystal_system: tetragonal
-  full_symbol: P4/nbm1
+  full_symbol: P4/nbm
   lattice_system: tetragonal
   point_group: 4/mmm
   point_symmetry: centrosymmetric
@@ -1252,7 +1252,7 @@
   crystal_class: ditetragonal-dipyramidal
   crystal_lattice_system_idx: 4
   crystal_system: tetragonal
-  full_symbol: P4/nnc1
+  full_symbol: P4/nnc
   lattice_system: tetragonal
   point_group: 4/mmm
   point_symmetry: centrosymmetric
@@ -1282,7 +1282,7 @@
   crystal_class: ditetragonal-dipyramidal
   crystal_lattice_system_idx: 4
   crystal_system: tetragonal
-  full_symbol: P4/nmm1
+  full_symbol: P4/nmm
   lattice_system: tetragonal
   point_group: 4/mmm
   point_symmetry: centrosymmetric
@@ -1292,7 +1292,7 @@
   crystal_class: ditetragonal-dipyramidal
   crystal_lattice_system_idx: 4
   crystal_system: tetragonal
-  full_symbol: P4/ncc1
+  full_symbol: P4/ncc
   lattice_system: tetragonal
   point_group: 4/mmm
   point_symmetry: centrosymmetric
@@ -1452,7 +1452,7 @@
   crystal_class: trigonal-pyramidal
   crystal_lattice_system_idx: 5
   crystal_system: trigonal
-  full_symbol: R3H
+  full_symbol: R3
   lattice_system: rhombohedral
   point_group: '3'
   point_symmetry: enantiomorphic-polar
@@ -1472,7 +1472,7 @@
   crystal_class: rhombohedral
   crystal_lattice_system_idx: 5
   crystal_system: trigonal
-  full_symbol: R-3H
+  full_symbol: R-3
   lattice_system: rhombohedral
   point_group: '-3'
   point_symmetry: centrosymmetric
@@ -1542,7 +1542,7 @@
   crystal_class: trigonal-trapezohedral
   crystal_lattice_system_idx: 5
   crystal_system: trigonal
-  full_symbol: R32H
+  full_symbol: R32
   lattice_system: rhombohedral
   point_group: '32'
   point_symmetry: enantiomorphic
@@ -1592,7 +1592,7 @@
   crystal_class: ditrigonal-pyramidal
   crystal_lattice_system_idx: 5
   crystal_system: trigonal
-  full_symbol: R3mH
+  full_symbol: R3m
   lattice_system: rhombohedral
   point_group: 3m
   point_symmetry: polar
@@ -1602,7 +1602,7 @@
   crystal_class: ditrigonal-pyramidal
   crystal_lattice_system_idx: 5
   crystal_system: trigonal
-  full_symbol: R3cH
+  full_symbol: R3c
   lattice_system: rhombohedral
   point_group: 3m
   point_symmetry: polar
@@ -1652,7 +1652,7 @@
   crystal_class: ditrigonal-scalenohedral
   crystal_lattice_system_idx: 5
   crystal_system: trigonal
-  full_symbol: R-3mH
+  full_symbol: R-3m
   lattice_system: rhombohedral
   point_group: -3m
   point_symmetry: centrosymmetric
@@ -1662,7 +1662,7 @@
   crystal_class: ditrigonal-scalenohedral
   crystal_lattice_system_idx: 5
   crystal_system: trigonal
-  full_symbol: R-3cH
+  full_symbol: R-3c
   lattice_system: rhombohedral
   point_group: -3m
   point_symmetry: centrosymmetric
@@ -2002,7 +2002,7 @@
   crystal_class: diploidal
   crystal_lattice_system_idx: 8
   crystal_system: cubic
-  full_symbol: Pn-31
+  full_symbol: Pn-3
   lattice_system: cubic
   point_group: m-3
   point_symmetry: centrosymmetric
@@ -2022,7 +2022,7 @@
   crystal_class: diploidal
   crystal_lattice_system_idx: 8
   crystal_system: cubic
-  full_symbol: Fd-31
+  full_symbol: Fd-3
   lattice_system: cubic
   point_group: m-3
   point_symmetry: centrosymmetric
@@ -2212,7 +2212,7 @@
   crystal_class: hexoctahedral
   crystal_lattice_system_idx: 8
   crystal_system: cubic
-  full_symbol: Pn-3n1
+  full_symbol: Pn-3n
   lattice_system: cubic
   point_group: m-3m
   point_symmetry: centrosymmetric
@@ -2232,7 +2232,7 @@
   crystal_class: hexoctahedral
   crystal_lattice_system_idx: 8
   crystal_system: cubic
-  full_symbol: Pn-3m1
+  full_symbol: Pn-3m
   lattice_system: cubic
   point_group: m-3m
   point_symmetry: centrosymmetric
@@ -2262,7 +2262,7 @@
   crystal_class: hexoctahedral
   crystal_lattice_system_idx: 8
   crystal_system: cubic
-  full_symbol: Fd-3m1
+  full_symbol: Fd-3m
   lattice_system: cubic
   point_group: m-3m
   point_symmetry: centrosymmetric
@@ -2272,7 +2272,7 @@
   crystal_class: hexoctahedral
   crystal_lattice_system_idx: 8
   crystal_system: cubic
-  full_symbol: Fd-3c1
+  full_symbol: Fd-3c
   lattice_system: cubic
   point_group: m-3m
   point_symmetry: centrosymmetric

--- a/tests/gflownet/envs/test_spacegroup.py
+++ b/tests/gflownet/envs/test_spacegroup.py
@@ -345,6 +345,9 @@ def test__states_are_compatible_with_pymatgen(env):
         sg = pmgg.SpaceGroup(sg_int)
         assert sg.int_number == env.state[env.sg_idx]
         assert sg.crystal_system == env.crystal_system
+        # If this test is the only one failing, you might have
+        # an older version of pymatgen in which there was a typo
+        # in the space group name P2_12_12_1
         assert sg.symbol == env.space_group_symbol
         assert sg.point_group == env.point_group
 

--- a/tests/gflownet/utils/test_batch.py
+++ b/tests/gflownet/utils/test_batch.py
@@ -1641,7 +1641,7 @@ def test__get_logrewards_multiple_env_returns_expected_non_zero_non_terminating(
         )
     ), (logrewards, logrewards_batch)
     assert ~torch.any(
-        torch.isclose(logrewards_batch, torch.zeros_like(logrewards_batch), atol=1e-10)
+        torch.isclose(logrewards_batch, torch.zeros_like(logrewards_batch))
     ), logrewards_batch
 
 

--- a/tests/gflownet/utils/test_batch.py
+++ b/tests/gflownet/utils/test_batch.py
@@ -1641,7 +1641,7 @@ def test__get_logrewards_multiple_env_returns_expected_non_zero_non_terminating(
         )
     ), (logrewards, logrewards_batch)
     assert ~torch.any(
-        torch.isclose(logrewards_batch, torch.zeros_like(logrewards_batch))
+        torch.isclose(logrewards_batch, torch.zeros_like(logrewards_batch), atol=1e-10)
     ), logrewards_batch
 
 


### PR DESCRIPTION
I've updated the names of the spacegroups in `gflownet/envs/crystals/space_groups.yaml` such that they correspond to the new conventions in pymatgen=2024.8.9.  All tests pass, but I'm not 100% sure this change doesn't affect some other things in the crystal-gfn. @alexhernandezgarcia or @carriepl if you have a moment to double check that it's all good, that would be very nice 🙏 