### PR TITLE
[Crystal] Synthetic corners proxy

### DIFF
--- a/config/experiments/crystals/gull_corners.yaml
+++ b/config/experiments/crystals/gull_corners.yaml
@@ -1,0 +1,139 @@
+# @package _global_
+#
+# Forward trajectories (10) + Replay buffer (5) + Train set (5)
+# Learning rate decay
+
+defaults:
+  - override /env: crystals/crystal
+  - override /gflownet: trajectorybalance
+  - override /proxy: crystals/corners
+  - override /logger: wandb
+
+device: cpu
+
+# Environment
+env:
+  do_composition_to_sg_constraints: False
+  do_sg_to_composition_constraints: True
+  do_sg_to_lp_constraints: True
+  do_sg_before_composition: True
+
+  composition_kwargs:
+    elements: [78, 46]
+    max_diff_elem: 1
+    min_diff_elem: 1
+    min_atoms: 2
+    max_atoms: 4
+    min_atom_i: 2
+    max_atom_i: 4
+    do_charge_check: False
+
+  space_group_kwargs:
+    space_groups_subset: [229, 225]
+    policy_fmt: onehot
+
+  lattice_parameters_kwargs:
+    min_length: 2.0
+    max_length: 4.0
+    min_angle: 60.0
+    max_angle: 140.0
+    n_comp: 5
+    beta_params_min: 0.1
+    beta_params_max: 100.0
+    min_incr: 0.1
+    fixed_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+    random_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+
+# Buffer
+buffer:
+  replay_capacity: 100
+  train: null
+  test:
+    type: csv
+    path: /network/projects/crystalgfn/data/playground/gull.csv
+
+# GFlowNet hyperparameters
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      # Keep total batch size in 20 because learning rate is unchanged
+      forward: 20
+      backward_replay: 0
+      backward_dataset: 0
+    lr: 0.0001
+    z_dim: 16
+    lr_z_mult: 100
+    n_train_steps: 20000
+    lr_decay_period: 11000
+    lr_decay_gamma: 0.5
+  replay_sampling: weighted
+  train_sampling: permutation
+
+# Policy
+policy:
+  forward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+  backward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+    shared_weights: False
+
+# Proxy (corners)
+proxy:
+  config:
+    - spacegroup: 225
+      mu: 0.85
+      sigma: 0.05
+    - spacegroup: 229
+      mu: 0.65
+      sigma: 0.05
+    - element: 46
+      mu: 0.75
+      sigma: 0.1
+    - element: 78
+      mu: 0.75
+      sigma: 0.001
+
+# Evaluator
+evaluator:
+  first_it: True
+  period: 100
+  checkpoints_period: 500
+  n_trajs_logprobs: 10
+  logprobs_batch_size: 10
+  n: 10
+  n_top_k: 5000
+  top_k: 100
+  top_k_period: -1
+
+# WandB
+logger:
+  lightweight: True
+  run_name: "gull corners"
+  project_name: "crystal-gfn"
+  tags:
+    - gflownet
+    - crystals
+    - formationenergy
+    - small
+  do:
+    online: true
+
+# Hydra
+hydra:
+  run:
+    dir: ${user.logdir.root}/crystalgfn/${oc.env:SLURM_JOB_ID,local}/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/config/experiments/crystals/gull_corners_default.yaml
+++ b/config/experiments/crystals/gull_corners_default.yaml
@@ -1,0 +1,123 @@
+# @package _global_
+#
+# Forward trajectories (10) + Replay buffer (5) + Train set (5)
+# Learning rate decay
+
+defaults:
+  - override /env: crystals/crystal
+  - override /gflownet: trajectorybalance
+  - override /proxy: crystals/corners
+  - override /logger: wandb
+
+device: cpu
+
+# Environment
+env:
+  do_composition_to_sg_constraints: False
+  do_sg_to_composition_constraints: True
+  do_sg_to_lp_constraints: True
+  do_sg_before_composition: True
+
+  composition_kwargs:
+    elements: [78, 46]
+    max_diff_elem: 1
+    min_diff_elem: 1
+    min_atoms: 2
+    max_atoms: 4
+    min_atom_i: 2
+    max_atom_i: 4
+    do_charge_check: False
+
+  space_group_kwargs:
+    space_groups_subset: [229, 225]
+    policy_fmt: onehot
+
+  lattice_parameters_kwargs:
+    min_length: 2.0
+    max_length: 4.0
+    min_angle: 60.0
+    max_angle: 140.0
+    n_comp: 5
+    beta_params_min: 0.1
+    beta_params_max: 100.0
+    min_incr: 0.1
+    fixed_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+    random_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+
+# Buffer
+buffer:
+  replay_capacity: 100
+  train: null
+  test:
+    type: csv
+    path: /network/projects/crystalgfn/data/playground/gull.csv
+
+# GFlowNet hyperparameters
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      # Keep total batch size in 20 because learning rate is unchanged
+      forward: 20
+      backward_replay: 0
+      backward_dataset: 0
+    lr: 0.0001
+    z_dim: 16
+    lr_z_mult: 100
+    n_train_steps: 20000
+    lr_decay_period: 11000
+    lr_decay_gamma: 0.5
+  replay_sampling: weighted
+  train_sampling: permutation
+
+# Policy
+policy:
+  forward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+  backward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+    shared_weights: False
+
+# Evaluator
+evaluator:
+  first_it: True
+  period: 100
+  checkpoints_period: 500
+  n_trajs_logprobs: 10
+  logprobs_batch_size: 10
+  n: 10
+  n_top_k: 5000
+  top_k: 100
+  top_k_period: -1
+
+# WandB
+logger:
+  lightweight: True
+  run_name: "gull corners default"
+  project_name: "crystal-gfn"
+  tags:
+    - gflownet
+    - crystals
+    - formationenergy
+    - small
+  do:
+    online: true
+
+# Hydra
+hydra:
+  run:
+    dir: ${user.logdir.root}/crystalgfn/${oc.env:SLURM_JOB_ID,local}/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/config/experiments/crystals/gull_fe.yaml
+++ b/config/experiments/crystals/gull_fe.yaml
@@ -1,0 +1,135 @@
+# @package _global_
+#
+# Forward trajectories (10) + Replay buffer (5) + Train set (5)
+# Learning rate decay
+
+defaults:
+  - override /env: crystals/crystal
+  - override /gflownet: trajectorybalance
+  - override /proxy: crystals/dave
+  - override /logger: wandb
+
+device: cpu
+
+# Environment
+env:
+  do_composition_to_sg_constraints: False
+  do_sg_to_composition_constraints: True
+  do_sg_to_lp_constraints: True
+  do_sg_before_composition: True
+
+  composition_kwargs:
+    elements: [78, 46]
+    max_diff_elem: 1
+    min_diff_elem: 1
+    min_atoms: 2
+    max_atoms: 4
+    min_atom_i: 2
+    max_atom_i: 4
+    do_charge_check: False
+
+  space_group_kwargs:
+    space_groups_subset: [229, 225]
+
+  lattice_parameters_kwargs:
+    min_length: 2.0
+    max_length: 4.0
+    min_angle: 60.0
+    max_angle: 140.0
+    n_comp: 5
+    beta_params_min: 0.1
+    beta_params_max: 100.0
+    min_incr: 0.1
+    fixed_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+    random_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+
+# Buffer
+buffer:
+  replay_capacity: 100
+  train: null
+  test:
+    type: csv
+    path: /network/projects/crystalgfn/data/playground/gull.csv
+
+# GFlowNet hyperparameters
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      # Keep total batch size in 20 because learning rate is unchanged
+      forward: 20
+      backward_replay: 0
+      backward_dataset: 0
+    lr: 0.0001
+    z_dim: 16
+    lr_z_mult: 100
+    n_train_steps: 20000
+    lr_decay_period: 11000
+    lr_decay_gamma: 0.5
+  replay_sampling: weighted
+  train_sampling: permutation
+
+# Policy
+policy:
+  forward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+  backward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+    shared_weights: False
+
+# Proxy (eform)
+proxy:
+  reward_min: 1e-08
+  do_clip_rewards: True
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
+  rescale_outputs: true
+  # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better
+  reward_function: exponential
+  # Parameters of the reward function
+  reward_function_kwargs:
+    beta: -8.0
+    alpha: 1.0
+
+# Evaluator
+evaluator:
+  first_it: True
+  period: 100
+  checkpoints_period: 500
+  n_trajs_logprobs: 10
+  logprobs_batch_size: 10
+  n: 10
+  n_top_k: 5000
+  top_k: 100
+  top_k_period: -1
+
+# WandB
+logger:
+  lightweight: True
+  run_name: "gull eform"
+  project_name: "crystal-gfn"
+  tags:
+    - gflownet
+    - crystals
+    - formationenergy
+    - small
+  do:
+    online: true
+
+# Hydra
+hydra:
+  run:
+    dir: ${user.logdir.root}/crystalgfn/${oc.env:SLURM_JOB_ID,local}/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/config/experiments/crystals/turaco_corners.yaml
+++ b/config/experiments/crystals/turaco_corners.yaml
@@ -1,0 +1,139 @@
+# @package _global_
+#
+# Forward trajectories (10) + Replay buffer (5) + Train set (5)
+# Learning rate decay
+
+defaults:
+  - override /env: crystals/crystal
+  - override /gflownet: trajectorybalance
+  - override /proxy: crystals/corners
+  - override /logger: wandb
+
+device: cpu
+
+# Environment
+env:
+  do_composition_to_sg_constraints: False
+  do_sg_to_composition_constraints: True
+  do_sg_to_lp_constraints: True
+  do_sg_before_composition: True
+
+  composition_kwargs:
+    elements: [78, 46]
+    max_diff_elem: 1
+    min_diff_elem: 1
+    min_atoms: 2
+    max_atoms: 4
+    min_atom_i: 2
+    max_atom_i: 4
+    do_charge_check: False
+
+  space_group_kwargs:
+    space_groups_subset: [229, 225]
+    policy_fmt: onehot
+
+  lattice_parameters_kwargs:
+    min_length: 2.0
+    max_length: 4.0
+    min_angle: 60.0
+    max_angle: 140.0
+    n_comp: 5
+    beta_params_min: 0.1
+    beta_params_max: 100.0
+    min_incr: 0.02
+    fixed_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+    random_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+
+# Buffer
+buffer:
+  replay_capacity: 100
+  train: null
+  test:
+    type: csv
+    path: /network/projects/crystalgfn/data/playground/gull.csv
+
+# GFlowNet hyperparameters
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      # Keep total batch size in 20 because learning rate is unchanged
+      forward: 20
+      backward_replay: 0
+      backward_dataset: 0
+    lr: 0.0001
+    z_dim: 16
+    lr_z_mult: 100
+    n_train_steps: 50000
+    lr_decay_period: 11000
+    lr_decay_gamma: 0.5
+  replay_sampling: weighted
+  train_sampling: permutation
+
+# Policy
+policy:
+  forward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+  backward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+    shared_weights: False
+
+# Proxy (corners)
+proxy:
+  config:
+    - spacegroup: 225
+      mu: 0.85
+      sigma: 0.05
+    - spacegroup: 229
+      mu: 0.65
+      sigma: 0.05
+    - element: 46
+      mu: 0.75
+      sigma: 0.2
+    - element: 78
+      mu: 0.75
+      sigma: 0.1
+
+# Evaluator
+evaluator:
+  first_it: True
+  period: 500
+  checkpoints_period: 5000
+  n_trajs_logprobs: 10
+  logprobs_batch_size: 10
+  n: 10
+  n_top_k: 5000
+  top_k: 100
+  top_k_period: -1
+
+# WandB
+logger:
+  lightweight: True
+  run_name: "turaco corners"
+  project_name: "crystal-gfn"
+  tags:
+    - gflownet
+    - crystals
+    - formationenergy
+    - small
+  do:
+    online: true
+
+# Hydra
+hydra:
+  run:
+    dir: ${user.logdir.root}/crystalgfn/${oc.env:SLURM_JOB_ID,local}/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/config/experiments/crystals/turaco_corners_default.yaml
+++ b/config/experiments/crystals/turaco_corners_default.yaml
@@ -1,0 +1,123 @@
+# @package _global_
+#
+# Forward trajectories (10) + Replay buffer (5) + Train set (5)
+# Learning rate decay
+
+defaults:
+  - override /env: crystals/crystal
+  - override /gflownet: trajectorybalance
+  - override /proxy: crystals/corners
+  - override /logger: wandb
+
+device: cpu
+
+# Environment
+env:
+  do_composition_to_sg_constraints: False
+  do_sg_to_composition_constraints: True
+  do_sg_to_lp_constraints: True
+  do_sg_before_composition: True
+
+  composition_kwargs:
+    elements: [78, 46]
+    max_diff_elem: 1
+    min_diff_elem: 1
+    min_atoms: 2
+    max_atoms: 4
+    min_atom_i: 2
+    max_atom_i: 4
+    do_charge_check: False
+
+  space_group_kwargs:
+    space_groups_subset: [229, 225]
+    policy_fmt: onehot
+
+  lattice_parameters_kwargs:
+    min_length: 2.0
+    max_length: 4.0
+    min_angle: 60.0
+    max_angle: 140.0
+    n_comp: 5
+    beta_params_min: 0.1
+    beta_params_max: 100.0
+    min_incr: 0.02
+    fixed_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+    random_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+
+# Buffer
+buffer:
+  replay_capacity: 100
+  train: null
+  test:
+    type: csv
+    path: /network/projects/crystalgfn/data/playground/gull.csv
+
+# GFlowNet hyperparameters
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      # Keep total batch size in 20 because learning rate is unchanged
+      forward: 20
+      backward_replay: 0
+      backward_dataset: 0
+    lr: 0.0001
+    z_dim: 16
+    lr_z_mult: 100
+    n_train_steps: 50000
+    lr_decay_period: 11000
+    lr_decay_gamma: 0.5
+  replay_sampling: weighted
+  train_sampling: permutation
+
+# Policy
+policy:
+  forward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+  backward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+    shared_weights: False
+
+# Evaluator
+evaluator:
+  first_it: True
+  period: 500
+  checkpoints_period: 5000
+  n_trajs_logprobs: 10
+  logprobs_batch_size: 10
+  n: 10
+  n_top_k: 5000
+  top_k: 100
+  top_k_period: -1
+
+# WandB
+logger:
+  lightweight: True
+  run_name: "turaco corners default"
+  project_name: "crystal-gfn"
+  tags:
+    - gflownet
+    - crystals
+    - formationenergy
+    - small
+  do:
+    online: true
+
+# Hydra
+hydra:
+  run:
+    dir: ${user.logdir.root}/crystalgfn/${oc.env:SLURM_JOB_ID,local}/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/config/experiments/crystals/turaco_fe.yaml
+++ b/config/experiments/crystals/turaco_fe.yaml
@@ -1,0 +1,136 @@
+# @package _global_
+#
+# Forward trajectories (10) + Replay buffer (5) + Train set (5)
+# Learning rate decay
+
+defaults:
+  - override /env: crystals/crystal
+  - override /gflownet: trajectorybalance
+  - override /proxy: crystals/dave
+  - override /logger: wandb
+
+device: cpu
+
+# Environment
+env:
+  do_composition_to_sg_constraints: False
+  do_sg_to_composition_constraints: True
+  do_sg_to_lp_constraints: True
+  do_sg_before_composition: True
+
+  composition_kwargs:
+    elements: [78, 46]
+    max_diff_elem: 1
+    min_diff_elem: 1
+    min_atoms: 2
+    max_atoms: 4
+    min_atom_i: 2
+    max_atom_i: 4
+    do_charge_check: False
+
+  space_group_kwargs:
+    space_groups_subset: [229, 225]
+    policy_fmt: onehot
+
+  lattice_parameters_kwargs:
+    min_length: 2.0
+    max_length: 4.0
+    min_angle: 60.0
+    max_angle: 140.0
+    n_comp: 5
+    beta_params_min: 0.1
+    beta_params_max: 100.0
+    min_incr: 0.02
+    fixed_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+    random_distr_params:
+      beta_weights: 1.0
+      beta_alpha: 10.0
+      beta_beta: 10.0
+      bernoulli_eos_prob: 0.1
+      bernoulli_bts_prob: 0.1
+
+# Buffer
+buffer:
+  replay_capacity: 100
+  train: null
+  test:
+    type: csv
+    path: /network/projects/crystalgfn/data/playground/gull.csv
+
+# GFlowNet hyperparameters
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      # Keep total batch size in 20 because learning rate is unchanged
+      forward: 20
+      backward_replay: 0
+      backward_dataset: 0
+    lr: 0.0001
+    z_dim: 16
+    lr_z_mult: 100
+    n_train_steps: 50000
+    lr_decay_period: 11000
+    lr_decay_gamma: 0.5
+  replay_sampling: weighted
+  train_sampling: permutation
+
+# Policy
+policy:
+  forward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+  backward:
+    type: mlp
+    n_hid: 256
+    n_layers: 3
+    shared_weights: False
+
+# Proxy (eform)
+proxy:
+  reward_min: 1e-08
+  do_clip_rewards: True
+  ckpt_path: /network/projects/crystalgfn/ckpts/dave/eform/
+  rescale_outputs: true
+  # Boltzmann (exponential), with negative beta because the formation energy is negative and the lower the better
+  reward_function: exponential
+  # Parameters of the reward function
+  reward_function_kwargs:
+    beta: -8.0
+    alpha: 1.0
+
+# Evaluator
+evaluator:
+  first_it: True
+  period: 500
+  checkpoints_period: 5000
+  n_trajs_logprobs: 10
+  logprobs_batch_size: 10
+  n: 10
+  n_top_k: 5000
+  top_k: 100
+  top_k_period: -1
+
+# WandB
+logger:
+  lightweight: True
+  run_name: "turaco eform"
+  project_name: "crystal-gfn"
+  tags:
+    - gflownet
+    - crystals
+    - formationenergy
+    - small
+  do:
+    online: true
+
+# Hydra
+hydra:
+  run:
+    dir: ${user.logdir.root}/crystalgfn/${oc.env:SLURM_JOB_ID,local}/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/gflownet/proxy/crystals/corners.py
+++ b/gflownet/proxy/crystals/corners.py
@@ -1,0 +1,84 @@
+"""Debugging proxy for Crystal-GFN"""
+
+from typing import Dict, List
+
+import numpy as np
+import torch
+from torchtyping import TensorType
+
+from gflownet.proxy.base import Proxy
+from gflownet.proxy.box.corners import Corners
+
+
+class CrystalCorners(Proxy):
+    """
+    A synthetic proxy which resembles the Corners proxy in the lattice parameters
+    domain. It places different corners (with varying mean and standard deviations for
+    the Gaussians) depending on the space group and composition.
+    """
+
+    def __init__(self, config: List[Dict], **kwargs):
+        """
+        Initializes the CrystalCorners proxy according the configuration passed as an
+        argument.
+
+        Parameters
+        ----------
+        config : list
+            A list of dictionaries specifying the parameters of the Corners
+            sub-proxies. Each element in the list is a dictionary that must contain at
+            least one of the following keys:
+                - spacegroup: int
+                - element: int
+            Additionally, it must contain the following keys:
+                - mu: float
+                - sigma:
+            mu and sigma are the mean and standard deviation for a Corners sub-proxy to
+            be applied for states that have the spacegroup and element indicated in the
+            configuration.
+        """
+        super().__init__(**kwargs)
+        if not all([self._dict_is_valid[el] for el in config]):
+            raise ValueError("Configuration is not valid")
+
+    @torch.no_grad()
+    def __call__(self, states: TensorType["batch", "102"]) -> TensorType["batch"]:
+        """
+        Builds the proxy values of the CornersProxy for a batch Crystal states.
+
+        Parameters
+        ----------
+        states : torch.Tensor
+            States to infer on. Shape: ``(batch, [6 + 1 + n_elements])``.
+
+        Returns
+        -------
+        torch.Tensor
+            Proxy scores. Shape: ``(batch,)``.
+        """
+        comp = states[:, :-7]
+        sg = states[:, -7]
+        lat_params = states[:, -6:]
+
+    @staticmethod
+    def _dict_is_valid(config: Dict):
+        """
+        Checks whether a dictionary of configuration is valid.
+
+        To be valid, the following conditions must be satisfied:
+            - There is a key 'mu' containing a float number.
+            - There is a key 'sigma' containing a float number.
+            - There is at least one of the keys 'spacegroup' and 'element' containing
+              an int number.
+        """
+        if "mu" not in config.keys() or isinstance(config["mu"], float):
+            return False
+        if "sigma" not in config.keys() or isinstance(config["sigma"], float):
+            return False
+        if "spacegroup" not in config.keys() and "element" not in config.keys():
+            return False
+        if "spacegroup" in config.keys() and not isinstance(config["spacegroup"], int):
+            return False
+        if "element" in config.keys() and not isinstance(config["spacegroup"], int):
+            return False
+        return True

--- a/gflownet/proxy/crystals/corners.py
+++ b/gflownet/proxy/crystals/corners.py
@@ -146,15 +146,12 @@ class CrystalCorners(Proxy):
         scores = torch.empty(states.shape[0], dtype=self.float)
         default = torch.ones(states.shape[0], dtype=torch.bool)
         for proxy in self.proxies:
-            if "spacegroup" in self.proxies:
-                sg_indices = sg == proxy["spacegroup"]
+            if "spacegroup" in proxy:
+                indices = sg == proxy["spacegroup"]
+            elif "element" in proxy:
+                indices = comp[:, proxy["element"]] > 0
             else:
-                sg_indices = torch.zeros(states.shape[0], dtype=torch.bool)
-            if "element" in self.proxies:
-                el_indices = comp[:, ["element"]] == 1
-            else:
-                el_indices = torch.zeros(states.shape[0], dtype=torch.bool)
-            indices = torch.logical_and(sg_indices, el_indices)
+                raise ValueError("Configuration is not valid")
             scores[indices] = proxy["proxy"](lp_lengths[indices])
             default[indices] = False
 

--- a/tests/gflownet/proxy/test_crystal_corners.py
+++ b/tests/gflownet/proxy/test_crystal_corners.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+
+from gflownet.envs.crystals.crystal import Crystal
+from gflownet.proxy.crystals.corners import CrystalCorners
+
+
+@pytest.fixture()
+def config_one_sg():
+    return [{"spacegroup": 225, "mu": 0.75, "sigma": 0.05}]
+
+
+@pytest.fixture
+def env_gull():
+    return Crystal(
+        composition_kwargs={
+            "elements": [78, 46],
+            "max_diff_elem": 1,
+            "min_atoms": 2,
+            "max_atoms": 4,
+            "min_atom_i": 2,
+            "max_atom_i": 4,
+            "do_charge_check": False,
+        },
+        space_group_kwargs={"space_group_subset": [225, 229]},
+        do_sg_to_composition_constraints=True,
+        do_sg_before_composition=True,
+    )

--- a/tests/gflownet/proxy/test_crystal_corners.py
+++ b/tests/gflownet/proxy/test_crystal_corners.py
@@ -217,9 +217,6 @@ def test__proxies_of_conditions_return_expected_values(config, env_gull, request
 
     # Check that mu is a maximum
     for c in proxy.proxies:
-        import ipdb
-
-        ipdb.set_trace()
         proxy_mu = c["proxy"](torch.tensor(c["mu"]).repeat(1, 3))[0]
         assert proxy_mu > c["proxy"](torch.tensor(c["mu"] + 0.01).repeat(1, 3))[0]
         assert proxy_mu > c["proxy"](torch.tensor(c["mu"] - 0.01).repeat(1, 3))[0]

--- a/tests/gflownet/proxy/test_crystal_corners.py
+++ b/tests/gflownet/proxy/test_crystal_corners.py
@@ -197,6 +197,34 @@ def test__proxy_default__returns_valid_scores(proxy_default, env_gull, n_states=
     assert torch.all(scores > 0)
 
 
+@pytest.mark.parametrize(
+    "config",
+    [
+        "config_one_sg",
+        "config_two_sg",
+        "config_one_el",
+        "config_two_el",
+        "config_all",
+    ],
+)
+def test__proxies_of_conditions_return_expected_values(config, env_gull, request):
+    config = request.getfixturevalue(config)
+    # Initialize proxy with condition
+    proxy = CrystalCorners(device="cpu", float_precision=32, config=config)
+    proxy.setup(env_gull)
+
+    assert config == proxy.proxies
+
+    # Check that mu is a maximum
+    for c in proxy.proxies:
+        import ipdb
+
+        ipdb.set_trace()
+        proxy_mu = c["proxy"](torch.tensor(c["mu"]).repeat(1, 3))[0]
+        assert proxy_mu > c["proxy"](torch.tensor(c["mu"] + 0.01).repeat(1, 3))[0]
+        assert proxy_mu > c["proxy"](torch.tensor(c["mu"] - 0.01).repeat(1, 3))[0]
+
+
 def test__applying_sg_condition_changes_scores(
     proxy_default, config_one_sg, env_gull, n_states=10
 ):

--- a/tests/gflownet/proxy/test_crystal_corners.py
+++ b/tests/gflownet/proxy/test_crystal_corners.py
@@ -20,6 +20,7 @@ def env_gull():
     return Crystal(
         composition_kwargs={
             "elements": [78, 46],
+            "min_diff_elem": 1,
             "max_diff_elem": 1,
             "min_atoms": 2,
             "max_atoms": 4,
@@ -28,10 +29,78 @@ def env_gull():
             "do_charge_check": False,
         },
         space_group_kwargs={"space_group_subset": [225, 229]},
+        lattice_parameters_kwargs={
+            "min_length": 2.0,
+            "max_length": 4.0,
+            "min_angle": 60.0,
+            "max_angle": 140.0,
+        },
         do_sg_to_composition_constraints=True,
         do_sg_before_composition=True,
     )
 
 
 def test__proxy_default__initializes_properly(proxy_default):
+    assert True
+
+
+def test__setup__works_as_expected(proxy_default, env_gull):
+    proxy_default.setup(env_gull)
+    assert hasattr(proxy_default, "min_length")
+    assert hasattr(proxy_default, "max_length")
+    assert proxy_default.min_length == 2.0
+    assert proxy_default.max_length == 4.0
+
+
+@pytest.mark.parametrize(
+    "lp_lengths, lp_lengths_corners",
+    [
+        (
+            torch.tensor(
+                [
+                    [2.0, 2.0, 2.0],
+                    [4.0, 4.0, 4.0],
+                    [2.0, 3.0, 4.0],
+                ],
+                dtype=torch.float32,
+            ),
+            torch.tensor(
+                [
+                    [-1.0, -1.0, -1.0],
+                    [1.0, 1.0, 1.0],
+                    [-1.0, 0.0, 1.0],
+                ],
+                dtype=torch.float32,
+            ),
+        ),
+        (
+            torch.tensor(
+                [
+                    [2.0, 2.5, 3.0, 3.5, 4.0],
+                ],
+                dtype=torch.float32,
+            ),
+            torch.tensor(
+                [
+                    [-1.0, -0.5, 0.0, 0.5, 1.0],
+                ],
+                dtype=torch.float32,
+            ),
+        ),
+    ],
+)
+def test__lattice_lengths_to_corners_proxy__returns_expected(
+    proxy_default, env_gull, lp_lengths, lp_lengths_corners
+):
+    proxy_default.setup(env_gull)
+    assert torch.equal(
+        proxy_default.lattice_lengths_to_corners_proxy(lp_lengths), lp_lengths_corners
+    )
+
+
+def test__proxy_default__returns_expected_scores(proxy_default, env_gull, n_states=2):
+    # Generate random crystal terminating states
+    states = env_gull.get_random_terminating_states(n_states)
+    states_proxy = env_gull.states2proxy(states)
+    scores = proxy_default(states_proxy)
     assert True

--- a/tests/gflownet/proxy/test_crystal_corners.py
+++ b/tests/gflownet/proxy/test_crystal_corners.py
@@ -6,6 +6,11 @@ from gflownet.proxy.crystals.corners import CrystalCorners
 
 
 @pytest.fixture()
+def proxy_default():
+    return CrystalCorners(device="cpu", float_precision=32)
+
+
+@pytest.fixture()
 def config_one_sg():
     return [{"spacegroup": 225, "mu": 0.75, "sigma": 0.05}]
 
@@ -26,3 +31,7 @@ def env_gull():
         do_sg_to_composition_constraints=True,
         do_sg_before_composition=True,
     )
+
+
+def test__proxy_default__initializes_properly(proxy_default):
+    assert True


### PR DESCRIPTION
This PR implements a new synthetic proxy for the Crystal-GFN.

The new proxy, CrystalCorners reuses the box's Corners proxy and applies it on the lattice parameters a, b, and c. Further, it allows to set different means and standard deviation for the Corners as a function of the presence of a space group or an element in the state. 