### PR TITLE
[Buffer] Speed up diversity check in replay buffer

### DIFF
--- a/config/buffer/base.yaml
+++ b/config/buffer/base.yaml
@@ -32,5 +32,14 @@ use_main_buffer: False
 # Whether new samples are compared to samples in the buffer before adding
 check_diversity: False
 
+# The accepted level of similarity of rewards to include samples from the
+# replay buffer in the diversity check. Assuming check_diversity is True, given
+# a sample x with reward R(x), the diversity check will only be performed
+# against those samples in the replay buffer whose reward difference with
+# respect to R(x) is smaller than diversity_check_reward_similarity times the
+# difference between the maximum reward and the minimum reward in the replay
+# buffer.
+diversity_check_reward_similarity: 0.1
+
 # Whether to show a progress bar while processing the data sets. False by default.
 progress_process_dataset: False

--- a/config/experiments/crystals/starling_bg.yaml
+++ b/config/experiments/crystals/starling_bg.yaml
@@ -64,6 +64,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/bandgap/train.csv

--- a/config/experiments/crystals/starling_bg_no_constraints.yaml
+++ b/config/experiments/crystals/starling_bg_no_constraints.yaml
@@ -64,6 +64,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/bandgap/train.csv

--- a/config/experiments/crystals/starling_density.yaml
+++ b/config/experiments/crystals/starling_density.yaml
@@ -64,6 +64,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/eform/train.csv

--- a/config/experiments/crystals/starling_density_no_constraints.yaml
+++ b/config/experiments/crystals/starling_density_no_constraints.yaml
@@ -64,6 +64,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/eform/train.csv

--- a/config/experiments/crystals/starling_fe.yaml
+++ b/config/experiments/crystals/starling_fe.yaml
@@ -64,6 +64,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/eform/train.csv

--- a/config/experiments/crystals/starling_fe_no_constraints.yaml
+++ b/config/experiments/crystals/starling_fe_no_constraints.yaml
@@ -63,6 +63,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/eform/train.csv

--- a/config/experiments/crystals/starling_fe_restricted_a.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_a.yaml
@@ -66,6 +66,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/eform/train.csv

--- a/config/experiments/crystals/starling_fe_restricted_b.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_b.yaml
@@ -64,14 +64,18 @@ env:
       beta_beta: 10.0
       bernoulli_eos_prob: 0.1
       bernoulli_bts_prob: 0.1
-  buffer:
-    replay_capacity: 1000
-    train:
-      type: csv
-      path: /network/projects/crystalgfn/data/eform/train.csv
-    test:
-      type: csv
-      path: /network/projects/crystalgfn/data/eform/val.csv
+
+# Buffer
+buffer:
+  replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
+  train:
+    type: csv
+    path: /network/projects/crystalgfn/data/eform/train.csv
+  test:
+    type: csv
+    path: /network/projects/crystalgfn/data/eform/val.csv
 
 # GFlowNet hyperparameters
 gflownet:

--- a/config/experiments/crystals/starling_fe_restricted_c.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_c.yaml
@@ -67,6 +67,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/eform/train.csv

--- a/config/experiments/crystals/starling_fe_restricted_d.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_d.yaml
@@ -68,6 +68,8 @@ env:
 # Buffer
 buffer:
   replay_capacity: 1000
+  check_diversity: True
+  diversity_check_reward_similarity: 0.01
   train:
     type: csv
     path: /network/projects/crystalgfn/data/eform/train.csv

--- a/gflownet/buffer/base.py
+++ b/gflownet/buffer/base.py
@@ -39,6 +39,7 @@ class BaseBuffer:
         test: Dict = None,
         use_main_buffer=False,
         check_diversity: bool = False,
+        diversity_check_reward_similarity: float = 0.1,
         progress_process_dataset: bool = False,
         **kwargs,
     ):
@@ -90,6 +91,14 @@ class BaseBuffer:
             for the comparison. It is False by default because this comparison can
             easily take most of the running time with an uncertain impact on the
             performance. The implementation should be improved to make this functional.
+        diversity_check_reward_similarity : float
+            The accepted level of similarity of rewards to include samples from the
+            replay buffer in the diversity check. Assuming check_diversity is True,
+            given a sample x with reward R(x), the diversity check will only be
+            performed against those samples in the replay buffer whose reward
+            difference with respect to R(x) is smaller than
+            diversity_check_reward_similarity times the difference between the maximum
+            reward and the minimum reward in the replay buffer. By default, it is 0.1.
         progress_process_dataset : bool
             Whether to show a progress bar while processing the data sets. False by
             default.
@@ -102,6 +111,7 @@ class BaseBuffer:
         self.test_config = self._process_data_config(test)
         self.use_main_buffer = use_main_buffer
         self.check_diversity = check_diversity
+        self.diversity_check_reward_similarity = diversity_check_reward_similarity
         self.progress_process_dataset = progress_process_dataset
         if self.use_main_buffer:
             self.main = pd.DataFrame(
@@ -396,7 +406,11 @@ class BaseBuffer:
         # TODO: this could be optimized by comparing only with samples with similar
         # reward
         if self.check_diversity:
-            for rsample in self.replay["samples"]:
+            rewards_range = self.replay["rewards"].max() - self.replay["rewards"].min()
+            max_reward_diff = self.diversity_check_reward_similarity * rewards_range
+            for rsample in self.replay.loc[
+                np.abs(self.replay["rewards"] - reward) < max_reward_diff
+            ]["samples"]:
                 if self.env.isclose(sample, rsample):
                     return
 


### PR DESCRIPTION
The replay buffer behaves significantly different - with a less positive or even with a negative effect - if the diversity of the samples in the buffer is not taken into account when inserting new samples.

Currently, because the Buffer is not yet implemented as a more efficient data structure, checking the similarity of a new sample with the samples already present in the replay buffer requires many pairwise comparisons. This incurs a significant computational overhead as the the capacity of the replay buffer gets larger and the states more complex, as is the case of the Crystal-GFN. In particular, I have observed that **checking the diversity of the replay buffer can account for more than half of the training time**.

This PR reduces the computational time of the diversity check in the replay buffer by comparing new samples only with those samples in the replay buffer that have similar reward. 

I have first introduced a new parameter for the Buffer, `diversity_check_reward_similarity`, which I will refer here as δ. Then, for every new sample that has larger reward than the minimum reward in the replay buffer, we compute the difference d between the maximum Rmax and minimum reward Rmin in the replay buffer, d = Rmax - Rmin. Then, we perform a similarity check, that is `self.env.isclose(sample, rsample)` where `sample` is the new sample and `rsample` is a sample from the replay buffer`, if the absolute difference between the rewards of `sample` and `rsample` is smaller than d * δ.

Using a δ of 0.01 in the Crystal-GFN, I observe that the run time is equivalent to not performing any similarity check while I see no visible impact in the performance and specifically on the training statistics of the replay buffer.  

Other improvements that can be introduced:
- Disable attempting to insert samples in the replay buffer that were sampled from the replay buffer itself.