### PR TITLE
[Logprobs efficiency] Improve handling of actions in `get_logprobs()`

### DIFF
--- a/gflownet/envs/ctorus.py
+++ b/gflownet/envs/ctorus.py
@@ -303,9 +303,7 @@ class ContinuousTorus(HybridTorus):
                 )[do_bts, : self.n_dim]
                 actions_bts = states_from_angles - source_angles
                 actions_tensor[do_bts] = actions_bts
-        # TODO: is this too inefficient because of the multiple data transfers?
-        actions = [tuple(a.tolist()) for a in actions_tensor]
-        return actions
+        return [tuple(a) for a in actions_tensor.tolist()]
 
     def get_logprobs(
         self,

--- a/gflownet/envs/ctorus.py
+++ b/gflownet/envs/ctorus.py
@@ -310,7 +310,7 @@ class ContinuousTorus(HybridTorus):
     def get_logprobs(
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
-        actions: TensorType["n_states", "n_dim"],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask: TensorType["n_states", "1"],
         states_from: Optional[List] = None,
         is_backward: bool = False,
@@ -318,18 +318,15 @@ class ContinuousTorus(HybridTorus):
         """
         Computes log probabilities of actions given policy outputs and actions.
 
-        Args
-        ----
+        Parameters
+        ----------
         policy_outputs : tensor
             The output of the GFlowNet policy model.
-
         mask : tensor
             The mask containing information special cases.
-
-        actions : tensor
+        actions : list or tensor
             The actions (angle increments) from each state in the batch for which to
             compute the log probability.
-
         states_from : tensor
             Ignored.
 
@@ -338,6 +335,7 @@ class ContinuousTorus(HybridTorus):
         """
         device = policy_outputs.device
         do_sample = torch.all(~mask, dim=1)
+        actions = tfloat(actions, float_type=self.float, device=self.device)
         n_states = policy_outputs.shape[0]
         logprobs = torch.zeros(n_states, self.n_dim).to(device)
         if torch.any(do_sample):

--- a/gflownet/envs/ctorus.py
+++ b/gflownet/envs/ctorus.py
@@ -3,7 +3,7 @@ Classes to represent hyper-torus environments
 """
 
 import itertools
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/gflownet/envs/cube.py
+++ b/gflownet/envs/cube.py
@@ -233,7 +233,7 @@ class CubeBase(GFlowNetEnv, ABC):
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
         is_forward: bool,
-        actions: TensorType["n_states", 2],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask_invalid_actions: TensorType["batch_size", "policy_output_dim"] = None,
         loginf: float = 1000,
     ) -> TensorType["batch_size"]:
@@ -1280,7 +1280,7 @@ class ContinuousCube(CubeBase):
     def get_logprobs(
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
-        actions: TensorType["n_states", "actions_dim"],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask: TensorType["n_states", "mask_dim"],
         states_from: List,
         is_backward: bool,
@@ -1288,22 +1288,18 @@ class ContinuousCube(CubeBase):
         """
         Computes log probabilities of actions given policy outputs and actions.
 
-        Args
-        ----
+        Parameters
+        ----------
         policy_outputs : tensor
             The output of the GFlowNet policy model.
-
         mask : tensor
             The mask containing information about invalid actions and special cases.
-
-        actions : tensor
+        actions : list or tensor
             The actions (absolute increments) from each state in the batch for which to
             compute the log probability.
-
         states_from : tensor
             The states originating the actions, in GFlowNet format. They are required
             so as to compute the relative increments and the Jacobian.
-
         is_backward : bool
             True if the actions are backward, False if the actions are forward
             (default). Required, since the computation for forward and backward actions
@@ -1321,7 +1317,7 @@ class ContinuousCube(CubeBase):
     def _get_logprobs_forward(
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
-        actions: TensorType["n_states", "actions_dim"],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask: TensorType["n_states", "3"],
         states_from: List,
     ) -> TensorType["batch_size"]:
@@ -1329,6 +1325,7 @@ class ContinuousCube(CubeBase):
         Computes log probabilities of forward actions.
         """
         # Initialize variables
+        actions = tfloat(actions, float_type=self.float, device=self.device)
         n_states = policy_outputs.shape[0]
         states_from_tensor = tfloat(
             states_from, float_type=self.float, device=self.device
@@ -1417,7 +1414,7 @@ class ContinuousCube(CubeBase):
     def _get_logprobs_backward(
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
-        actions: TensorType["n_states", "actions_dim"],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask: TensorType["n_states", "3"],
         states_from: List,
     ) -> TensorType["batch_size"]:
@@ -1425,6 +1422,7 @@ class ContinuousCube(CubeBase):
         Computes log probabilities of backward actions.
         """
         # Initialize variables
+        actions = tfloat(actions, float_type=self.float, device=self.device)
         n_states = policy_outputs.shape[0]
         states_from_tensor = tfloat(
             states_from, float_type=self.float, device=self.device

--- a/gflownet/envs/cube.py
+++ b/gflownet/envs/cube.py
@@ -1157,8 +1157,7 @@ class ContinuousCube(CubeBase):
                 (increments, torch.zeros((increments.shape[0], 1))), dim=1
             )
         actions_tensor[is_source, -1] = 1
-        actions = [tuple(a.tolist()) for a in actions_tensor]
-        return actions
+        return [tuple(a) for a in actions_tensor.tolist()]
 
     def _sample_actions_batch_backward(
         self,
@@ -1274,8 +1273,7 @@ class ContinuousCube(CubeBase):
             actions_tensor[is_bts, :-1] = self._mask_ignored_dimensions(
                 mask[is_bts], actions_tensor[is_bts, :-1]
             )
-        actions = [tuple(a.tolist()) for a in actions_tensor]
-        return actions
+        return [tuple(a) for a in actions_tensor.tolist()]
 
     def get_logprobs(
         self,

--- a/gflownet/envs/htorus.py
+++ b/gflownet/envs/htorus.py
@@ -376,7 +376,7 @@ class HybridTorus(GFlowNetEnv):
     def get_logprobs(
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
-        actions: TensorType["n_states", 2],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask: TensorType["batch_size", "policy_output_dim"] = None,
         states_from: Optional[List] = None,
         is_backward: bool = False,

--- a/gflownet/envs/set.py
+++ b/gflownet/envs/set.py
@@ -12,7 +12,7 @@ import torch
 from torchtyping import TensorType
 
 from gflownet.envs.base import GFlowNetEnv
-from gflownet.utils.common import copy, tlong
+from gflownet.utils.common import copy, tfloat, tlong
 
 
 class BaseSet(GFlowNetEnv):

--- a/gflownet/envs/stack.py
+++ b/gflownet/envs/stack.py
@@ -831,7 +831,7 @@ class Stack(GFlowNetEnv):
     def get_logprobs(
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
-        actions: TensorType["n_states", "actions_dim"],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask: TensorType["n_states", "mask_dim"],
         states_from: List,
         is_backward: bool,
@@ -839,25 +839,22 @@ class Stack(GFlowNetEnv):
         """
         Computes log probabilities of actions given policy outputs and actions.
 
-        Args
-        ----
+        Parameters
+        ----------
         policy_outputs : tensor
             The output of the GFlowNet policy model.
-
         mask : tensor
             The mask containing information about invalid actions and special cases.
-
-        actions : tensor
+        actions : list or tensor
             The actions (global) from each state in the batch for which to compute the
             log probability.
-
         states_from : tensor
             The states originating the actions, in environment format.
-
         is_backward : bool
             True if the actions are backward, False if the actions are forward
             (default).
         """
+        actions = tfloat(actions, float_type=self.float, device=self.device)
         n_states = policy_outputs.shape[0]
         # Get the relevant stage of each mask from the one-hot prefix
         stages = torch.where(mask[:, : self.n_subenvs])[1]

--- a/gflownet/envs/tree.py
+++ b/gflownet/envs/tree.py
@@ -722,7 +722,6 @@ class Tree(GFlowNetEnv):
         random_action_prob: Optional[float] = 0.0,
         temperature_logits: Optional[float] = 1.0,
         max_sampling_attempts: Optional[int] = 10,
-        get_logprobs: bool = True,
     ) -> Tuple[List[Tuple], TensorType["n_states"]]:
         """
         Samples a batch of actions from a batch of policy outputs.
@@ -737,7 +736,6 @@ class Tree(GFlowNetEnv):
                 random_action_prob=random_action_prob,
                 temperature_logits=temperature_logits,
                 max_sampling_attempts=max_sampling_attempts,
-                get_logprobs=get_logprobs,
             )
         else:
             return super().sample_actions_batch(
@@ -749,13 +747,12 @@ class Tree(GFlowNetEnv):
                 random_action_prob=random_action_prob,
                 temperature_logits=temperature_logits,
                 max_sampling_attempts=max_sampling_attempts,
-                get_logprobs=get_logprobs,
             )
 
     def get_logprobs_continuous(
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
-        actions: TensorType["n_states", "n_dim"],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask: TensorType["n_states", "1"] = None,
         states_from: Optional[List] = None,
         is_backward: bool = False,
@@ -763,6 +760,7 @@ class Tree(GFlowNetEnv):
         """
         Computes log probabilities of actions given policy outputs and actions.
         """
+        actions = tfloat(actions, float_type=self.float, device=self.device)
         n_states = policy_outputs.shape[0]
         # TODO: make nicer
         if states_from is None:
@@ -807,7 +805,7 @@ class Tree(GFlowNetEnv):
     def get_logprobs(
         self,
         policy_outputs: TensorType["n_states", "policy_output_dim"],
-        actions: TensorType["n_states", "n_dim"],
+        actions: Union[List, TensorType["n_states", "action_dim"]],
         mask: TensorType["n_states", "1"] = None,
         states_from: Optional[List] = None,
         is_backward: bool = False,

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -362,10 +362,9 @@ class GFlowNetAgent:
             temperature_logits=temperature,
         )
         # Compute logprobs from policy outputs
-        actions_tensor = tfloat(actions, device=self.device, float_type=self.float)
         logprobs = self.env.get_logprobs(
             policy_outputs=policy_outputs,
-            actions=actions_tensor,
+            actions=actions,
             mask=mask_invalid_actions,
             states_from=states,
             is_backward=backward,

--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -580,11 +580,16 @@ class Batch:
             return states_proxy
         return self.readonly_env.states2proxy(states)
 
-    def get_actions(self) -> TensorType["n_states, action_dim"]:
+    def get_actions(self) -> List:
         """
-        Returns the actions in the batch as a float tensor.
+        Returns the actions in the batch.
+
+        Returns
+        -------
+        list
+            The list of actions in the batch.
         """
-        return tfloat(self.actions, float_type=self.float, device=self.device)
+        return self.actions
 
     def get_logprobs(self, backward: bool = False) -> TensorType["n_states"]:
         """

--- a/tests/gflownet/utils/test_batch.py
+++ b/tests/gflownet/utils/test_batch.py
@@ -416,9 +416,7 @@ def test__forward_sampling_multiple_envs_all_as_expected(env, proxy, batch, requ
     assert torch.equal(states_policy_batch, env.states2policy(states))
     # Check actions
     actions_batch = batch.get_actions()
-    assert torch.equal(
-        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
-    )
+    assert actions_batch == actions
     # Check done
     done_batch = batch.get_done()
     assert torch.equal(done_batch, tbool(done, device=batch.device))
@@ -601,9 +599,7 @@ def test__forward_sampling_multiple_envs_with_logprobs_all_as_expected(
     assert torch.equal(states_policy_batch, env.states2policy(states))
     # Check actions
     actions_batch = batch.get_actions()
-    assert torch.equal(
-        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
-    )
+    assert actions_batch == actions
     # Check logprobs
     logprobs_batch = batch.get_logprobs()
     assert torch.equal(
@@ -787,9 +783,7 @@ def test__backward_sampling_multiple_envs_all_as_expected(env, proxy, batch, req
     assert torch.equal(states_policy_batch, env.states2policy(states))
     # Check actions
     actions_batch = batch.get_actions()
-    assert torch.equal(
-        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
-    )
+    assert actions_batch == actions
     # Check done
     done_batch = batch.get_done()
     assert torch.equal(done_batch, tbool(dones, device=batch.device))
@@ -1039,9 +1033,7 @@ def test__mixed_sampling_multiple_envs_all_as_expected(env, proxy, batch, reques
     assert torch.equal(states_policy_batch, env.states2policy(states))
     # Check actions
     actions_batch = batch.get_actions()
-    assert torch.equal(
-        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
-    )
+    assert actions_batch == actions
     # Check done
     done_batch = batch.get_done()
     assert torch.equal(done_batch, tbool(dones, device=batch.device))
@@ -1300,9 +1292,7 @@ def test__mixed_sampling_merged_all_as_expected(env, proxy, request):
     assert torch.equal(states_policy_batch, env.states2policy(states))
     # Check actions
     actions_batch = batch.get_actions()
-    assert torch.equal(
-        actions_batch, tfloat(actions, float_type=batch.float, device=batch.device)
-    )
+    assert actions_batch == actions
     # Check done
     done_batch = batch.get_done()
     assert torch.equal(done_batch, tbool(dones, device=batch.device))


### PR DESCRIPTION
- Improve the handling of actions in `get_logprobs()`:
  - By default, the format of the actions remains a list of tuples. This results in easier-to-read code and it is even more efficient.
  - But in some environments (meta-environments such as Set and Stack) it is practical to convert the actions into a tensor for easier indexing.
  - Therefore, `get_logprobs()` may receive actions as a list or as a tensor
- The conversion from a tensor of actions into actions as tuples is also improved.