### PR TITLE
[Crystal] Adapt Dave proxy to update in proxy repo

### DIFF
--- a/config/experiments/crystals/starling_bg.yaml
+++ b/config/experiments/crystals/starling_bg.yaml
@@ -94,7 +94,6 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 2.0.3
   ckpt_path: /network/projects/crystalgfn/ckpts/dave/bandgap/
   # RBF exponential, to compute the proximity to a target
   reward_function: rbf_exponential

--- a/config/experiments/crystals/starling_bg.yaml
+++ b/config/experiments/crystals/starling_bg.yaml
@@ -94,7 +94,8 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 1.0.0 # Bandgap release
+  release: 2.0.3
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/bandgap/
   # RBF exponential, to compute the proximity to a target
   reward_function: rbf_exponential
   # Parameters of the reward function

--- a/config/experiments/crystals/starling_bg_no_constraints.yaml
+++ b/config/experiments/crystals/starling_bg_no_constraints.yaml
@@ -94,7 +94,7 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 1.0.0 # Bandgap release
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/bandgap/
   # RBF exponential, to compute the proximity to a target
   reward_function: rbf_exponential
   # Parameters of the reward function

--- a/config/experiments/crystals/starling_fe.yaml
+++ b/config/experiments/crystals/starling_fe.yaml
@@ -93,7 +93,6 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 2.0.3
   ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
   rescale_outputs: true
   # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better

--- a/config/experiments/crystals/starling_fe.yaml
+++ b/config/experiments/crystals/starling_fe.yaml
@@ -93,7 +93,9 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 0.3.4 # Formation energy release
+  release: 2.0.3
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
+  rescale_outputs: true
   # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better
   reward_function: exponential
   # Parameters of the reward function

--- a/config/experiments/crystals/starling_fe_no_constraints.yaml
+++ b/config/experiments/crystals/starling_fe_no_constraints.yaml
@@ -93,7 +93,7 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 0.3.4 # Formation energy release
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
   # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better
   reward_function: exponential
   # Parameters of the reward function

--- a/config/experiments/crystals/starling_fe_restricted_a.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_a.yaml
@@ -95,7 +95,7 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 0.3.4 # Formation energy release
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
   # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better
   reward_function: exponential
   # Parameters of the reward function

--- a/config/experiments/crystals/starling_fe_restricted_b.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_b.yaml
@@ -96,7 +96,7 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 0.3.4 # Formation energy release
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
   # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better
   reward_function: exponential
   # Parameters of the reward function

--- a/config/experiments/crystals/starling_fe_restricted_c.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_c.yaml
@@ -96,7 +96,7 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 0.3.4 # Formation energy release
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
   # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better
   reward_function: exponential
   # Parameters of the reward function

--- a/config/experiments/crystals/starling_fe_restricted_d.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_d.yaml
@@ -97,7 +97,7 @@ policy:
 proxy:
   reward_min: 1e-08
   do_clip_rewards: True
-  release: 0.3.4 # Formation energy release
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
   # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better
   reward_function: exponential
   # Parameters of the reward function

--- a/config/proxy/crystals/dave.yaml
+++ b/config/proxy/crystals/dave.yaml
@@ -3,14 +3,11 @@ defaults:
 
 _target_: gflownet.proxy.crystals.dave.DAVE
 
-# Releases 2.X.X handles Formation Energy and Band Gap in the same model, depending on the checkpoint
-# Releases <2.0.3 are deprecated
 # ckpt_path should be a path to a directory containing a *.cpkt file
 #   Examples:
 #   EForm (default): /network/projects/crystalgfn/ckpts/dave/eform/
 #   Band gap: /network/projects/crystalgfn/ckpts/dave/bandgap/
 ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
-release: 2.0.3
 rescale_outputs: true
 
 # Reward function: exponential by default

--- a/config/proxy/crystals/dave.yaml
+++ b/config/proxy/crystals/dave.yaml
@@ -3,12 +3,14 @@ defaults:
 
 _target_: gflownet.proxy.crystals.dave.DAVE
 
-# releases 0.x.x refer to Formation Energy models
-# releases 1.x.x refer to Band Gap models
-release: 0.3.4
-ckpt_path:
-  mila: /network/scratch/s/schmidtv/crystals-proxys/proxy-ckpts/
-  victor: ~/Documents/Github/ActiveLearningMaterials/checkpoints/980065c0/checkpoints-3ff648a2
+# Releases 2.X.X handles Formation Energy and Band Gap in the same model, depending on the checkpoint
+# Releases <2.0.3 are deprecated
+# ckpt_path should be a path to a directory containing a *.cpkt file
+#   Examples:
+#   EForm (default): /network/projects/crystalgfn/ckpts/dave/eform/
+#   Band gap: /network/projects/crystalgfn/ckpts/dave/bandgap/
+ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
+release: 2.0.3
 rescale_outputs: true
 
 # Reward function: exponential by default


### PR DESCRIPTION
Previously, the various Dave proxies (for example, to predict the formation energy or the band gap) were anchored to different releases. This has been recently changed in the [crystalproxies repo](https://github.com/sh-divya/crystalproxies) (whose name has been also updated). Now, the installation of the dave package and its use is much simpler. This PR updates the relevant code in the gflownet repo, which essentially simplifies the code in the Dave proxy by removing unnecessary code and checks.

From now on, to use one proxy model or another, one simply passes the path to its checkpoint file (without a release). The dependence on a release is handled by the dependencies specified in `pyproject.toml` as for any other package.