### PR TITLE
Simplify `sample_actions_batch()`

### DIFF
--- a/gflownet/envs/set.py
+++ b/gflownet/envs/set.py
@@ -681,10 +681,8 @@ class BaseSet(GFlowNetEnv):
         mask: Optional[TensorType["n_states", "policy_output_dim"]] = None,
         states_from: List = None,
         is_backward: Optional[bool] = False,
-        sampling_method: Optional[str] = "policy",
         random_action_prob: Optional[float] = 0.0,
         temperature_logits: Optional[float] = 1.0,
-        max_sampling_attempts: Optional[int] = 10,
     ) -> Tuple[List[Tuple], TensorType["n_states"]]:
         """
         Samples a batch of actions from a batch of policy outputs.
@@ -711,10 +709,8 @@ class BaseSet(GFlowNetEnv):
                 self._extract_core_mask(mask[is_set], idx_unique=-1),
                 None,
                 is_backward,
-                sampling_method,
                 random_action_prob,
                 temperature_logits,
-                max_sampling_attempts,
             )
 
         # Get the active sub-environment of each mask from the one-hot prefix
@@ -758,10 +754,8 @@ class BaseSet(GFlowNetEnv):
                 ),
                 states_dict[idx],
                 is_backward,
-                sampling_method,
                 random_action_prob,
                 temperature_logits,
-                max_sampling_attempts,
             )
         # Stitch all environment actions in the right order, with the right padding
         actions_subenvs = []

--- a/gflownet/envs/stack.py
+++ b/gflownet/envs/stack.py
@@ -778,10 +778,8 @@ class Stack(GFlowNetEnv):
         mask: Optional[TensorType["n_states", "policy_output_dim"]] = None,
         states_from: List = None,
         is_backward: Optional[bool] = False,
-        sampling_method: Optional[str] = "policy",
         random_action_prob: Optional[float] = 0.0,
         temperature_logits: Optional[float] = 1.0,
-        max_sampling_attempts: Optional[int] = 10,
     ) -> Tuple[List[Tuple], TensorType["n_states"]]:
         """
         Samples a batch of actions from a batch of policy outputs.
@@ -816,10 +814,8 @@ class Stack(GFlowNetEnv):
                 mask[stage_mask, self.n_subenvs : self.n_subenvs + subenv.mask_dim],
                 states_dict[stage],
                 is_backward,
-                sampling_method,
                 random_action_prob,
                 temperature_logits,
-                max_sampling_attempts,
             )
 
         # Stitch all actions in the right order, with the right padding

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -93,7 +93,7 @@ class GFlowNetAgent:
         random_action_prob : float
             Probability of sampling random actions. If None (default),
             self.random_action_prob is used, unless its value is forced to either 0.0 or
-            1.0 by other arguments (sampling_method or no_random).
+            1.0 by other arguments.
         logger : gflownet.utils.logger.Logger
             Logger object to be used for logging and saving checkpoints
             (`gflownet/utils/logger.py:Logger`).
@@ -375,7 +375,6 @@ class GFlowNetAgent:
             mask=mask_invalid_actions,
             states_from=states,
             is_backward=backward,
-            sampling_method=sampling_method,
             random_action_prob=random_action_prob,
             temperature_logits=temperature,
         )


### PR DESCRIPTION
With the recent changes in the sampling of actions and the computation of logprobs, I realised that the method `sampling_actions_batch()` could be further simplified:
- I have removed the stuff about the maximum number of attempts to check the sampled actions are valid. This was introduced long ago because of a bug in torch that I think was also fixed long ago. I don't think it's needed any longer. Furthermore, we also have a check of the actions before making the steps, so bye bye.
- I have removed the stuff about `sampling_method` since it is actually not used. The code is simpler this way
- I have also removed some debugging code that was hanging in there.
- And I have reorganised the code a bit to make things simpler.

To be done:
- [ ] Rename the variable `policy_outputs` to something like `logits_sampling` directly. The reason is that this tensor may not even be policy outputs, and now it's always used just to sample actions, so I think it would be clearer. Do you agree?  