### PR TITLE
Fix logprob bug

### DIFF
--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -13,6 +13,7 @@ from gflownet.utils.common import (
     concat_items,
     copy,
     extend,
+    index_select,
     set_device,
     set_float_precision,
     tbool,
@@ -120,6 +121,7 @@ class Batch:
         self._logrewards_parents_available = False
         self._logrewards_source_available = False
         self._proxy_values_available = False
+        self._logprobs_available = False
 
     def __len__(self):
         return self.size
@@ -323,7 +325,7 @@ class Batch:
             if backward:
                 # Add logpb for current action
                 self.logprobs_backward.append(logp)
-                self.logprobs_backward_valid.append(True)
+                self.logprobs_backward_valid.append(True if logp is not None else False)
                 # Add logpf for previous action
                 if not env.is_source(env.state) or logp_rev is None:
                     # Store a None placeholder for the current logpf which will be
@@ -352,7 +354,7 @@ class Batch:
             else:
                 # Add logpf for current action
                 self.logprobs_forward.append(logp)
-                self.logprobs_forward_valid.append(True)
+                self.logprobs_forward_valid.append(True if logp is not None else False)
                 # Add logpb for previous action
                 if not env.done or logp_rev is None:
                     # Store a None placeholder for the current logpb which will be
@@ -484,6 +486,7 @@ class Batch:
         policy: Optional[bool] = False,
         proxy: Optional[bool] = False,
         force_recompute: Optional[bool] = False,
+        index: Optional[Union[List, Tuple, TensorType, npt.NDArray]] = None,
     ) -> Union[TensorType["n_states", "..."], npt.NDArray[np.float32], List]:
         """
         Returns all the states in the batch.
@@ -506,11 +509,16 @@ class Batch:
             If True, the policy states are recomputed even if they are available.
             Ignored if policy is False.
 
+        index: list, tuple, tensor or np.ndarray
+            1-dimentional sequence of bacth indecies for selecting states, optional.
+            If None (default), all the states will be returned.
+
         Returns
         -------
         self.states or self.states_policy or self.states2proxy(self.states) : list or
         torch.tensor or ndarray
-            The set of all states in the batch.
+            The set of states in the selected format with the selected index. If index is
+            None, all states of the batch are returned.
         """
         if policy is True and proxy is True:
             raise ValueError(
@@ -519,10 +527,10 @@ class Batch:
         if policy is True:
             if self.states_policy is None or force_recompute is True:
                 self.states_policy = self.states2policy()
-            return self.states_policy
+            return index_select(self.states_policy, index)
         if proxy is True:
-            return self.states2proxy()
-        return self.states
+            return index_select(self.states2proxy(), index)
+        return index_select(self.states, index)
 
     def states2policy(
         self,
@@ -633,16 +641,26 @@ class Batch:
             return states_proxy
         return self.readonly_env.states2proxy(states)
 
-    def get_actions(self) -> List:
+    def get_actions(
+        self,
+        index: Optional[Union[List, Tuple, TensorType, npt.NDArray]] = None,
+    ) -> List:
         """
         Returns the actions in the batch.
+
+        Parameters
+        ----------
+        index: list, tuple, tensor or np.ndarray
+            1-dimentional sequence of bacth indecies for selecting actions, optional.
+            If None (default), all the actions will be returned.
 
         Returns
         -------
         list
-            The list of actions in the batch.
+            The list of actions in the batch with selected index. If index is None,
+            all the actions will be returned.
         """
-        return self.actions
+        return index_select(self.actions, index)
 
     def get_logprobs(
         self, backward: bool = False
@@ -668,22 +686,51 @@ class Batch:
             valid. The flag is False if the corresponding logprob value is a zero / None
             placefolder.
         """
+        if not self._logprobs_available:
+            self._compute_logprobs()
 
         if backward:
-            if self.logprobs_backward[0] is None:
-                return None, None
-            logprobs = tfloat(
-                self.logprobs_backward, float_type=self.float, device=self.device
-            )
-            valids = tbool(self.logprobs_backward_valid, device=self.device)
+            return self.logprobs_backward, self.logprobs_backward_valid
         else:
-            if self.logprobs_forward[0] is None:
-                return None, None
-            logprobs = tfloat(
-                self.logprobs_forward, float_type=self.float, device=self.device
+            return self.logprobs_forward, self.logprobs_forward_valid
+
+    def _compute_logprobs(self):
+        """
+        Convert all logprobs and their validity flags to tensors and update validity flags
+        """
+        self.logprobs_forward, self.logprobs_forward_valid = (
+            self._logprobs_to_clean_tensor(
+                self.logprobs_forward, self.logprobs_forward_valid
             )
-            valids = tbool(self.logprobs_forward_valid, device=self.device)
-        return logprobs, valids
+        )
+        self.logprobs_backward, self.logprobs_backward_valid = (
+            self._logprobs_to_clean_tensor(
+                self.logprobs_backward, self.logprobs_backward_valid
+            )
+        )
+        self._logprobs_available = True
+
+    def _logprobs_to_clean_tensor(self, logprobs, logprobs_valid):
+        """
+        Convert logprobs and logprobs_valid to tensors and update validity flags
+        """
+        if any(x is None for x in logprobs):
+            logprobs_clean = []
+            for idx, lp in enumerate(logprobs):
+                if lp is None:
+                    logprobs_valid[idx] = False
+                    logprobs_clean.append(
+                        tfloat(0.0, device=self.device, float_type=self.float)
+                    )
+                else:
+                    logprobs_clean.append(lp)
+        else:
+            logprobs_clean = logprobs
+        logprobs_clean = tfloat(
+            logprobs_clean, float_type=self.float, device=self.device
+        )
+        logprobs_valid = tbool(logprobs_valid, device=self.device)
+        return logprobs_clean, logprobs_valid
 
     def get_done(self) -> TensorType["n_states"]:
         """
@@ -693,7 +740,10 @@ class Batch:
 
     # TODO: check availability one by one as in get_masks
     def get_parents(
-        self, policy: Optional[bool] = False, force_recompute: Optional[bool] = False
+        self,
+        policy: Optional[bool] = False,
+        force_recompute: Optional[bool] = False,
+        index: Optional[Union[List, Tuple, TensorType, npt.NDArray]] = None,
     ) -> TensorType["n_states", "..."]:
         """
         Returns the parent (single parent for each state) of all states in the batch.
@@ -704,8 +754,8 @@ class Batch:
         The parents are returned in "policy format" if policy is True, otherwise they
         are returned in "GFlowNet" format (default).
 
-        Args
-        ----
+        Parameters
+        ----------
         policy : bool
             If True, the policy format of parents is returned. Otherwise, the GFlowNet
             format is returned.
@@ -713,21 +763,26 @@ class Batch:
         force_recompute : bool
             If True, the parents are recomputed even if they are available.
 
+        index: list, tuple, tensor or np.ndarray
+            1-dimentional sequence of bacth indecies for selecting parents, optional.
+            If None (default), the parents of all states in the batch will be returned.
+
         Returns
         -------
         self.parents or self.parents_policy : torch.tensor
-            The parent of all states in the batch.
+            The parent of states selected by index. If index is None, the parents of
+            all states in the batch are returned.
         """
         if self._parents_available is False or force_recompute is True:
             self._compute_parents()
         if policy:
             if self._parents_policy_available is False or force_recompute is True:
                 self._compute_parents_policy()
-            return self.parents_policy
+            return index_select(self.parents_policy, index)
         else:
-            return self.parents
+            return index_select(self.parents, index)
 
-    def get_parents_indices(self):
+    def get_parents_indices(self, index=None):
         """
         Returns the indices of the parents of the states in the batch.
 
@@ -742,7 +797,7 @@ class Batch:
         """
         if self._parents_available is False:
             self._compute_parents()
-        return self.parents_indices
+        return index_select(self.parents_indices, index)
 
     def _compute_parents(self):
         """
@@ -942,6 +997,7 @@ class Batch:
         self,
         of_parents: bool = False,
         force_recompute: bool = False,
+        index: Optional[Union[List, Tuple, TensorType, npt.NDArray]] = None,
     ) -> TensorType["n_states", "action_space_dim"]:
         """
         Returns the forward mask of invalid actions of all states in the batch or of
@@ -958,10 +1014,15 @@ class Batch:
         force_recompute : bool
             If True, the masks are recomputed even if they are available.
 
+        index: list, tuple, tensor or np.ndarray
+            1-dimentional sequence of bacth indecies for selecting masks, optional.
+            If None (default), the masks of all states in the batch will be returned.
+
         Returns
         -------
         self.masks_invalid_actions_forward : torch.tensor
-            The forward mask of all states in the batch.
+            The forward mask of the selected states (by index). If index is None, the
+            masks of all states in the batch will be returned.
         """
         if self._masks_forward_available is False or force_recompute is True:
             self._compute_masks_forward()
@@ -992,8 +1053,8 @@ class Batch:
             masks_invalid_actions_forward_parents[parents_indices != -1] = (
                 masks_invalid_actions_forward[parents_indices[parents_indices != -1]]
             )
-            return masks_invalid_actions_forward_parents
-        return masks_invalid_actions_forward
+            return index_select(masks_invalid_actions_forward_parents, index)
+        return index_select(masks_invalid_actions_forward, index)
 
     def _compute_masks_forward(self):
         """
@@ -1019,6 +1080,7 @@ class Batch:
     def get_masks_backward(
         self,
         force_recompute: bool = False,
+        index: Optional[Union[List, Tuple, TensorType, npt.NDArray]] = None,
     ) -> TensorType["n_states", "action_space_dim"]:
         """
         Returns the backward mask of invalid actions of all states in the batch. The
@@ -1030,14 +1092,20 @@ class Batch:
         force_recompute : bool
             If True, the masks are recomputed even if they are available.
 
+        index: list, tuple, tensor or np.ndarray
+            1-dimentional sequence of bacth indecies for selecting masks, optional.
+            If None (default), the masks of all states in the batch will be returned.
+
         Returns
         -------
         self.masks_invalid_actions_backward : torch.tensor
-            The backward mask of all states in the batch.
+            The backward mask of the selected states (by index). If index is None, the
+            masks of all states in the batch will be returned.
         """
         if self._masks_backward_available is False or force_recompute is True:
             self._compute_masks_backward()
-        return tbool(self.masks_invalid_actions_backward, device=self.device)
+        masks = tbool(self.masks_invalid_actions_backward, device=self.device)
+        return index_select(masks, index)
 
     def _compute_masks_backward(self):
         """
@@ -1881,51 +1949,50 @@ def compute_logprobs_trajectories(
 
     # Take logprobs from the batch if they are available.
     logprobs_states, logprobs_valid = batch.get_logprobs(backward)
-    if logprobs_states is not None:
-        if backward:
-            assert torch.all(logprobs_valid)
-        logprobs_nonvalid = ~logprobs_valid
+    logprobs_nonvalid = ~logprobs_valid
 
+    # Make indices of batch consecutive since they are used for indexing here
     traj_indices = batch.get_trajectory_indices(consecutive=True)
 
     # Otherwise, compute the log probs from the states and actions in the batch
-    if logprobs_states is None:
-        # Make indices of batch consecutive since they are used for indexing here
+    if torch.any(logprobs_nonvalid):
+        if torch.all(logprobs_nonvalid):
+            # setting indecies to None to select everything
+            indices_nonvalid = None
+        else:
+            indices_nonvalid = torch.where(logprobs_nonvalid)[0]
+
         # Get necessary tensors from batch
-        states_policy = batch.get_states(policy=True)
-        states = batch.get_states(policy=False)
-        actions = batch.get_actions()
-        parents_policy = batch.get_parents(policy=True)
-        parents = batch.get_parents(policy=False)
+
+        states = batch.get_states(policy=False, index=indices_nonvalid)
+        actions = batch.get_actions(index=indices_nonvalid)
+
+        parents = batch.get_parents(policy=False, index=indices_nonvalid)
+
+        states_policy = batch.get_states(policy=True, index=indices_nonvalid)
+        parents_policy = batch.get_parents(policy=True, index=indices_nonvalid)
         if backward:
             # Backward trajectories
-            masks_b = batch.get_masks_backward()
+            masks_b = batch.get_masks_backward(index=indices_nonvalid)
             policy_output_b = backward_policy(states_policy)
-            logprobs_states = env.get_logprobs(
+            logprobs_states_val = env.get_logprobs(
                 policy_output_b, actions, masks_b, states, backward
             )
+            if indices_nonvalid is None:
+                logprobs_states = logprobs_states_val
+            else:
+                logprobs_states[indices_nonvalid] = logprobs_states_val
         else:
             # Forward trajectories
-            masks_f = batch.get_masks_forward(of_parents=True)
+            masks_f = batch.get_masks_forward(of_parents=True, index=indices_nonvalid)
             policy_output_f = forward_policy(parents_policy)
-            logprobs_states = env.get_logprobs(
+            logprobs_states_val = env.get_logprobs(
                 policy_output_f, actions, masks_f, parents, backward
             )
-    elif torch.any(logprobs_nonvalid):
-        # Compute missing logprobs. This should happen only for forward logprobs
-        # when the batch was sampled backwards
-        assert not backward
-        indices_nonvalid = torch.where(logprobs_nonvalid)[0]
-        parents_all = batch.get_parents(policy=False)
-        parents = [parents_all[idx] for idx in indices_nonvalid]
-        parents_policy = batch.states2policy(parents)
-        policy_output_f = forward_policy(parents_policy)
-        actions = batch.get_actions()
-        actions = [actions[idx] for idx in indices_nonvalid]
-        masks_f = batch.get_masks_forward(of_parents=True)[logprobs_nonvalid]
-        logprobs_states[logprobs_nonvalid] = env.get_logprobs(
-            policy_output_f, actions, masks_f, parents, backward
-        )
+            if indices_nonvalid is None:
+                logprobs_states = logprobs_states_val
+            else:
+                logprobs_states[indices_nonvalid] = logprobs_states_val
     # Sum log probabilities of all transitions in each trajectory
     logprobs = torch.zeros(
         batch.get_n_trajectories(),

--- a/gflownet/utils/batch.py
+++ b/gflownet/utils/batch.py
@@ -327,7 +327,7 @@ class Batch:
                 self.logprobs_backward.append(logp)
                 self.logprobs_backward_valid.append(True if logp is not None else False)
                 # Add logpf for previous action
-                if not env.is_source(env.state) or logp_rev is None:
+                if not env.is_source(env.state):
                     # Store a None placeholder for the current logpf which will be
                     # replaced at the next step
                     self.logprobs_forward.append(None)
@@ -356,7 +356,7 @@ class Batch:
                 self.logprobs_forward.append(logp)
                 self.logprobs_forward_valid.append(True if logp is not None else False)
                 # Add logpb for previous action
-                if not env.done or logp_rev is None:
+                if not env.done:
                     # Store a None placeholder for the current logpb which will be
                     # replaced at the next step
                     self.logprobs_backward.append(None)

--- a/gflownet/utils/common.py
+++ b/gflownet/utils/common.py
@@ -4,9 +4,10 @@ from copy import deepcopy
 from functools import partial
 from os.path import expandvars
 from pathlib import Path
-from typing import List, Union
+from typing import List, Tuple, Union
 
 import numpy as np
+import numpy.typing as npt
 import torch
 from hydra import compose, initialize_config_dir
 from hydra.utils import get_original_cwd, instantiate
@@ -773,3 +774,40 @@ def example_documented_function(arg1, arg2):
     if arg1 == arg2:
         raise ValueError("arg1 must not be equal to arg2")
     return True
+
+
+def index_select(
+    iterable: Union[List, Tuple, TensorType, npt.NDArray],
+    index: Optional[Union[List, Tuple, TensorType, npt.NDArray]] = None,
+):
+    """
+    Select elements form iterable
+
+    Parameters
+    ----------
+    iterable: list, tuple, tensor or np.ndarray
+        An iterable to select elements from. It can have multiple dimensions
+        and selection is always preformed over the first dimension
+    index: list, tuple, tensor or np.ndarray
+        1-dimentional sequence of indecies for selecting elements, optional. If None,
+        the iterable will be returned as is. Default None
+
+    Returns
+    -------
+    list, tuple, tensor or np.ndarray
+        A sequence of selected elements. The type of the returned sequence is
+        the same as the type of the input iterable
+    """
+    if index is None:
+        return iterable
+    if isinstance(iterable, (list, tuple)):
+        result = [iterable[idx] for idx in index]
+        if isinstance(iterable, tuple):
+            result = tuple(result)
+        return result
+    elif torch.is_tensor(iterable) or isinstance(iterable, np.ndarray):
+        if isinstance(index, tuple):
+            index = list(index)
+        return iterable[index]
+    else:
+        raise Exception(f"Cannon select elements from {type(iterable)}")

--- a/gflownet/utils/common.py
+++ b/gflownet/utils/common.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from functools import partial
 from os.path import expandvars
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/gflownet/test_gflownet.py
+++ b/tests/gflownet/test_gflownet.py
@@ -51,6 +51,8 @@ def gfn_grid():
         (0, 100, False),
         (0, 100, True),
         (0, 100, True),
+        (100, 100, False),
+        (100, 100, True),
     ],
 )
 def test__compute_logprobs_trajectories__logprobs_from_batch_are_same_as_computed(
@@ -125,7 +127,7 @@ def test__compute_logprobs_trajectories__logprobs_from_batch_are_same_as_compute
     logpobs_fw_from_batch, logprobs_fw_valid = batch.get_logprobs()
     logpobs_bw_from_batch, logprobs_bw_valid = batch.get_logprobs(backward=True)
 
-    if n_train > 0 or (collect_reversed_logprobs and n_forward > 0):
+    if (n_train > 0 and n_forward == 0) or collect_reversed_logprobs:
         assert torch.all(logprobs_bw_valid)
     if n_forward > 0 and n_train == 0:
         assert torch.all(logprobs_fw_valid)

--- a/tests/gflownet/utils/test_common.py
+++ b/tests/gflownet/utils/test_common.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+import torch
+
+from gflownet.utils.common import index_select
+
+
+@pytest.mark.parametrize(
+    "iterable, index, expected",
+    [
+        ([1, 2, 3, 4, 5, 6], [0, 4, 3], [1, 5, 4]),
+        (
+            [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+            [1, 0],
+            [[5, 6, 7, 8], [1, 2, 3, 4]],
+        ),
+    ],
+)
+def test__index_select(iterable, index, expected):
+    output = index_select(iterable, index)
+    assert output == expected
+    index_tuple = tuple(index)
+    output = index_select(iterable, index_tuple)
+    assert output == expected
+    index_tensor = torch.tensor(index)
+    output = index_select(iterable, index_tensor)
+    assert output == expected
+    index_np = np.array(index)
+    output = index_select(iterable, index_np)
+    assert output == expected
+
+    iterable_tuple = tuple(iterable)
+    expected_tuple = tuple(expected)
+    output = index_select(iterable_tuple, index)
+    assert output == expected_tuple
+    output = index_select(iterable_tuple, index_tuple)
+    assert output == expected_tuple
+    output = index_select(iterable_tuple, index_tensor)
+    assert output == expected_tuple
+    output = index_select(iterable_tuple, index_np)
+    assert output == expected_tuple
+
+    iterable_tensor = torch.tensor(iterable)
+    expected_tensor = torch.tensor(expected)
+    output = index_select(iterable_tensor, index)
+    assert torch.equal(output, expected_tensor)
+    output = index_select(iterable_tensor, index_tuple)
+    assert torch.equal(output, expected_tensor)
+
+    output = index_select(iterable_tensor, index_tensor)
+    assert torch.equal(output, expected_tensor)
+    output = index_select(iterable_tensor, index_np)
+    assert torch.equal(output, expected_tensor)
+
+    iterable_np = np.array(iterable)
+    expected_np = np.array(expected)
+    output = index_select(iterable_np, index)
+    assert np.all(output == expected_np)
+    output = index_select(iterable_np, index_tuple)
+    assert np.all(output == expected_np)
+    output = index_select(iterable_np, index_tensor)
+    assert np.all(output == expected_np)
+    output = index_select(iterable_np, index_np)
+    assert np.all(output == expected_np)


### PR DESCRIPTION
There is a bug introduced by the logprobs efficiency PR: runs are crushing with gflownet.collect_reversed_logprobs=False and with both forward and backward trajectories present in the training batch. This PR fixes this bug.