### PR TITLE
[Tiny] Change default value of Cube's beta_params_min from 0.1 to 1.0

### DIFF
--- a/config/env/ccube.yaml
+++ b/config/env/ccube.yaml
@@ -13,7 +13,7 @@ kappa: 1e-3
 min_incr: 0.1
 n_comp: 2
 epsilon: 1e-6
-beta_params_min: 0.1
+beta_params_min: 1.0
 beta_params_max: 100.0
 fixed_distr_params:
   beta_weights: 1.0

--- a/config/env/crystals/crystal.yaml
+++ b/config/env/crystals/crystal.yaml
@@ -26,7 +26,7 @@ lattice_parameters_kwargs:
   min_incr: 0.1
   n_comp: 2
   epsilon: 1e-6
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   fixed_distr_params:
     beta_weights: 1.0

--- a/config/env/crystals/lattice_parameters.yaml
+++ b/config/env/crystals/lattice_parameters.yaml
@@ -17,7 +17,7 @@ max_angle: 150.0
 min_incr: 0.1
 n_comp: 2
 epsilon: 1e-6
-beta_params_min: 0.1
+beta_params_min: 1.0
 beta_params_max: 100.0
 fixed_distribution:
   beta_weights: 1.0

--- a/config/env/crystals/lattice_parameters_sgccg.yaml
+++ b/config/env/crystals/lattice_parameters_sgccg.yaml
@@ -12,7 +12,7 @@ lattice_system: triclinic
 min_incr: 0.1
 n_comp: 2
 epsilon: 1e-6
-beta_params_min: 0.1
+beta_params_min: 1.0
 beta_params_max: 100.0
 fixed_distribution:
   beta_weights: 1.0

--- a/config/env/hcube.yaml
+++ b/config/env/hcube.yaml
@@ -13,7 +13,7 @@ kappa: 1e-3
 min_incr: 0.1
 n_comp: 2
 epsilon: 1e-6
-beta_params_min: 0.1
+beta_params_min: 1.0
 beta_params_max: 100.0
 fixed_distr_params:
   beta_weights: 1.0

--- a/config/env/points.yaml
+++ b/config/env/points.yaml
@@ -19,7 +19,7 @@ cube_kwargs:
   min_incr: 0.1
   n_comp: 2
   epsilon: 1e-6
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   fixed_distr_params:
     beta_weights: 1.0

--- a/config/env/setbox.yaml
+++ b/config/env/setbox.yaml
@@ -16,7 +16,7 @@ cube_kwargs:
   min_incr: 0.1
   n_comp: 2
   epsilon: 1e-6
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   fixed_distr_params:
     beta_weights: 1.0

--- a/config/env/tree.yaml
+++ b/config/env/tree.yaml
@@ -20,7 +20,7 @@ test_args:
 
 # Policy parameters
 threshold_components: 3
-beta_params_min: 0.1
+beta_params_min: 1.0
 beta_params_max: 100.0
 fixed_distr_params:
   beta_alpha: 2.0

--- a/config/experiments/ccube/branin.yaml
+++ b/config/experiments/ccube/branin.yaml
@@ -13,7 +13,7 @@ defaults:
 env:
   n_dim: 2
   n_comp: 5
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   min_incr: 0.1
   fixed_distr_params:

--- a/config/experiments/ccube/corners.yaml
+++ b/config/experiments/ccube/corners.yaml
@@ -13,7 +13,7 @@ defaults:
 env:
   n_comp: 5
   n_dim: 2
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   min_incr: 0.1
   fixed_distr_params:

--- a/config/experiments/ccube/hartmann.yaml
+++ b/config/experiments/ccube/hartmann.yaml
@@ -13,7 +13,7 @@ defaults:
 env:
   n_dim: 6
   n_comp: 5
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   min_incr: 0.1
   fixed_distr_params:

--- a/config/experiments/ccube/hyperparams_search_20230920_batch1.yaml
+++ b/config/experiments/ccube/hyperparams_search_20230920_batch1.yaml
@@ -75,7 +75,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 5
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -117,7 +117,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 5
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 1000.0
         random_distr_params:
           beta_weights: 1.0

--- a/config/experiments/ccube/hyperparams_search_20230920_batch2.yaml
+++ b/config/experiments/ccube/hyperparams_search_20230920_batch2.yaml
@@ -75,7 +75,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 5
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -117,7 +117,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 5
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 1000.0
         random_distr_params:
           beta_weights: 1.0

--- a/config/experiments/ccube/hyperparams_search_20230920_batch3.yaml
+++ b/config/experiments/ccube/hyperparams_search_20230920_batch3.yaml
@@ -75,7 +75,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 2
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -117,7 +117,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 2
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 1000.0
         random_distr_params:
           beta_weights: 1.0

--- a/config/experiments/ccube/hyperparams_search_20230920_batch4.yaml
+++ b/config/experiments/ccube/hyperparams_search_20230920_batch4.yaml
@@ -61,7 +61,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 2
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -75,7 +75,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 2
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -89,7 +89,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 2
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -103,7 +103,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 2
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -117,7 +117,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 5
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -131,7 +131,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 5
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -145,7 +145,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 5
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -159,7 +159,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 5
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -173,7 +173,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 1
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -187,7 +187,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 1
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -201,7 +201,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 1
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0
@@ -215,7 +215,7 @@ jobs:
       env:
         __value__: ccube
         n_comp: 1
-        beta_params_min: 0.1
+        beta_params_min: 1.0
         beta_params_max: 100.0
         random_distr_params:
           beta_weights: 1.0

--- a/config/experiments/ccube/uniform.yaml
+++ b/config/experiments/ccube/uniform.yaml
@@ -13,7 +13,7 @@ defaults:
 env:
   n_comp: 2
   n_dim: 2
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   min_incr: 0.1
   fixed_distr_params:

--- a/config/experiments/crystals/gull_corners.yaml
+++ b/config/experiments/crystals/gull_corners.yaml
@@ -39,7 +39,7 @@ env:
     min_angle: 60.0
     max_angle: 140.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/gull_corners_default.yaml
+++ b/config/experiments/crystals/gull_corners_default.yaml
@@ -39,7 +39,7 @@ env:
     min_angle: 60.0
     max_angle: 140.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/gull_fe.yaml
+++ b/config/experiments/crystals/gull_fe.yaml
@@ -38,7 +38,7 @@ env:
     min_angle: 60.0
     max_angle: 140.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/lattice_parameters_hexagonal_uniform.yaml
+++ b/config/experiments/crystals/lattice_parameters_hexagonal_uniform.yaml
@@ -11,7 +11,7 @@ defaults:
 env:
   lattice_system: hexagonal
   n_comp: 2
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   min_incr: 0.1
   fixed_distr_params:

--- a/config/experiments/crystals/starling_bg.yaml
+++ b/config/experiments/crystals/starling_bg.yaml
@@ -46,7 +46,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_bg_no_constraints.yaml
+++ b/config/experiments/crystals/starling_bg_no_constraints.yaml
@@ -46,7 +46,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_density.yaml
+++ b/config/experiments/crystals/starling_density.yaml
@@ -46,7 +46,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_density_no_constraints.yaml
+++ b/config/experiments/crystals/starling_density_no_constraints.yaml
@@ -46,7 +46,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_fe.yaml
+++ b/config/experiments/crystals/starling_fe.yaml
@@ -46,7 +46,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_fe_no_constraints.yaml
+++ b/config/experiments/crystals/starling_fe_no_constraints.yaml
@@ -45,7 +45,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_fe_restricted_a.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_a.yaml
@@ -48,7 +48,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_fe_restricted_b.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_b.yaml
@@ -50,7 +50,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_fe_restricted_c.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_c.yaml
@@ -49,7 +49,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/starling_fe_restricted_d.yaml
+++ b/config/experiments/crystals/starling_fe_restricted_d.yaml
@@ -50,7 +50,7 @@ env:
     min_angle: 75.0
     max_angle: 135.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/crystals/turaco_corners.yaml
+++ b/config/experiments/crystals/turaco_corners.yaml
@@ -39,7 +39,7 @@ env:
     min_angle: 60.0
     max_angle: 140.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.02
     fixed_distr_params:

--- a/config/experiments/crystals/turaco_corners_default.yaml
+++ b/config/experiments/crystals/turaco_corners_default.yaml
@@ -39,7 +39,7 @@ env:
     min_angle: 60.0
     max_angle: 140.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.02
     fixed_distr_params:

--- a/config/experiments/crystals/turaco_density.yaml
+++ b/config/experiments/crystals/turaco_density.yaml
@@ -39,7 +39,7 @@ env:
     min_angle: 60.0
     max_angle: 140.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.02
     fixed_distr_params:

--- a/config/experiments/crystals/turaco_fe.yaml
+++ b/config/experiments/crystals/turaco_fe.yaml
@@ -39,7 +39,7 @@ env:
     min_angle: 60.0
     max_angle: 140.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.02
     fixed_distr_params:

--- a/config/experiments/crystals/whistler_uniform.yaml
+++ b/config/experiments/crystals/whistler_uniform.yaml
@@ -47,7 +47,7 @@ env:
     min_angle: 50.0
     max_angle: 150.0
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/config/experiments/hcube/branin.yaml
+++ b/config/experiments/hcube/branin.yaml
@@ -12,7 +12,7 @@ defaults:
 env:
   n_dim: 2
   n_comp: 5
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   min_incr: 0.1
   fixed_distr_params:

--- a/config/experiments/hcube/corners.yaml
+++ b/config/experiments/hcube/corners.yaml
@@ -13,7 +13,7 @@ defaults:
 env:
   n_comp: 5
   n_dim: 2
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   min_incr: 0.1
   fixed_distr_params:

--- a/config/experiments/hcube/uniform.yaml
+++ b/config/experiments/hcube/uniform.yaml
@@ -12,7 +12,7 @@ defaults:
 env:
   n_comp: 2
   n_dim: 2
-  beta_params_min: 0.1
+  beta_params_min: 1.0
   beta_params_max: 100.0
   min_incr: 0.1
   fixed_distr_params:

--- a/config/experiments/setbox/corners.yaml
+++ b/config/experiments/setbox/corners.yaml
@@ -18,7 +18,7 @@ env:
   # Cubes config
   cube_kwargs:
     n_comp: 5
-    beta_params_min: 0.1
+    beta_params_min: 1.0
     beta_params_max: 100.0
     min_incr: 0.1
     fixed_distr_params:

--- a/gflownet/envs/cube.py
+++ b/gflownet/envs/cube.py
@@ -62,7 +62,7 @@ class CubeBase(GFlowNetEnv, ABC):
         n_dim: int = 2,
         min_incr: float = 0.1,
         n_comp: int = 1,
-        beta_params_min: float = 0.1,
+        beta_params_min: float = 1.0,
         beta_params_max: float = 100.0,
         epsilon: float = 1e-6,
         kappa: float = 1e-3,

--- a/gflownet/envs/points.py
+++ b/gflownet/envs/points.py
@@ -38,7 +38,7 @@ class Points(SetFix):
         cube_kwargs: Optional[dict] = {
             "min_incr": 0.1,
             "n_comp": 1,
-            "beta_params_min": 0.1,
+            "beta_params_min": 1.0,
             "beta_params_max": 100.0,
             "epsilon": 1e-6,
             "kappa": 1e-3,

--- a/gflownet/envs/tree.py
+++ b/gflownet/envs/tree.py
@@ -160,7 +160,7 @@ class Tree(GFlowNetEnv):
         continuous: bool = True,
         n_thresholds: Optional[int] = 9,
         threshold_components: int = 1,
-        beta_params_min: float = 0.1,
+        beta_params_min: float = 1.0,
         beta_params_max: float = 2.0,
         fixed_distr_params: dict = {
             "beta_alpha": 2.0,


### PR DESCRIPTION
The new value has been found to be much more stable and offer better results.