### PR TITLE
[Corners proxy] Fix exponent in constant of normal pdf

### DIFF
--- a/gflownet/proxy/box/corners.py
+++ b/gflownet/proxy/box/corners.py
@@ -28,7 +28,7 @@ class Corners(Proxy):
             )
             cov_det = torch.linalg.det(cov)
             self.cov_inv = torch.linalg.inv(cov)
-            self.mulnormal_norm = 1.0 / ((2 * torch.pi) ** 2 * cov_det) ** 0.5
+            self.mulnormal_norm = 1.0 / ((2 * torch.pi) ** self.n_dim * cov_det) ** 0.5
 
     @property
     def optimum(self):


### PR DESCRIPTION
Very small PR (one line) with a minor fix in the Corners proxy: a exponent in the denominator of the normal pdf used to create the corners proxy was set to 2 as though it was for 2-dimensional normal distributions. It should be the number of dimensions instead.