### PR TITLE
Grid update

### DIFF
--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -109,9 +109,11 @@ class Grid(GFlowNetEnv):
         """
         Returns which actions are invalid (True) and which are not invalid (False).
 
-        This method makes use of ``self.actions_np``, defined in
-        :py:meth:`~gflownet.envs.grid.Grid.get_action_space`, and operates with numpy
-        arrays in order to improve the efficiency of the operations.
+        A version of the code operation with numpy arrays is left commented out as a
+        potential alternative, for future reference. The numpy way makes use of
+        ``self.actions_np``, defined in
+        :py:meth:`~gflownet.envs.grid.Grid.get_action_space`.
+
 
         Parameters
         ----------
@@ -128,10 +130,18 @@ class Grid(GFlowNetEnv):
         done = self._get_done(done)
         if done:
             return [True] * self.mask_dim
-        dist_to_edge = (self.length - 1) * np.ones(self.n_dim, dtype=int) - np.array(
-            state
-        )
-        mask = np.any(dist_to_edge < self.actions_np, axis=1).tolist()
+        # Numpy way: less efficient at least with few dimensions
+        # dist_to_edge = (self.length - 1) * np.ones(self.n_dim, dtype=int) - np.array(
+        #     state
+        # )
+        # mask = np.any(dist_to_edge < self.actions_np, axis=1).tolist()
+        mask = [False] * self.mask_dim
+        max_val = self.length - 1
+        for idx, action in enumerate(self.action_space):
+            for s_dim, a_dim in zip(state, action):
+                if (max_val - s_dim) < a_dim:
+                    mask[idx] = True
+                    break
         return mask
 
     def get_mask_invalid_actions_backward(
@@ -146,9 +156,10 @@ class Grid(GFlowNetEnv):
         it is overwritten here to improve the efficiency and because it is used by
         :py:meth:`~gflownet.envs.grid.Grid.get_parents`.
 
-        This method makes use of ``self.actions_np``, defined in
-        :py:meth:`~gflownet.envs.grid.Grid.get_action_space`, and operates with numpy
-        arrays in order to improve the efficiency of the operations.
+        A version of the code operation with numpy arrays is left commented out as a
+        potential alternative, for future reference. The numpy way makes use of
+        ``self.actions_np``, defined in
+        :py:meth:`~gflownet.envs.grid.Grid.get_action_space`.
 
         Parameters
         ----------
@@ -168,9 +179,18 @@ class Grid(GFlowNetEnv):
             mask = [True] * self.mask_dim
             mask[self.action2index(self.eos)] = False
             return mask
-        mask = np.any(self.actions_np > np.array(state), axis=1).tolist()
-        # Make EOS invalid, since the trajectory is not done
-        mask[self.action2index(self.eos)] = True
+        # Numpy way: less efficient at least with few dimensions
+        # mask = np.any(self.actions_np > np.array(state), axis=1).tolist()
+        # mask[self.action2index(self.eos)] = True
+        mask = [False] * self.mask_dim
+        for idx, action in enumerate(self.action_space):
+            if action == self.eos:
+                mask[idx] = True
+                continue
+            for s_dim, a_dim in zip(state, action):
+                if a_dim > s_dim:
+                    mask[idx] = True
+                    break
         return mask
 
     def get_parents(
@@ -207,7 +227,7 @@ class Grid(GFlowNetEnv):
         parents = []
         actions = []
         for action in actions_valid:
-            parent = list(np.array(state, dtype=int) - np.array(action))
+            parent = [s_dim - a_dim for s_dim, a_dim in zip(state, action)]
             parents.append(parent)
             actions.append(action)
         return parents, actions

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -114,7 +114,6 @@ class Grid(GFlowNetEnv):
         ``self.actions_np``, defined in
         :py:meth:`~gflownet.envs.grid.Grid.get_action_space`.
 
-
         Parameters
         ----------
         state : list

--- a/tests/gflownet/envs/test_grid.py
+++ b/tests/gflownet/envs/test_grid.py
@@ -202,6 +202,125 @@ def test__get_mask_invalid_actions_forward__masks_expected_actions(
     assert set(env.get_valid_actions()) == set()
 
 
+@pytest.mark.parametrize(
+    "env, state, actions_valid_exp",
+    [
+        (
+            "env_extended_action_space_2d",
+            [0, 0],
+            set(),
+        ),
+        (
+            "env_extended_action_space_2d",
+            [2, 2],
+            {(1, 0), (2, 0), (0, 1), (1, 1), (2, 1), (0, 2), (1, 2), (2, 2)},
+        ),
+        (
+            "env_extended_action_space_2d",
+            [1, 3],
+            {(1, 0), (0, 1), (1, 1), (0, 2), (1, 2)},
+        ),
+        (
+            "env_extended_action_space_2d",
+            [0, 1],
+            {(0, 1)},
+        ),
+        (
+            "env_extended_action_space_3d",
+            [0, 0, 0],
+            set(),
+        ),
+        (
+            "env_extended_action_space_3d",
+            [4, 3, 2],
+            {
+                (1, 0, 0),
+                (0, 1, 0),
+                (0, 0, 1),
+                (1, 1, 0),
+                (1, 0, 1),
+                (0, 1, 1),
+                (2, 0, 0),
+                (0, 2, 0),
+                (0, 0, 2),
+                (2, 1, 0),
+                (2, 0, 1),
+                (1, 2, 0),
+                (1, 0, 2),
+                (0, 2, 1),
+                (0, 1, 2),
+                (2, 2, 0),
+                (2, 0, 2),
+                (0, 2, 2),
+            },
+        ),
+        (
+            "env_extended_action_space_3d",
+            [1, 0, 2],
+            {
+                (1, 0, 0),
+                (0, 0, 1),
+                (1, 0, 1),
+                (0, 0, 2),
+                (1, 0, 2),
+            },
+        ),
+    ],
+)
+def test__get_mask_invalid_actions_backward__masks_expected_actions(
+    env, state, actions_valid_exp, request
+):
+    env = request.getfixturevalue(env)
+    assert set(actions_valid_exp) == set(
+        env.get_valid_actions(state=state, backward=True)
+    )
+    env.set_state(state)
+    assert set(actions_valid_exp) == set(env.get_valid_actions(backward=True))
+
+
+@pytest.mark.parametrize(
+    "state, parents_expected, parents_a_expected",
+    [
+        (
+            [0, 0],
+            [],
+            [],
+        ),
+        (
+            [1, 0],
+            [[0, 0]],
+            [(1, 0)],
+        ),
+        (
+            [1, 1],
+            [[0, 1], [1, 0], [0, 0]],
+            [(1, 0), (0, 1), (1, 1)],
+        ),
+        (
+            [3, 4],
+            [[2, 4], [1, 4], [3, 3], [2, 3], [1, 3], [3, 2], [2, 3], [1, 2]],
+            [(1, 0), (2, 0), (0, 1), (1, 1), (2, 1), (0, 2), (1, 2), (2, 2)],
+        ),
+    ],
+)
+def test__get_parents__returns_expected(
+    env_extended_action_space_2d, state, parents_expected, parents_a_expected
+):
+    env = env_extended_action_space_2d
+    parents, parents_a = env.get_parents(state)
+    assert len(parents) == len(parents_expected)
+    assert len(parents_a) == len(parents_a_expected)
+    # Create dictionaries of parent_action: parent for comparison
+    parents_actions_exp_dict = {}
+    for parent, action in zip(parents_expected, parents_a_expected):
+        parents_actions_exp_dict[action] = tuple(parent.copy())
+    parents_actions_dict = {}
+    for parent, action in zip(parents, parents_a):
+        parents_actions_dict[action] = tuple(parent.copy())
+
+    assert sorted(parents_actions_exp_dict) == sorted(parents_actions_dict)
+
+
 class TestGridBasic(common.BaseTestsDiscrete):
     """Common tests for 5x5 Grid with standard action space."""
 

--- a/tests/gflownet/envs/test_grid.py
+++ b/tests/gflownet/envs/test_grid.py
@@ -34,7 +34,7 @@ def env_extended_action_space_3d():
         n_dim=3,
         length=5,
         max_increment=2,
-        max_dim_per_action=3,
+        max_dim_per_action=2,
         cell_min=-1.0,
         cell_max=1.0,
     )
@@ -87,15 +87,41 @@ def test__states2proxy__returns_expected(env, states, states2proxy):
 
 
 @pytest.mark.parametrize(
-    "action_space",
+    "env, action_space",
     [
-        [(0, 0), (1, 0), (2, 0), (0, 1), (1, 1), (2, 1), (0, 2), (1, 2), (2, 2)],
+        (
+            "env_extended_action_space_2d",
+            [(0, 0), (1, 0), (2, 0), (0, 1), (1, 1), (2, 1), (0, 2), (1, 2), (2, 2)],
+        ),
+        (
+            "env_extended_action_space_3d",
+            [
+                (0, 0, 0),
+                (1, 0, 0),
+                (0, 1, 0),
+                (0, 0, 1),
+                (1, 1, 0),
+                (1, 0, 1),
+                (0, 1, 1),
+                (2, 0, 0),
+                (0, 2, 0),
+                (0, 0, 2),
+                (2, 1, 0),
+                (2, 0, 1),
+                (1, 2, 0),
+                (1, 0, 2),
+                (0, 2, 1),
+                (0, 1, 2),
+                (2, 2, 0),
+                (2, 0, 2),
+                (0, 2, 2),
+            ],
+        ),
     ],
 )
-def test__get_action_space__returns_expected(
-    env_extended_action_space_2d, action_space
-):
-    assert set(action_space) == set(env_extended_action_space_2d.action_space)
+def test__get_action_space__returns_expected(env, action_space, request):
+    env = request.getfixturevalue(env)
+    assert set(action_space) == set(env.action_space)
 
 
 class TestGridBasic(common.BaseTestsDiscrete):

--- a/tests/gflownet/envs/test_grid.py
+++ b/tests/gflownet/envs/test_grid.py
@@ -124,6 +124,84 @@ def test__get_action_space__returns_expected(env, action_space, request):
     assert set(action_space) == set(env.action_space)
 
 
+@pytest.mark.parametrize(
+    "env, state, actions_valid_exp",
+    [
+        (
+            "env_extended_action_space_2d",
+            [0, 0],
+            {(0, 0), (1, 0), (0, 1), (1, 1), (2, 0), (0, 2), (2, 1), (1, 2), (2, 2)},
+        ),
+        (
+            "env_extended_action_space_2d",
+            [2, 2],
+            {(0, 0), (1, 0), (0, 1), (1, 1), (2, 0), (0, 2), (2, 1), (1, 2), (2, 2)},
+        ),
+        (
+            "env_extended_action_space_2d",
+            [2, 3],
+            {(0, 0), (1, 0), (0, 1), (1, 1), (2, 0), (2, 1)},
+        ),
+        (
+            "env_extended_action_space_2d",
+            [4, 1],
+            {(0, 0), (0, 1), (0, 2)},
+        ),
+        (
+            "env_extended_action_space_2d",
+            [4, 3],
+            {(0, 0), (0, 1)},
+        ),
+        (
+            "env_extended_action_space_3d",
+            [0, 0, 0],
+            {
+                (0, 0, 0),
+                (1, 0, 0),
+                (0, 1, 0),
+                (0, 0, 1),
+                (1, 1, 0),
+                (1, 0, 1),
+                (0, 1, 1),
+                (2, 0, 0),
+                (0, 2, 0),
+                (0, 0, 2),
+                (2, 1, 0),
+                (2, 0, 1),
+                (1, 2, 0),
+                (1, 0, 2),
+                (0, 2, 1),
+                (0, 1, 2),
+                (2, 2, 0),
+                (2, 0, 2),
+                (0, 2, 2),
+            },
+        ),
+        (
+            "env_extended_action_space_3d",
+            [4, 3, 2],
+            {
+                (0, 0, 0),
+                (0, 1, 0),
+                (0, 0, 1),
+                (0, 1, 1),
+                (0, 0, 2),
+                (0, 1, 2),
+            },
+        ),
+    ],
+)
+def test__get_mask_invalid_actions_forward__masks_expected_actions(
+    env, state, actions_valid_exp, request
+):
+    env = request.getfixturevalue(env)
+    assert set(actions_valid_exp) == set(env.get_valid_actions(state=state))
+    env.set_state(state)
+    assert set(actions_valid_exp) == set(env.get_valid_actions())
+    env.done = True
+    assert set(env.get_valid_actions()) == set()
+
+
 class TestGridBasic(common.BaseTestsDiscrete):
     """Common tests for 5x5 Grid with standard action space."""
 

--- a/tests/gflownet/envs/test_setbox.py
+++ b/tests/gflownet/envs/test_setbox.py
@@ -127,7 +127,7 @@ def test__set_state__sets_state_and_dones(env, state, dones, request):
             # fmt: off
             [
                 True, False, # ACTIVE SUBENV (Stack)
-                True, True, False, # MASK (Conditioning Grid)
+                False, True, True, # MASK (Conditioning Grid)
                 False, False, False, # PADDING
             ]
             # fmt: on

--- a/tests/gflownet/envs/test_setfix.py
+++ b/tests/gflownet/envs/test_setfix.py
@@ -2556,7 +2556,7 @@ def test__step_backwards__eos_action_valid_if_all_subenvs_are_done(
             # fmt: off
             [
                 True, False, # ACTIVE SUBENV
-                False, True, False, # MASK
+                False, False, True, # MASK
                 False, False, False, False, False # PAD
             ]
             # fmt: on
@@ -2663,7 +2663,7 @@ def test__step_backwards__eos_action_valid_if_all_subenvs_are_done(
             # fmt: off
             [
                 True, # ACTIVE UNIQUE ENV
-                True, False, False, # MASK GRID
+                False, True, False, # MASK GRID
             ]
             # fmt: on
         ),
@@ -3194,7 +3194,7 @@ def test__get_mask_invalid_actions_forward__returns_expected(
             # fmt: off
             [
                 True, False, # ACTIVE SUBENV
-                False, False, True, # MASK
+                True, False, False, # MASK
                 False, False, False, False, False # PAD
             ]
             # fmt: on
@@ -3253,7 +3253,7 @@ def test__get_mask_invalid_actions_forward__returns_expected(
             # fmt: off
             [
                 True, # ACTIVE UNIQUE ENV
-                True, True, False, # MASK GRID
+                False, True, True, # MASK GRID
             ]
             # fmt: on
         ),
@@ -3272,7 +3272,7 @@ def test__get_mask_invalid_actions_forward__returns_expected(
             # fmt: off
             [
                 True, # ACTIVE UNIQUE ENV
-                True, True, False, # MASK GRID
+                False, True, True, # MASK GRID
             ]
             # fmt: on
         ),
@@ -3613,7 +3613,7 @@ def test__get_mask_invalid_actions_forward__all_subenvs_done(
             # fmt: off
             [
                 True, False, # ACTIVE SUBENV
-                True, True, False, # MASK
+                False, True, True, # MASK
                 False, False, False, False, False # PAD
             ]
             # fmt: on

--- a/tests/gflownet/envs/test_setflex.py
+++ b/tests/gflownet/envs/test_setflex.py
@@ -1409,7 +1409,7 @@ def test__set_state__sets_state_dones_and_subenvs(env, state, done, subenvs, req
             # fmt: off
             [
                 True, False, # ACTIVE SUBENV
-                True, False, False, # MASK
+                False, True, False, # MASK
             ]
             # fmt: on
         ),
@@ -1655,7 +1655,7 @@ def test__get_mask_invalid_actions_forward__returns_expected(
             # fmt: off
             [
                 True, False, # ACTIVE SUBENV
-                True, False, False, # MASK
+                False, True, False, # MASK
             ]
             # fmt: on
         ),
@@ -2000,7 +2000,7 @@ def test__get_mask_invalid_actions_forward__returns_expected_without_setting_sub
             # fmt: off
             [
                 True, False, False, # ACTIVE SUBENV
-                False, False, True, # MASK
+                True, False, False, # MASK
                 False, False, # PAD
             ]
             # fmt: on
@@ -2226,7 +2226,7 @@ def test__get_mask_invalid_actions_backward__returns_expected(
             # fmt: off
             [
                 True, False, False, # ACTIVE SUBENV
-                False, False, True, # MASK
+                True, False, False, # MASK
                 False, False, # PAD
             ]
             # fmt: on


### PR DESCRIPTION
This PR is a simple update and refactoring of the Grid environment on the following aspects:
- Re-implement a few methods for clarity (and minor efficiency improvements):
  - `get_action_space()`
  - `get_mask_invalid_actions_forward()`
  - `get_parents()`
- Implement `get_mask_invalid_actions_backward()` which is not needed by default.
- Extend docstrings
- Extend tests

An original motivation was to improve the efficiency through the use of numpy, but there is no efficiency gains with low dimensions. 

## Training time comparisons with respect to main branch

All experiments are with uniform proxy, batch size 10 and 1000 iterations, unless specified otherwise, that is:

```
python train.py env=grid proxy=uniform gflownet.optimizer.batch_size.forward=10 gflownet.optimizer.n_train_steps=1000
```

The experiments are run in the Mila cluster with an interactive job obtained with
```
salloc --gres="" -c 1 --nodelist=cn-m[001] --mem=4G
```

### 10x10

```
env.length=10 env.n_dim=2
```
- New: `[00:09<00:00, 104.45it/s]`
- Main: `[00:09<00:00, 103.14it/s]`

### 10^5

```
env.length=10 env.n_dim=5
```
- New: `[00:18<00:00, 53.71it/s]`
- Main: `[00:18<00:00, 54.56it/s]`

### 100^5

These experiments are run for 5k iterations

```
env.length=100 env.n_dim=5 gflownet.optimizer.n_train_steps=5000
```
- New: `[09:49<00:00,  8.48it/s]`
- Main: `[09:47<00:00,  8.51it/s]`


### 100^5 with max increment 5

These experiments are run for 5k iterations too

```
env.length=100 env.n_dim=5 env.max_increment=5 gflownet.optimizer.n_train_steps=5000
```
- New: `[07:21<00:00, 11.32it/s]`
- Main: `[07:58<00:00, 10.45it/s]`
- New, numpy way: `[07:17<00:00, 11.43it/s]`

---

So it seems that the changes only slightly speed up the environments that allow increments of more than one, since that increases the size of the action space.

- [x] Fix tests that use the Grid environment (action space order and hence mask have changed)