### PR TITLE
Extend Corners proxy

### DIFF
--- a/config/experiments/grid/corners_orig_paper.yaml
+++ b/config/experiments/grid/corners_orig_paper.yaml
@@ -1,0 +1,74 @@
+# @package _global_
+# A configuration that works well with a 10x10 Grid environment and the corners proxy.
+
+defaults:
+   - override /env: grid
+   - override /gflownet: flowmatch
+   - override /loss: flowmatching
+   - override /proxy: box/corners
+   - override /logger: wandb
+
+# Environment
+env:
+  n_dim: 4
+  length: 8
+  max_increment: 1
+  max_dim_per_action: 1
+
+# Proxy
+proxy:
+  mu: 0.7
+  sigma: 0.05
+  do_gaussians: False
+  scores:
+    - 2.0
+    - 0.5
+    - 0.01
+
+# Buffer
+buffer:
+  replay_capacity: 16
+  check_diversity: True
+  test:
+    type: all
+
+# GFlowNet hyperparameters
+gflownet:
+  random_action_prob: 0.0
+  optimizer:
+    batch_size:
+      forward: 16
+    lr: 0.0001
+    n_train_steps: 20000
+
+# Policy
+policy:
+  forward:
+    type: mlp
+    n_hid: 256
+    n_layers: 2
+
+# WandB
+logger:
+  do:
+    online: False
+  lightweight: True
+  project_name: "grid"
+  run_name: "4D L8 FM"
+  tags: 
+    - gflownet
+    - grid
+    - corners
+
+# Evaluator
+evaluator:
+  first_it: True
+  period: 500
+  n: 1000
+  checkpoints_period: 500
+
+
+# Hydra
+hydra:
+  run:
+    dir: ${user.logdir.root}/grid/corners/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/config/proxy/box/corners.yaml
+++ b/config/proxy/box/corners.yaml
@@ -2,3 +2,8 @@ _target_: gflownet.proxy.box.corners.Corners
 
 mu: 0.75
 sigma: 0.05
+do_threshold: False
+thresholds:
+  - [0.0, 2.0, 1e-6]
+  - [2.0, 3.0, 2.0]
+  - [3.0, 100, 10.0]

--- a/config/proxy/box/corners.yaml
+++ b/config/proxy/box/corners.yaml
@@ -2,8 +2,13 @@ _target_: gflownet.proxy.box.corners.Corners
 
 mu: 0.75
 sigma: 0.05
+do_gaussians: True
 do_threshold: False
 thresholds:
   - [0.0, 2.0, 1e-6]
   - [2.0, 3.0, 2.0]
   - [3.0, 100, 10.0]
+scores:
+  - 2.0
+  - 0.5
+  - 0.01

--- a/gflownet/proxy/box/corners.py
+++ b/gflownet/proxy/box/corners.py
@@ -58,7 +58,7 @@ class Corners(Proxy):
         self.mu = mu
         self.sigma = sigma
         self.do_threshold = do_threshold
-        self.thresholds = (tuple(el) for el in thresholds)
+        self.thresholds = tuple(tuple(el) for el in thresholds)
 
     def setup(self, env=None):
         if env:

--- a/gflownet/proxy/box/corners.py
+++ b/gflownet/proxy/box/corners.py
@@ -2,16 +2,27 @@
 Corners objective function, defined for box-like environments, such as the hyper-grid
 and the cube.
 
-The function places high scores in all corners of the hyper-box via a mixture of
-Gaussians. Optionally, the scores and can be thresholded in order to make the task
-harder.
+The function places high scores in all corners of the hyper-box according to either of
+these options:
+     - A mixture of Gaussians. Optionally, the scores and can be thresholded in order
+       to make the task harder.
+     - A hard-coded function that assigns each point of the hyper-box to one of three
+       scores (this matches the function used in the original GFlowNets paper):
+        - High scores: points in the corners at a distance from the edge between 0.2
+          and 0.1 the length of the box.
+        - Middle scores: points in the corners at distance from the edge within a
+          quarter the length of the box.
+        - Low scores: all other points.
 """
+
+from typing import Iterable
 
 import numpy as np
 import torch
 from torchtyping import TensorType
 
 from gflownet.proxy.base import Proxy
+from gflownet.utils.common import tfloat
 
 
 class Corners(Proxy):
@@ -24,8 +35,10 @@ class Corners(Proxy):
         n_dim=None,
         mu=None,
         sigma=None,
+        do_gaussians=True,
         do_threshold=False,
-        thresholds=((0.0, 2.0, 1e-6), (2.0, 3.0, 2.0), (3.0, 100, 10.0)),
+        thresholds: Iterable = ((0.0, 2.0, 1e-6), (2.0, 3.0, 2.0), (3.0, 100, 10.0)),
+        scores: Iterable = [2.0, 0.5, 0.01],
         **kwargs,
     ):
         """
@@ -38,27 +51,37 @@ class Corners(Proxy):
         mu : float
             Mean of the Gaussian distributions that make the objective function. It
             should be a value between 0.0 and 1.0. A value closer to 1.0 places the
-            regions of high reward closer to the edges (in the corners) and a value
-            closer to 0.0 places the regions of high reward closer to the center.
+            regions of high scores closer to the edges (in the corners) and a value
+            closer to 0.0 places the regions of high scores closer to the center.
         sigma : float
             Standard deviation of the Gaussian distributions that make the objective
             function.
+        do_gaussians : bool
+            If True, the score landscape is modelled by a mixture of Gaussians.
+            Otherwise, the scores are assigned via an indicator function, as in the
+            original GFlowNets paper.
         do_threshold : bool
             If True, the values of the Gaussians are thresholded using the values in
             ``thresholds``.
-        thresholds : list
+        thresholds : iterable
             A list of tuples with the information to threshold the objective function.
             The first two values of the tuple indicate the lower and upper bound of a
             range, and the third value indicates the value onto which values in the
             range are mapped. For example, (0.0, 1.0, 1e-6) will map all values between
             0.0 and 1.0 to 1e-6.
+        scores : iterable
+            The scores of the three regions for the non-Gaussian version. It should be
+            a list with three elements, where the first element is highest score, the
+            second element the middle score and the third element the lowest score.
         """
         super().__init__(**kwargs)
         self.n_dim = n_dim
         self.mu = mu
         self.sigma = sigma
+        self.do_gaussians = do_gaussians
         self.do_threshold = do_threshold
         self.thresholds = tuple(tuple(el) for el in thresholds)
+        self.scores = tuple(scores)
 
     def setup(self, env=None):
         if env:
@@ -77,28 +100,43 @@ class Corners(Proxy):
     @property
     def optimum(self):
         if not hasattr(self, "_optimum"):
-            mode = self.mu * torch.ones(
-                self.n_dim, device=self.device, dtype=self.float
-            )
-            self._optimum = self(torch.unsqueeze(mode, 0))[0]
+            if self.do_gaussians:
+                mode = self.mu * torch.ones(
+                    self.n_dim, device=self.device, dtype=self.float
+                )
+                self._optimum = self(torch.unsqueeze(mode, 0))[0]
+            else:
+                self._optimum = sum(self.scores)
         return self._optimum
 
     def __call__(self, states: TensorType["batch", "state_dim"]) -> TensorType["batch"]:
-        scores = self.mulnormal_norm * torch.exp(
-            -0.5
-            * (
-                torch.diag(
-                    torch.tensordot(
+        if self.do_gaussians:
+            scores = self.mulnormal_norm * torch.exp(
+                -0.5
+                * (
+                    torch.diag(
                         torch.tensordot(
-                            (torch.abs(states) - self.mu_vec), self.cov_inv, dims=1
-                        ),
-                        (torch.abs(states) - self.mu_vec).T,
-                        dims=1,
+                            torch.tensordot(
+                                (torch.abs(states) - self.mu_vec), self.cov_inv, dims=1
+                            ),
+                            (torch.abs(states) - self.mu_vec).T,
+                            dims=1,
+                        )
                     )
                 )
             )
-        )
-        if self.do_threshold:
-            for th in self.thresholds:
-                scores[(scores >= th[0]) & (scores < th[1])] = th[2]
+            if self.do_threshold:
+                for th in self.thresholds:
+                    scores[(scores >= th[0]) & (scores < th[1])] = th[2]
+        else:
+            states_abs = torch.abs(states)
+            mid_scores = self.scores[1] * tfloat(
+                states_abs >= 0.5, float_type=self.float, device=self.device
+            ).prod(dim=1)
+            high_scores = self.scores[0] * tfloat(
+                (states_abs >= 0.6) & (states_abs < 0.8),
+                float_type=self.float,
+                device=self.device,
+            ).prod(dim=1)
+            scores = self.scores[2] + mid_scores + high_scores
         return scores

--- a/gflownet/proxy/box/corners.py
+++ b/gflownet/proxy/box/corners.py
@@ -1,3 +1,12 @@
+"""
+Corners objective function, defined for box-like environments, such as the hyper-grid
+and the cube.
+
+The function places high scores in all corners of the hyper-box via a mixture of
+Gaussians. Optionally, the scores and can be thresholded in order to make the task
+harder.
+"""
+
 import numpy as np
 import torch
 from torchtyping import TensorType
@@ -10,11 +19,46 @@ class Corners(Proxy):
     It is assumed that the state values will be in the range [-1.0, 1.0].
     """
 
-    def __init__(self, n_dim=None, mu=None, sigma=None, **kwargs):
+    def __init__(
+        self,
+        n_dim=None,
+        mu=None,
+        sigma=None,
+        do_threshold=False,
+        thresholds=((0.0, 2.0, 1e-6), (2.0, 3.0, 2.0), (3.0, 100, 10.0)),
+        **kwargs,
+    ):
+        """
+        Initializes an instance of the Corners proxy.
+
+        Parameters
+        ----------
+        n_dim : int
+            Dimensionality of the hyper-box.
+        mu : float
+            Mean of the Gaussian distributions that make the objective function. It
+            should be a value between 0.0 and 1.0. A value closer to 1.0 places the
+            regions of high reward closer to the edges (in the corners) and a value
+            closer to 0.0 places the regions of high reward closer to the center.
+        sigma : float
+            Standard deviation of the Gaussian distributions that make the objective
+            function.
+        do_threshold : bool
+            If True, the values of the Gaussians are thresholded using the values in
+            ``thresholds``.
+        thresholds : list
+            A list of tuples with the information to threshold the objective function.
+            The first two values of the tuple indicate the lower and upper bound of a
+            range, and the third value indicates the value onto which values in the
+            range are mapped. For example, (0.0, 1.0, 1e-6) will map all values between
+            0.0 and 1.0 to 1e-6.
+        """
         super().__init__(**kwargs)
         self.n_dim = n_dim
         self.mu = mu
         self.sigma = sigma
+        self.do_threshold = do_threshold
+        self.thresholds = (tuple(el) for el in thresholds)
 
     def setup(self, env=None):
         if env:
@@ -40,7 +84,7 @@ class Corners(Proxy):
         return self._optimum
 
     def __call__(self, states: TensorType["batch", "state_dim"]) -> TensorType["batch"]:
-        return self.mulnormal_norm * torch.exp(
+        scores = self.mulnormal_norm * torch.exp(
             -0.5
             * (
                 torch.diag(
@@ -54,3 +98,7 @@ class Corners(Proxy):
                 )
             )
         )
+        if self.do_threshold:
+            for th in self.thresholds:
+                scores[(scores >= th[0]) & (scores < th[1])] = th[2]
+        return scores


### PR DESCRIPTION
This PR extends the Corners proxy with additional options:
- Applying thresholds to the mixture of Gaussians to make the proxy scores landscape harder.
- Using an alternative formulation for the corners function to match the one used in the original GFlowNets paper.