### PR TITLE
[Removes-one-line] Remove assertion that all actions must be valid

### DIFF
--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -1066,7 +1066,6 @@ class GFlowNetAgent:
                 )
                 # Update environments with sampled actions
                 envs, actions, valids = self.step(envs, actions, backward=True)
-                assert all(valids)
                 # Add to batch
                 batch.add_to_batch(envs, actions, valids, backward=True, train=True)
                 # Filter out finished trajectories


### PR DESCRIPTION
There was an `assert all(valids)` in `estimate_logprobs_data()`, which causes some runs to crash unnecessarily. The assertion is no (longer) needed because the Batch can handle invalid actions by discarding them. It is possible that some environments could get stuck without this assertion but that's a much lesser evil than having fine runs crash. The reason why sometimes actions are invalid is that the Cube environment sometimes samples _invalid_ actions due to (the lack of) numerical precision with actions near the edges of the cube, which need to be exact - for example to reach exactly 0.0 when sampling backwards.