### PR TITLE
Fix mixed-device bugs in Grid, SetFix, and SetFlex envs

### DIFF
--- a/gflownet/envs/composite/setfix.py
+++ b/gflownet/envs/composite/setfix.py
@@ -145,24 +145,6 @@ class SetFix(BaseSet):
         """
         n_states = len(states)
 
-        # Obtain torch tensors for the active subenvironments, the toggle flags and
-        # the done indicators
-        active_subenvs = torch.zeros((n_states, self.n_subenvs), dtype=self.float)
-        dones = []
-        for idx, state in enumerate(states):
-            active_subenv = self._get_active_subenv(state)
-            if active_subenv != -1:
-                active_subenvs[idx, active_subenv] = 1.0
-            dones.append(self._get_dones(state))
-        dones = torch.tensor(dones, dtype=self.float)
-
-        # Obtain the torch tensor containing the toggle flags
-        toggle_flags = torch.tensor(
-            [self._get_toggle_flag(s) for s in states], dtype=self.float
-        ).reshape(
-            (-1, 1)
-        )  # reshape to (n_states, 1)
-
         # Obtain the torch tensor containing the states2policy of the sub-environments
         substates = []
         for idx_subenv, subenv in enumerate(self.subenvs):
@@ -172,6 +154,29 @@ class SetFix(BaseSet):
             # Convert the subenv_states to policy format
             substates.append(subenv.states2policy(subenv_states))
         substates = torch.cat(substates, dim=1)
+        device = substates.device
+
+        # Obtain torch tensors for the active subenvironments, the toggle flags and
+        # the done indicators
+        active_subenvs = torch.zeros(
+            (n_states, self.n_subenvs), dtype=self.float, device=device
+        )
+        dones = []
+        for idx, state in enumerate(states):
+            active_subenv = self._get_active_subenv(state)
+            if active_subenv != -1:
+                active_subenvs[idx, active_subenv] = 1.0
+            dones.append(self._get_dones(state))
+        dones = torch.tensor(dones, dtype=self.float, device=device)
+
+        # Obtain the torch tensor containing the toggle flags
+        toggle_flags = torch.tensor(
+            [self._get_toggle_flag(s) for s in states],
+            dtype=self.float,
+            device=device,
+        ).reshape(
+            (-1, 1)
+        )  # reshape to (n_states, 1)
 
         return torch.cat([active_subenvs, toggle_flags, dones, substates], dim=1)
 

--- a/gflownet/envs/composite/setflex.py
+++ b/gflownet/envs/composite/setflex.py
@@ -436,9 +436,25 @@ class SetFlex(BaseSet):
         """
         n_states = len(states)
 
+        # Initialize the policy representation of the states with self.max_elements
+        # source states in their policy representation per unique environment.
+        substates = torch.tile(
+            torch.cat(
+                [
+                    subenv.state2policy(subenv.source).tile((self.max_elements,))
+                    for subenv in self.envs_unique
+                ],
+                dim=0,
+            ),
+            (n_states, 1),
+        )
+        device = substates.device
+
         # Obtain torch tensors for the active sub-environments, the toggle flags,
         # the done indicators and the number of subenvs per unique environment
-        active_subenvs = torch.zeros((n_states, self.max_elements), dtype=self.float)
+        active_subenvs = torch.zeros(
+            (n_states, self.max_elements), dtype=self.float, device=device
+        )
         dones = []
         n_subenvs_per_unique_env = []
         for idx_state, state in enumerate(states):
@@ -453,30 +469,19 @@ class SetFlex(BaseSet):
             if len(indices) != 0:
                 n_subenvs[indices] = counts
             n_subenvs_per_unique_env.append(n_subenvs.tolist())
-        dones = torch.tensor(dones, dtype=self.float)
+        dones = torch.tensor(dones, dtype=self.float, device=device)
         n_subenvs_per_unique_env = torch.tensor(
-            n_subenvs_per_unique_env, dtype=self.float
+            n_subenvs_per_unique_env, dtype=self.float, device=device
         )
 
         # Obtain the torch tensor containing the toggle flags
         toggle_flags = torch.tensor(
-            [self._get_toggle_flag(s) for s in states], dtype=self.float
+            [self._get_toggle_flag(s) for s in states],
+            dtype=self.float,
+            device=device,
         ).reshape(
             (-1, 1)
         )  # reshape to (n_states, 1)
-
-        # Initialize the policy representation of the states with self.max_elements
-        # source states in their policy representation per unique environment.
-        substates = torch.tile(
-            torch.cat(
-                [
-                    subenv.state2policy(subenv.source).tile((self.max_elements,))
-                    for subenv in self.envs_unique
-                ],
-                dim=0,
-            ),
-            (n_states, 1),
-        )
 
         # Obtain the policy representation of the states that are present.
         for idx_state, state in enumerate(states):

--- a/gflownet/envs/grid.py
+++ b/gflownet/envs/grid.py
@@ -176,10 +176,17 @@ class Grid(GFlowNetEnv):
         """
         states = tlong(states, device=self.device)
         n_states = states.shape[0]
-        cols = states + torch.arange(self.n_dim) * self.length
-        rows = torch.repeat_interleave(torch.arange(n_states), self.n_dim)
+        device = states.device
+        index_dtype = states.dtype
+        cols = (
+            states
+            + torch.arange(self.n_dim, device=device, dtype=index_dtype) * self.length
+        )
+        rows = torch.repeat_interleave(
+            torch.arange(n_states, device=device, dtype=index_dtype), self.n_dim
+        )
         states_policy = torch.zeros(
-            (n_states, self.length * self.n_dim), dtype=self.float, device=self.device
+            (n_states, self.length * self.n_dim), dtype=self.float, device=device
         )
         states_policy[rows, cols.flatten()] = 1.0
         return states_policy

--- a/tests/gflownet/envs/test_grid.py
+++ b/tests/gflownet/envs/test_grid.py
@@ -2,6 +2,7 @@ import common
 import pytest
 import torch
 
+import gflownet.envs.grid as grid_module
 from gflownet.envs.grid import Grid
 from gflownet.utils.common import tfloat
 
@@ -84,6 +85,32 @@ def test__state2proxy__returns_expected(env, state, state2proxy):
 )
 def test__states2proxy__returns_expected(env, states, states2proxy):
     assert torch.equal(torch.Tensor(states2proxy), env.states2proxy(states))
+
+
+def test__states2policy__creates_helper_indices_on_env_device(monkeypatch):
+    recorded_devices = []
+
+    def tracked_arange(*args, **kwargs):
+        recorded_devices.append(kwargs.get("device"))
+        return torch.arange(*args, **kwargs)
+
+    class TorchProxy:
+        def __getattr__(self, name):
+            if name == "arange":
+                return tracked_arange
+            return getattr(torch, name)
+
+    monkeypatch.setattr(grid_module, "torch", TorchProxy())
+
+    env = Grid(n_dim=3, length=4, cell_min=-1.0, cell_max=1.0, device="cpu")
+    states_policy = env.states2policy([[0, 1, 2]])
+
+    assert states_policy.device == env.device
+    assert recorded_devices
+    assert all(
+        device is not None and torch.device(device) == env.device
+        for device in recorded_devices
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/gflownet/envs/test_setfix.py
+++ b/tests/gflownet/envs/test_setfix.py
@@ -4,6 +4,7 @@ import common
 import numpy as np
 import pytest
 import torch
+import gflownet.envs.composite.setfix as setfix_module
 from torch import Tensor
 
 from gflownet.envs.base import GFlowNetEnv
@@ -7320,6 +7321,44 @@ def test__trajectory_bacwards_random__does_not_crash_and_reaches_source(env, req
 def test__states2policy__returns_expected(env, states, states_policy_exp, request):
     env = request.getfixturevalue(env)
     assert torch.equal(states_policy_exp, env.states2policy(states))
+
+
+def test__states2policy__creates_helper_tensors_on_env_device(monkeypatch):
+    recorded_devices = []
+
+    def tracked_zeros(*args, **kwargs):
+        recorded_devices.append(kwargs.get("device"))
+        return torch.zeros(*args, **kwargs)
+
+    def tracked_tensor(*args, **kwargs):
+        recorded_devices.append(kwargs.get("device"))
+        return torch.tensor(*args, **kwargs)
+
+    class TorchProxy:
+        def __getattr__(self, name):
+            if name == "zeros":
+                return tracked_zeros
+            if name == "tensor":
+                return tracked_tensor
+            return getattr(torch, name)
+
+    monkeypatch.setattr(setfix_module, "torch", TorchProxy())
+
+    env = SetFix(
+        subenvs=(
+            Grid(n_dim=2, length=3, cell_min=-1.0, cell_max=1.0, device="cpu"),
+            Grid(n_dim=2, length=3, cell_min=-1.0, cell_max=1.0, device="cpu"),
+        ),
+        device="cpu",
+    )
+    states_policy = env.states2policy([env.state])
+
+    assert states_policy.device == env.device
+    assert recorded_devices
+    assert all(
+        device is not None and torch.device(device) == env.device
+        for device in recorded_devices
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/gflownet/envs/test_setfix.py
+++ b/tests/gflownet/envs/test_setfix.py
@@ -4,9 +4,9 @@ import common
 import numpy as np
 import pytest
 import torch
-import gflownet.envs.composite.setfix as setfix_module
 from torch import Tensor
 
+import gflownet.envs.composite.setfix as setfix_module
 from gflownet.envs.base import GFlowNetEnv
 from gflownet.envs.composite.setfix import SetFix
 from gflownet.envs.composite.stack import Stack

--- a/tests/gflownet/envs/test_setflex.py
+++ b/tests/gflownet/envs/test_setflex.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 from torch import Tensor
 
+import gflownet.envs.composite.setflex as setflex_module
 from gflownet.envs.base import GFlowNetEnv
 from gflownet.envs.composite.setflex import SetFlex
 from gflownet.envs.composite.stack import Stack
@@ -5484,6 +5485,48 @@ def test__states2policy__returns_expected(env, states, states_policy_exp, reques
     env = request.getfixturevalue(env)
     states_policy = env.states2policy(states)
     assert torch.all(torch.isclose(states_policy_exp, env.states2policy(states)))
+
+
+def test__states2policy__creates_helper_tensors_on_env_device(monkeypatch):
+    recorded_devices = []
+
+    def tracked_zeros(*args, **kwargs):
+        recorded_devices.append(kwargs.get("device"))
+        return torch.zeros(*args, **kwargs)
+
+    def tracked_tensor(*args, **kwargs):
+        recorded_devices.append(kwargs.get("device"))
+        return torch.tensor(*args, **kwargs)
+
+    class TorchProxy:
+        def __getattr__(self, name):
+            if name == "zeros":
+                return tracked_zeros
+            if name == "tensor":
+                return tracked_tensor
+            return getattr(torch, name)
+
+    monkeypatch.setattr(setflex_module, "torch", TorchProxy())
+
+    env = SetFlex(
+        envs_unique=(
+            Grid(n_dim=2, length=3, cell_min=-1.0, cell_max=1.0, device="cpu"),
+        ),
+        max_elements=2,
+        subenvs=(
+            Grid(n_dim=2, length=3, cell_min=-1.0, cell_max=1.0, device="cpu"),
+            Grid(n_dim=2, length=3, cell_min=-1.0, cell_max=1.0, device="cpu"),
+        ),
+        device="cpu",
+    )
+    states_policy = env.states2policy([env.state])
+
+    assert states_policy.device == env.device
+    assert recorded_devices
+    assert all(
+        device is not None and torch.device(device) == env.device
+        for device in recorded_devices
+    )
 
 
 class TestSetFlexTwoGrids(common.BaseTestsDiscrete):


### PR DESCRIPTION
## Summary

This PR fixes CUDA/CPU device mismatches in environment state encoding by ensuring helper tensors in `states2policy()` are created on the active runtime device instead of defaulting to CPU.

 ### Changes
 - fix `Grid.states2policy()` (issue #307)
 - fix analogous device bugs in `SetFix.states2policy()` and `SetFlex.states2policy()`
 - add CPU-only regression tests for all three envs to verify device propagation
 - verify targeted env tests pass and CUDA smoke checks succeed

 Fixes #307