### PR TITLE
Replay buffer based on loss

### DIFF
--- a/config/buffer/base.yaml
+++ b/config/buffer/base.yaml
@@ -2,6 +2,7 @@ _target_: gflownet.buffer.base.BaseBuffer
 
 replay_buffer: null
 replay_capacity: 0
+replay_criterion: "reward"
 
 # Train and test data
 # Both train and test are dictionaries with the following keys:

--- a/gflownet/buffer/base.py
+++ b/gflownet/buffer/base.py
@@ -480,7 +480,7 @@ class BaseBuffer:
 
     # TODO: there may be issues with certain state types
     # TODO: add parameter(s) to control isclose()
-    def _add_greater_update_single_sample(self, sample, trajectory, value, it):
+    def _add_greater_update_single_sample(self, sample, trajectory, value, it) -> bool:
         """
         Adds a single sample (with the trajectory actions and value) to the buffer
         if the state value is larger than the minimum value in the buffer.
@@ -520,7 +520,8 @@ class BaseBuffer:
 
         Returns
         -------
-        self.replay : The updated replay buffer
+        bool
+            Whether the same is added to the buffer or not.
         """
         # Check whether the sample is close to any sample already present in the buffer
         # If a match is found, drop it and return if the new value is smaller than the
@@ -530,7 +531,7 @@ class BaseBuffer:
             if self.env.isclose(sample, rsample):
                 self.replay.drop(self.replay.index[idx], inplace=True)
                 if value < self.replay["values"].min():
-                    return
+                    return False
                 else:
                     break
 
@@ -541,9 +542,9 @@ class BaseBuffer:
             if value > self.replay["values"].loc[index_min]:
                 self.replay.drop(self.replay.index[index_update], inplace=True)
             else:
-                return
+                return False
         else:
-            return
+            return False
 
         # TODO: make separate method common to all
         # Add the sample to the buffer
@@ -570,6 +571,7 @@ class BaseBuffer:
             ],
             ignore_index=True,
         )
+        return True
 
     def make_data_set(self, config):
         """

--- a/gflownet/buffer/base.py
+++ b/gflownet/buffer/base.py
@@ -540,11 +540,9 @@ class BaseBuffer:
         if len(self.replay) >= self.replay_capacity:
             index_min = self.replay.index[self.replay["values"].argmin()]
             if value > self.replay["values"].loc[index_min]:
-                self.replay.drop(self.replay.index[index_update], inplace=True)
+                self.replay.drop(self.replay.index[index_min], inplace=True)
             else:
                 return False
-        else:
-            return False
 
         # TODO: make separate method common to all
         # Add the sample to the buffer

--- a/gflownet/buffer/base.py
+++ b/gflownet/buffer/base.py
@@ -436,7 +436,7 @@ class BaseBuffer:
         if self.check_diversity:
             # If the value similarity is negative, compare with the full replay buffer
             if self.diversity_check_value_similarity < 0.0:
-                for idx, rsample in enumerate(self.replay["samples"]):
+                for rsample in self.replay["samples"]:
                     if self.env.isclose(sample, rsample):
                         return
             # Otherwise, compare only with samples with similar value
@@ -449,7 +449,7 @@ class BaseBuffer:
                     if self.env.isclose(sample, rsample):
                         return
 
-        # If index_min is larger than zero, drop the sample with the minimum value`
+        # If index_min is larger than zero, drop the sample with the minimum value
         if index_min >= 0:
             self.replay.drop(self.replay.index[index_min], inplace=True)
 

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -691,8 +691,8 @@ class GFlowNetAgent:
             and self.buffer.replay is not None
             and len(self.buffer.replay) > 0
         ):
-            envs = [env_instances.pop().reset(idx) for idx in range(n_replay)]
             n_replay = min(n_replay, len(self.buffer.replay))
+            envs = [env_instances.pop().reset(idx) for idx in range(n_replay)]
             x_replay = self.buffer.select(
                 self.buffer.replay,
                 n_replay,
@@ -1149,7 +1149,7 @@ class GFlowNetAgent:
 
             # Log replay buffer values
             if self.buffer.replay_updated:
-                values_replay = self.buffer.replay.values
+                values_replay = self.buffer.replay["values"].values
                 if self.buffer.replay_criterion == "reward":
                     self.logger.log_rewards_and_scores(
                         values_replay,

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -1077,16 +1077,11 @@ class GFlowNetAgent:
             )
 
         # Update replay buffer
-        # TODO: improve handling of losses depending on loss
-        if self.loss.id in ["trajectorybalance", "vargrad"]:
-            losses_buffer = losses["units"]
-        else:
-            loss_buffer = None
         self.buffer.add(
             states_term,
             actions_trajectories,
             rewards,
-            losses_buffer,
+            losses.pop("units", None),
             self.it,
             buffer="replay",
         )

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -963,7 +963,7 @@ class GFlowNetAgent:
             for j in range(self.ttsr):
                 losses = self.loss.compute(batch, get_sublosses=True)
                 # TODO: deal with this in a better way
-                if not all([torch.isfinite(loss) for loss in losses.values()]):
+                if not torch.isfinite(losses["all"]):
                     if self.logger.debug:
                         print("Loss is not finite - skipping iteration")
                 else:
@@ -1077,10 +1077,16 @@ class GFlowNetAgent:
             )
 
         # Update replay buffer
+        # TODO: improve handling of losses depending on loss
+        if self.loss.id in ["trajectorybalance", "vargrad"]:
+            losses_buffer = losses["units"]
+        else:
+            loss_buffer = None
         self.buffer.add(
             states_term,
             actions_trajectories,
             rewards,
+            losses_buffer,
             self.it,
             buffer="replay",
         )

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -1147,17 +1147,30 @@ class GFlowNetAgent:
                 use_context=self.use_context,
             )
 
-            # Log replay buffer rewards
+            # Log replay buffer values
             if self.buffer.replay_updated:
-                rewards_replay = self.buffer.replay.rewards
-                self.logger.log_rewards_and_scores(
-                    rewards_replay,
-                    np.log(rewards_replay),
-                    scores=None,
-                    step=self.it,
-                    prefix="Replay buffer -",
-                    use_context=self.use_context,
-                )
+                values_replay = self.buffer.replay.values
+                if self.buffer.replay_criterion == "reward":
+                    self.logger.log_rewards_and_scores(
+                        values_replay,
+                        np.log(values_replay),
+                        scores=None,
+                        step=self.it,
+                        prefix="Replay buffer -",
+                        use_context=self.use_context,
+                    )
+                elif self.buffer.replay_criterion == "loss":
+                    self.logger.log_min_max_mean(
+                        values_replay,
+                        step=self.it,
+                        prefix="Replay buffer loss -",
+                        use_context=self.use_context,
+                    )
+                else:
+                    raise ValueError(
+                        "Unknown replay buffer criterion identifier. Received "
+                        f"{self.buffer.replay_criterion}, expected reward or loss"
+                    )
 
         t1_log = time.time()
         times.update({"log": t1_log - t0_log})

--- a/gflownet/losses/base.py
+++ b/gflownet/losses/base.py
@@ -234,7 +234,9 @@ class BaseLoss(metaclass=ABCMeta):
         """
         losses = self.compute_losses_of_batch(batch)
         if get_sublosses:
-            return self.aggregate_losses_of_batch(losses, batch)
+            losses_dict = self.aggregate_losses_of_batch(losses, batch)
+            losses_dict["units"] = losses
+            return losses_dict
         else:
             return losses.mean()
 

--- a/gflownet/utils/logger.py
+++ b/gflownet/utils/logger.py
@@ -6,6 +6,7 @@ from typing import Union
 
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 import torch
 from numpy import array
 from omegaconf import OmegaConf
@@ -243,6 +244,37 @@ class Logger:
                 }
             )
 
+        self.log_metrics(metrics, step=step, use_context=use_context)
+
+    def log_min_max_mean(
+        self,
+        scores: Union[npt.NDArray, TensorType["n_samples"]],
+        step: int,
+        prefix: str,
+        use_context: bool = True,
+    ):
+        """
+        Logs the minimum, maximum and mean of the values passed as arguments.
+
+        Parameters
+        ----------
+        values : tensor
+            Values corresponding to batch of states.
+        step : int
+            The training iteration number.
+        prefix : str
+            Prefix to be added to the metric names.
+        use_context : bool
+            If True, prepend self.context + / to the key of the metric.
+        """
+        if not self.do.online:
+            return
+
+        metrics = {
+            f"{prefix} min": rewards.min(),
+            f"{prefix} max": rewards.max(),
+            f"{prefix} mean": rewards.mean(),
+        }
         self.log_metrics(metrics, step=step, use_context=use_context)
 
     def log_metrics(


### PR DESCRIPTION
This PR enables using the replay buffer based on the loss instead of just the reward.

The motivation is that it may be beneficial to resample for training trajectories from states that have recently led to high loss. The logic to fill the buffer is slightly different than with the reward because the loss changes as we train.