### PR TITLE
Small fix in Toy environment

### DIFF
--- a/gflownet/envs/toy.py
+++ b/gflownet/envs/toy.py
@@ -260,8 +260,8 @@ class Toy(GFlowNetEnv):
         A 2D tensor containing all the states in the batch.
         """
         states_policy = F.one_hot(
-            tlong(states, device=self.device).squeeze(), len(self.connections)
-        )
+            tlong(states, device=self.device), len(self.connections)
+        ).squeeze(1)
         return tfloat(states_policy, device=self.device, float_type=self.float)
 
     def state2readable(self, state: List[int] = None) -> str:

--- a/tests/gflownet/envs/common.py
+++ b/tests/gflownet/envs/common.py
@@ -747,6 +747,18 @@ class BaseTestsCommon:
             assert torch.all(torch.isfinite(logprobs))
             assert torch.all(logprobs > -1e6)
 
+    def test__dimensionality_policy_representation(self, n_repeat=1):
+        """
+        Checks whether the number of dimensions of the policy representation is the
+        same for a batch with a single state than for a batch with multiple (2) states.
+        This is to catch cases where with a single state a dimensions gets squeezed.
+        """
+        batch_one = self.env.get_random_states(n_states=1)
+        batch_two = self.env.get_random_states(n_states=2)
+        batch_one_policy = self.env.states2policy(batch_one)
+        batch_two_policy = self.env.states2policy(batch_two)
+        assert batch_one_policy.ndim == batch_two_policy.ndim
+
     def test__gflownet_minimal_runs(self, n_repeat=1, batch_size=2):
         method_name = _get_current_method_name()
 

--- a/tests/gflownet/envs/common.py
+++ b/tests/gflownet/envs/common.py
@@ -753,11 +753,17 @@ class BaseTestsCommon:
         same for a batch with a single state than for a batch with multiple (2) states.
         This is to catch cases where with a single state a dimensions gets squeezed.
         """
-        batch_one = self.env.get_random_states(n_states=1)
-        batch_two = self.env.get_random_states(n_states=2)
-        batch_one_policy = self.env.states2policy(batch_one)
-        batch_two_policy = self.env.states2policy(batch_two)
-        assert batch_one_policy.ndim == batch_two_policy.ndim
+        method_name = _get_current_method_name()
+
+        if hasattr(self, "repeats") and method_name in self.repeats:
+            n_repeat = self.repeats[method_name]
+
+        for _ in range(n_repeat):
+            batch_one = self.env.get_random_states(n_states=1)
+            batch_two = self.env.get_random_states(n_states=2)
+            batch_one_policy = self.env.states2policy(batch_one)
+            batch_two_policy = self.env.states2policy(batch_two)
+            assert batch_one_policy.ndim == batch_two_policy.ndim
 
     def test__gflownet_minimal_runs(self, n_repeat=1, batch_size=2):
         method_name = _get_current_method_name()

--- a/tests/gflownet/envs/test_constant.py
+++ b/tests/gflownet/envs/test_constant.py
@@ -79,6 +79,7 @@ class TestConstantListCommon(common.BaseTestsDiscrete):
             "test__gflownet_minimal_runs": 3,
             "test__get_mask__is_consistent_regardless_of_inputs": 0,
             "test__get_valid_actions__is_consistent_regardless_of_inputs": 0,
+            "test__dimensionality_policy_representation": 0,
         }
         self.n_states = {
             "test__backward_actions_have_nonzero_forward_prob": 1,
@@ -116,6 +117,7 @@ class TestConstantTensorCommon(common.BaseTestsDiscrete):
             "test__gflownet_minimal_runs": 3,
             "test__get_mask__is_consistent_regardless_of_inputs": 0,
             "test__get_valid_actions__is_consistent_regardless_of_inputs": 0,
+            "test__dimensionality_policy_representation": 0,
         }
         self.n_states = {
             "test__backward_actions_have_nonzero_forward_prob": 1,

--- a/tests/gflownet/envs/test_dummy.py
+++ b/tests/gflownet/envs/test_dummy.py
@@ -106,6 +106,7 @@ class TestDummyListCommon(common.BaseTestsDiscrete):
             "test__sample_backwards_reaches_source": 10,
             "test__state2readable__is_reversible": 0,
             "test__gflownet_minimal_runs": 3,
+            "test__dimensionality_policy_representation": 0,
         }
         self.n_states = {
             "test__backward_actions_have_nonzero_forward_prob": 1,
@@ -141,6 +142,7 @@ class TestDummyTensorCommon(common.BaseTestsDiscrete):
             "test__sample_backwards_reaches_source": 10,
             "test__state2readable__is_reversible": 0,
             "test__gflownet_minimal_runs": 3,
+            "test__dimensionality_policy_representation": 0,
         }
         self.n_states = {
             "test__backward_actions_have_nonzero_forward_prob": 1,


### PR DESCRIPTION
I have also added a new common environment test, to catch the potential issue that the policy representation of batches with a single state gets squeezed and has the wrong number of dimensions.