### PR TITLE
Fixes on the state of sequence

### DIFF
--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -1100,7 +1100,9 @@ class GFlowNetEnv:
         at all states (intermediate states are not fully constructed objects) should
         overwrite this method and check for validity.
         """
-        self.state = copy(state).to(self.device) if torch.is_tensor(state) else copy(state)
+        self.state = (
+            copy(state).to(self.device) if torch.is_tensor(state) else copy(state)
+        )
         self.done = done
         return self
 

--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -1100,7 +1100,7 @@ class GFlowNetEnv:
         at all states (intermediate states are not fully constructed objects) should
         overwrite this method and check for validity.
         """
-        self.state = copy(state)
+        self.state = copy(state).to(self.device) if torch.is_tensor(state) else copy(state)
         self.done = done
         return self
 

--- a/gflownet/envs/sequences/base.py
+++ b/gflownet/envs/sequences/base.py
@@ -87,6 +87,11 @@ class SequenceBase(GFlowNetEnv):
         self.eos = (self.eos_idx,)
         # Base class init
         super().__init__(**kwargs)
+    
+    def set_state(self, state, done=False):
+        self.state = tlong(state, device=self.device)
+        self.done = done
+        return self
 
     def get_action_space(self) -> List[Tuple]:
         """
@@ -327,7 +332,7 @@ class SequenceBase(GFlowNetEnv):
         A string of space-separated tokens.
         """
         state = self._get_state(state)
-        state = self._unpad(state.tolist())
+        state = self._unpad(state.tolist() if torch.is_tensor(state) else state)
         return "".join([str(self.idx2token[idx]) + " " for idx in state])[:-1]
 
     def readable2state(self, readable: str) -> TensorType["max_length"]:  # noqa: F821

--- a/gflownet/envs/sequences/base.py
+++ b/gflownet/envs/sequences/base.py
@@ -87,7 +87,7 @@ class SequenceBase(GFlowNetEnv):
         self.eos = (self.eos_idx,)
         # Base class init
         super().__init__(**kwargs)
-    
+
     def set_state(self, state, done=False):
         self.state = tlong(state, device=self.device)
         self.done = done

--- a/gflownet/evaluator/base.py
+++ b/gflownet/evaluator/base.py
@@ -295,10 +295,10 @@ class BaseEvaluator(AbstractEvaluator):
             if "corr_probs_rewards" in metrics:
                 probs_x_tt = np.exp(logprobs_x_tt.cpu().numpy())
                 lp_metrics["corr_probs_rewards"] = np.corrcoef(
-                    probs_x_tt, rewards_x_tt
+                    probs_x_tt, rewards_x_tt.detach().cpu().numpy()
                 )[0, 1]
                 lp_metrics["corr_logprobs_logrewards"] = np.corrcoef(
-                    logprobs_x_tt, logrewards_x_tt
+                    logprobs_x_tt.detach().cpu().numpy(), logrewards_x_tt.detach().cpu().numpy()
                 )[0, 1]
                 lp_data["probs"] = probs_x_tt
                 lp_data["logprobs"] = logprobs_x_tt
@@ -639,10 +639,16 @@ class BaseEvaluator(AbstractEvaluator):
             fig_scatter_rewards_probs, ax = plt.subplots(
                 nrows=1, ncols=2, figsize=(8, 4), dpi=150
             )
-            ax[0].scatter(rewards, probs)
+            ax[0].scatter(
+                rewards.detach().cpu().numpy() if hasattr(rewards, 'detach') else rewards,
+                probs.detach().cpu().numpy() if hasattr(probs, 'detach') else probs,
+            )
             ax[0].set_xlabel(f"Rewards")
             ax[0].set_ylabel(f"Probs")
-            ax[1].scatter(logrewards, logprobs)
+            ax[1].scatter(
+                logrewards.detach().cpu().numpy() if hasattr(logrewards, 'detach') else logrewards,
+                logprobs.detach().cpu().numpy() if hasattr(logprobs, 'detach') else logprobs,
+            )
             ax[1].set_xlabel(f"Log-rewards")
             ax[1].set_ylabel(f"Log-probs")
             fig_scatter_rewards_probs.tight_layout()

--- a/gflownet/evaluator/base.py
+++ b/gflownet/evaluator/base.py
@@ -298,7 +298,8 @@ class BaseEvaluator(AbstractEvaluator):
                     probs_x_tt, rewards_x_tt.detach().cpu().numpy()
                 )[0, 1]
                 lp_metrics["corr_logprobs_logrewards"] = np.corrcoef(
-                    logprobs_x_tt.detach().cpu().numpy(), logrewards_x_tt.detach().cpu().numpy()
+                    logprobs_x_tt.detach().cpu().numpy(),
+                    logrewards_x_tt.detach().cpu().numpy(),
                 )[0, 1]
                 lp_data["probs"] = probs_x_tt
                 lp_data["logprobs"] = logprobs_x_tt
@@ -640,14 +641,26 @@ class BaseEvaluator(AbstractEvaluator):
                 nrows=1, ncols=2, figsize=(8, 4), dpi=150
             )
             ax[0].scatter(
-                rewards.detach().cpu().numpy() if hasattr(rewards, 'detach') else rewards,
-                probs.detach().cpu().numpy() if hasattr(probs, 'detach') else probs,
+                (
+                    rewards.detach().cpu().numpy()
+                    if hasattr(rewards, "detach")
+                    else rewards
+                ),
+                probs.detach().cpu().numpy() if hasattr(probs, "detach") else probs,
             )
             ax[0].set_xlabel(f"Rewards")
             ax[0].set_ylabel(f"Probs")
             ax[1].scatter(
-                logrewards.detach().cpu().numpy() if hasattr(logrewards, 'detach') else logrewards,
-                logprobs.detach().cpu().numpy() if hasattr(logprobs, 'detach') else logprobs,
+                (
+                    logrewards.detach().cpu().numpy()
+                    if hasattr(logrewards, "detach")
+                    else logrewards
+                ),
+                (
+                    logprobs.detach().cpu().numpy()
+                    if hasattr(logprobs, "detach")
+                    else logprobs
+                ),
             )
             ax[1].set_xlabel(f"Log-rewards")
             ax[1].set_ylabel(f"Log-probs")


### PR DESCRIPTION
Fixes to incorporate different data types of the state in the sequence
Fixes include handling state as a tensor vs list and cpu vs cuda device which appears in the sequence environment and when using a buffer and offline training data. The main cause of the errors are the initialization of the state as a long tensor (`tlong`) in the `__init__` of the `SequenceBase()` class, [which is needed to pad the sequence efficiently](https://github.com/alexhernandezgarcia/gflownet/blob/b8c1d40ab04eba095f24d0113358ea74c4533cc2/gflownet/envs/sequences/base.py#L83) 

Changes: 

1. `gflownet/envs/base.py` 
in `GFlowNetEnv.set_state( )`
changed the implementation of setting the state to incorporate states with tensor data type. This class is inherited by `gflownet.envs.sequences.base.SequenceBase` 

2. `gflownet/evaluator/base.py` 
in `BaseEvaluator.compute_log_prob_metrics( ) ` and `BaseEvaluator.plot( )`
the `SequenceBase( )` environment passes tensors which returns an error when using `numpy.corrcoef( )` and `matplotlib.pyplot.scatter( )`  
all the tensors needed to be transformed using `tensor_var.detach().cpu().numpy()`

3. `gflownet/envs/sequences/base.py` 
- added a `SequenceBase.set_state( )` to always point the state to the same device used by the object (`self.device`)
- in `SequenceBase.state2readable( )` added a condition to consider if the state is not a tensor


Errors before the changes: 

1. `RuntimeError: Expected all tensors to be on the same device, found cpu and cuda:0`
  `envs/base.py` (in `isclose`):
  `return torch.equal(state_x, state_y)`  
2. `AttributeError: 'list' object has no attribute 'to'`
  `envs/base.py` (in `set_state`):
  `self.state = copy(state).to(self.device)`
3. `AttributeError: 'list' object has no attribute 'tolist'`
  `envs/sequences/base.py` (in `state2readable`):
  `state = self._unpad(state.tolist())`
4. `TypeError: where(): argument 'condition' must be Tensor, not bool`
  `envs/sequences/base.py:488` (in `_get_seq_length`):
  `return torch.where(state == self.pad_idx)[0][0]`
5. `TypeError: can't convert cuda:0 device type tensor to numpy`
  `evaluator/base.py:297` (in `compute_log_prob_metrics`):
  `lp_metrics["corr_probs_rewards"] = np.corrcoef(probs_x_tt, rewards_x_tt)[0, 1]`
6. `AttributeError: 'numpy.ndarray' object has no attribute 'detach'`
  `evaluator/base.py:642` (in `plot`):
  `ax[0].scatter(rewards.detach().cpu().numpy(), probs.detach().cpu().numpy())`
