### PR TITLE
s3gfn - toy env

### DIFF
--- a/config/buffer/base.yaml
+++ b/config/buffer/base.yaml
@@ -32,6 +32,9 @@ use_main_buffer: False
 # Whether new samples are compared to samples in the buffer before adding
 check_diversity: False
 
+# Whether replay insertion skips trajectories already present in replay
+reject_duplicate_trajectories: False
+
 # The accepted level of similarity of rewards to include samples from the
 # replay buffer in the diversity check. Assuming check_diversity is True, given
 # a sample x with reward R(x), the diversity check will only be performed

--- a/config/env/toy.yaml
+++ b/config/env/toy.yaml
@@ -19,3 +19,4 @@ connections:
   10: [-1]
 
 action_space_only_valid: True
+infeasible_states: []

--- a/config/experiments/s3gfn_toy/s3gfn.yaml
+++ b/config/experiments/s3gfn_toy/s3gfn.yaml
@@ -1,0 +1,75 @@
+# @package _global_
+# Toy TB baseline with reward-prioritized replay enabled.
+
+defaults:
+  - override /env: toy
+  - override /gflownet: trajectorybalance
+  - override /loss: s3gfn
+  - override /proxy: toy
+  - override /logger: wandb
+
+buffer:
+  replay_capacity: 20
+  reject_duplicate_trajectories: true
+  test:
+    type: all
+
+negative_buffer:
+  _target_: gflownet.buffer.base.BaseBuffer
+  replay_capacity: 20
+  reject_duplicate_trajectories: true
+  train:
+    type: null
+  test:
+    type: null
+
+env:
+  infeasible_states:
+    - s3
+    - s4
+
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      forward: 10
+      backward_replay: 5
+      backward_dataset: 0
+    lr: 0.001
+    z_dim: 8
+    lr_z_mult: 100
+    n_train_steps: 100
+  replay_sampling: weighted
+
+policy:
+  forward:
+    type: mlp
+    n_hid: 64
+    n_layers: 2
+  backward:
+    shared_weights: True
+
+logger:
+  do:
+    online: False
+  lightweight: False
+  project_name: "s3gfn_toy"
+  run_name: "Toy TB replay"
+  tags:
+    - gflownet
+    - s3gfn
+    - toy
+    - tb
+    - replay
+
+evaluator:
+  first_it: True
+  period: 25
+  n: 100
+  checkpoints_period: 50
+
+n_samples: 50
+
+hydra:
+  run:
+    dir: ${user.logdir.root}/s3gfn_toy/s3gfn/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/config/experiments/s3gfn_toy/tb_replay.yaml
+++ b/config/experiments/s3gfn_toy/tb_replay.yaml
@@ -1,0 +1,75 @@
+# @package _global_
+# Toy TB baseline with reward-prioritized replay enabled.
+
+defaults:
+  - override /env: toy
+  - override /gflownet: trajectorybalance
+  - override /loss: trajectorybalance
+  - override /proxy: toy
+  - override /logger: wandb
+
+buffer:
+  replay_capacity: 20
+  reject_duplicate_trajectories: false
+  test:
+    type: all
+
+negative_buffer:
+  _target_: gflownet.buffer.base.BaseBuffer
+  replay_capacity: 20
+  reject_duplicate_trajectories: false
+  train:
+    type: null
+  test:
+    type: null
+
+env:
+  infeasible_states:
+    - s3
+    - s4
+
+gflownet:
+  random_action_prob: 0.1
+  optimizer:
+    batch_size:
+      forward: 10
+      backward_replay: 5
+      backward_dataset: 0
+    lr: 0.001
+    z_dim: 8
+    lr_z_mult: 100
+    n_train_steps: 50
+  replay_sampling: permutation
+
+policy:
+  forward:
+    type: mlp
+    n_hid: 64
+    n_layers: 2
+  backward:
+    shared_weights: True
+
+logger:
+  do:
+    online: False
+  lightweight: True
+  project_name: "s3gfn_toy"
+  run_name: "Toy TB replay"
+  tags:
+    - gflownet
+    - s3gfn
+    - toy
+    - tb
+    - replay
+
+evaluator:
+  first_it: True
+  period: 25
+  n: 100
+  checkpoints_period: 50
+
+n_samples: 50
+
+hydra:
+  run:
+    dir: ${user.logdir.root}/s3gfn_toy/tb_replay/${now:%Y-%m-%d_%H-%M-%S_%f}

--- a/config/loss/s3gfn.yaml
+++ b/config/loss/s3gfn.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - base
+
+_target_: gflownet.losses.s3gfn.S3TrajectoryBalance
+
+aux_weight: 10.0

--- a/gflownet/buffer/base.py
+++ b/gflownet/buffer/base.py
@@ -39,6 +39,7 @@ class BaseBuffer:
         test: Dict = None,
         use_main_buffer=False,
         check_diversity: bool = False,
+        reject_duplicate_trajectories: bool = False,
         diversity_check_reward_similarity: float = 0.1,
         progress_process_dataset: bool = False,
         **kwargs,
@@ -114,6 +115,7 @@ class BaseBuffer:
         self.test_config = self._process_data_config(test)
         self.use_main_buffer = use_main_buffer
         self.check_diversity = check_diversity
+        self.reject_duplicate_trajectories = reject_duplicate_trajectories
         self.diversity_check_reward_similarity = diversity_check_reward_similarity
         self.progress_process_dataset = progress_process_dataset
         if self.use_main_buffer:
@@ -288,7 +290,7 @@ class BaseBuffer:
         buffer : str
             Identifier of the buffer: main or replay
         criterion : str
-            Identifier of the criterion. Currently, only greater is implemented.
+            Identifier of the replay insertion criterion. Options: greater, fifo.
         """
         if torch.is_tensor(rewards):
             rewards = rewards.tolist()
@@ -316,10 +318,12 @@ class BaseBuffer:
                 self.replay_updated = False
                 if criterion == "greater":
                     self.replay = self._add_greater(samples, trajectories, rewards, it)
+                elif criterion == "fifo":
+                    self.replay = self._add_fifo(samples, trajectories, rewards, it)
                 else:
                     raise ValueError(
-                        f"Unknown criterion identifier. Received {buffer}, "
-                        "expected greater"
+                        f"Unknown criterion identifier. Received {criterion}, "
+                        "expected greater or fifo"
                     )
         else:
             raise ValueError(
@@ -361,6 +365,58 @@ class BaseBuffer:
         self.save_replay()
         return self.replay
 
+    def _add_fifo(
+        self,
+        samples: List,
+        trajectories: List,
+        rewards: List,
+        it: int,
+    ):
+        """
+        Adds a batch of samples to the replay buffer in FIFO order.
+
+        New samples are appended until the replay capacity is reached. Once full, the
+        oldest sample is evicted before appending the next sample.
+        """
+        for sample, traj, reward in zip(samples, trajectories, rewards):
+            self._add_fifo_single_sample(sample, traj, reward, it)
+        self.save_replay()
+        return self.replay
+
+    def _add_fifo_single_sample(self, sample, trajectory, reward, it):
+        """
+        Adds one sample to replay with first-in first-out eviction.
+        """
+        if self._has_duplicate_trajectory(trajectory):
+            return
+
+        if len(self.replay) >= self.replay_capacity:
+            self.replay.drop(self.replay.index[0], inplace=True)
+
+        self.replay_updated = True
+        if torch.is_tensor(sample):
+            sample = sample.tolist()
+        if torch.is_tensor(trajectory):
+            trajectory = trajectory.tolist()
+        if torch.is_tensor(reward):
+            reward = reward.item()
+        self.replay = pd.concat(
+            [
+                self.replay,
+                pd.DataFrame(
+                    {
+                        "samples": [sample],
+                        "trajectories": [trajectory],
+                        "rewards": [reward],
+                        "iter": [it],
+                        "samples_readable": [self.env.state2readable(sample)],
+                        "trajectories_readable": [self.env.traj2readable(trajectory)],
+                    }
+                ),
+            ],
+            ignore_index=True,
+        )
+
     # TODO: there may be issues with certain state types
     # TODO: add parameter(s) to control isclose()
     def _add_greater_single_sample(self, sample, trajectory, reward, it):
@@ -387,6 +443,9 @@ class BaseBuffer:
         -------
         self.replay : The updated replay buffer
         """
+        if self._has_duplicate_trajectory(trajectory):
+            return
+
         # If the buffer is not full, sample can be added to the buffer
         if len(self.replay) < self.replay_capacity:
             can_add = True
@@ -452,6 +511,22 @@ class BaseBuffer:
             ],
             ignore_index=True,
         )
+
+    def _has_duplicate_trajectory(self, trajectory) -> bool:
+        if not self.reject_duplicate_trajectories:
+            return False
+        trajectory = self._canonicalize_trajectory(trajectory)
+        for replay_trajectory in self.replay["trajectories"]:
+            if self._canonicalize_trajectory(replay_trajectory) == trajectory:
+                return True
+        return False
+
+    def _canonicalize_trajectory(self, trajectory):
+        if torch.is_tensor(trajectory):
+            trajectory = trajectory.tolist()
+        if isinstance(trajectory, (list, tuple)):
+            return tuple(self._canonicalize_trajectory(item) for item in trajectory)
+        return trajectory
 
     def make_data_set(self, config):
         """

--- a/gflownet/envs/base.py
+++ b/gflownet/envs/base.py
@@ -1047,6 +1047,15 @@ class GFlowNetEnv:
         """
         return readable
 
+    def check_feasibility(self, states: List) -> List[bool]:
+        """
+        Labels states as feasible for S3GFN-style positive/negative splitting.
+
+        By default, all states are feasible. Environments with domain-specific
+        feasibility criteria should override this method.
+        """
+        return [True] * len(states)
+
     def traj2readable(self, traj=None):
         """
         Converts a trajectory into a human-readable string.

--- a/gflownet/envs/toy.py
+++ b/gflownet/envs/toy.py
@@ -8,7 +8,7 @@ defined as in Figure 2 of the GFlowNet Foundations paper, Bengio et al (JMLR, 20
 """
 
 import random
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import torch.nn.functional as F
 from torchtyping import TensorType
@@ -72,8 +72,12 @@ class Toy(GFlowNetEnv):
             10: (-1,),
         },
         action_space_only_valid: bool = True,
+        infeasible_states: Optional[List[Union[int, str, List[int]]]] = None,
         **kwargs,
     ):
+        self.infeasible_states = {
+            self._parse_state_idx(state) for state in infeasible_states or []
+        }
         # Convert the iterable with the target states in connections into a tuple for
         # efficiency
         self.connections = {k: tuple(v) for k, v in connections.items()}
@@ -296,6 +300,24 @@ class Toy(GFlowNetEnv):
         A state in environment format.
         """
         return [int(readable.strip("s"))]
+
+    def check_feasibility(self, states: List[List[int]]) -> List[bool]:
+        """
+        Labels toy states as feasible according to optional state-index constraints.
+        """
+        if self.infeasible_states:
+            return [state[0] not in self.infeasible_states for state in states]
+        return [True] * len(states)
+
+    @staticmethod
+    def _parse_state_idx(state: Union[int, str, List[int], Tuple[int]]) -> int:
+        if isinstance(state, int):
+            return state
+        if isinstance(state, str):
+            return int(state.strip().lstrip("s"))
+        if isinstance(state, (list, tuple)) and len(state) == 1:
+            return int(state[0])
+        raise ValueError(f"Could not parse toy state identifier: {state}")
 
     def get_all_terminating_states(self) -> List[List[int]]:
         """

--- a/gflownet/evaluator/base.py
+++ b/gflownet/evaluator/base.py
@@ -372,17 +372,25 @@ class BaseEvaluator(AbstractEvaluator):
             assert batch.is_valid()
             x_sampled = batch.get_terminating_states()
 
-            if "density_true" in dict_tt:
+            feasible = np.array(self.gfn.env.check_feasibility(x_tt), dtype=bool)
+            has_infeasible = not np.all(feasible)
+
+            if "density_true" in dict_tt and not has_infeasible:
                 density_true = torch2np(dict_tt["density_true"])
             else:
                 rewards = torch2np(
                     self.gfn.proxy.rewards(self.gfn.env.states2proxy(x_tt))
                 )
+                rewards = rewards * feasible
                 z_true = rewards.sum()
-                density_true = rewards / z_true
-                with open(self.gfn.buffer.test_config.pkl, "wb") as f:
-                    dict_tt["density_true"] = density_true
-                    pickle.dump(dict_tt, f)
+                if z_true <= 0:
+                    density_true = np.zeros_like(rewards)
+                else:
+                    density_true = rewards / z_true
+                    if not has_infeasible:
+                        with open(self.gfn.buffer.test_config.pkl, "wb") as f:
+                            dict_tt["density_true"] = density_true
+                            pickle.dump(dict_tt, f)
             hist = defaultdict(int)
             for x in x_sampled:
                 hist[tuple(x)] += 1

--- a/gflownet/gflownet.py
+++ b/gflownet/gflownet.py
@@ -51,6 +51,7 @@ class GFlowNetAgent:
         logger,
         evaluator,
         state_flow=None,
+        negative_buffer=None,
         use_context=False,
         replay_sampling="permutation",
         train_sampling="permutation",
@@ -79,6 +80,8 @@ class GFlowNetAgent:
             Optimizer config dictionary. See gflownet.yaml:optimizer for details.
         buffer : dict
             Buffer config dictionary. See gflownet.yaml:buffer for details.
+        negative_buffer : dict, optional
+            Optional buffer used to store infeasible terminal samples for S3GFN.
         forward_policy : gflownet.policy.base.Policy
             The forward policy to be used for training. Parameterized from
             `gflownet.yaml:forward_policy` and parsed with
@@ -160,6 +163,7 @@ class GFlowNetAgent:
         self.replay_sampling = replay_sampling
         self.train_sampling = train_sampling
         self.buffer = buffer
+        self.negative_buffer = negative_buffer
         # Train set statistics and reward normalization constant
         if self.buffer.train is not None:
             scores_stats_tr = [
@@ -740,6 +744,112 @@ class GFlowNetAgent:
 
         return batch, times
 
+    def _build_backward_batch_from_replay(
+        self,
+        replay,
+        n_samples: int,
+        sampling_mode: str,
+        replay_buffer,
+        env_instances: List[GFlowNetEnv],
+        env_cond: Optional[GFlowNetEnv] = None,
+        train: bool = True,
+    ):
+        batch_replay = Batch(
+            env=self.env,
+            proxy=self.proxy,
+            device=self.device,
+            float_type=self.float,
+            collect_forwards_masks=True,
+            collect_backwards_masks=self.collect_backwards_masks,
+        )
+        if n_samples <= 0 or replay is None or len(replay) == 0:
+            return batch_replay
+
+        envs = [env_instances.pop().reset(idx) for idx in range(n_samples)]
+        x_replay = replay_buffer.select(
+            replay,
+            n_samples,
+            sampling_mode,
+            self.rng,
+        )["samples"].values.tolist()
+        for env, x in zip(envs, x_replay):
+            env.set_state(x, done=True)
+
+        while envs:
+            actions, logprobs, logprobs_rev = self.sample_actions(
+                envs,
+                batch_replay,
+                env_cond,
+                backward=True,
+                no_random=not train,
+                compute_reversed_logprobs=self.collect_reversed_logprobs,
+            )
+            envs, actions, valids = self.step(envs, actions, backward=True)
+            batch_replay.add_to_batch(
+                envs,
+                actions,
+                logprobs,
+                logprobs_rev,
+                valids,
+                backward=True,
+                train=train,
+            )
+            envs = [env for env in envs if not env.equal(env.state, env.source)]
+        return batch_replay
+
+    def _s3gfn_replay_update(self):
+        zero = torch.zeros((), device=self.device, dtype=self.float)
+        losses = {
+            "replay_tb": zero,
+            "aux": zero,
+            "all": zero,
+        }
+        n_aux = self.batch_size.backward_replay
+        if (
+            n_aux <= 0
+            or self.negative_buffer is None
+            or self.buffer.replay is None
+            or self.negative_buffer.replay is None
+            or len(self.buffer.replay) == 0
+            or len(self.negative_buffer.replay) == 0
+        ):
+            return losses
+
+        env_instances = [self.env_maker() for _ in range(2 * n_aux)]
+        batch_pos = self._build_backward_batch_from_replay(
+            self.buffer.replay,
+            n_aux,
+            self.replay_sampling,
+            self.buffer,
+            env_instances,
+        )
+        batch_neg = self._build_backward_batch_from_replay(
+            self.negative_buffer.replay,
+            n_aux,
+            "uniform",
+            self.negative_buffer,
+            env_instances,
+        )
+        if len(batch_pos) == 0 or len(batch_neg) == 0:
+            return losses
+
+        losses = self.loss.compute_replay_loss(batch_pos, batch_neg)
+        if not all([torch.isfinite(loss) for loss in losses.values()]):
+            if self.logger.debug:
+                print("S3GFN replay loss is not finite - skipping replay update")
+            return {
+                "replay_tb": zero,
+                "aux": zero,
+                "all": zero,
+            }
+        losses["all"].backward()
+        if self.clip_grad_norm > 0:
+            torch.nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_norm)
+        self.opt.step()
+        self.lr_scheduler.step()
+        self.opt.zero_grad()
+        return losses
+
     @torch.no_grad()
     def estimate_logprobs_data(
         self,
@@ -949,6 +1059,7 @@ class GFlowNetAgent:
                 self.evaluator.eval_and_log_top_k(self.it)
 
             t0_iter = time.time()
+            is_s3gfn = getattr(self.loss, "uses_s3gfn_aux", False)
             batch = Batch(
                 env=self.env,
                 proxy=self.proxy,
@@ -959,7 +1070,7 @@ class GFlowNetAgent:
                 sub_batch, times = self.sample_batch(
                     n_forward=self.batch_size.forward,
                     n_train=self.batch_size.backward_dataset,
-                    n_replay=self.batch_size.backward_replay,
+                    n_replay=0 if is_s3gfn else self.batch_size.backward_replay,
                     collect_forwards_masks=True,
                     collect_backwards_masks=self.collect_backwards_masks,
                 )
@@ -979,6 +1090,14 @@ class GFlowNetAgent:
                     self.opt.step()
                     self.lr_scheduler.step()
                     self.opt.zero_grad()
+            if is_s3gfn:
+                replay_losses = self._s3gfn_replay_update()
+                losses = {
+                    "tb": losses["all"],
+                    "replay_tb": replay_losses["replay_tb"],
+                    "aux": replay_losses["aux"],
+                    "all": losses["all"] + replay_losses["all"],
+                }
 
             # Log training iteration: progress bar, buffer, metrics, intermediate
             # models
@@ -1020,6 +1139,54 @@ class GFlowNetAgent:
         # Close logger
         if self.use_context is False:
             self.logger.end()
+
+    def _add_split_replay(self, states, trajectories, rewards, feasible):
+        """
+        Adds feasible samples to the main replay buffer and infeasible samples to the
+        optional negative replay buffer.
+        """
+        self.buffer.replay_updated = False
+        self.negative_buffer.replay_updated = False
+        if torch.is_tensor(rewards):
+            rewards_list = rewards.tolist()
+        else:
+            rewards_list = rewards
+
+        positives = [
+            (state, traj, reward)
+            for state, traj, reward, is_feasible in zip(
+                states, trajectories, rewards_list, feasible
+            )
+            if is_feasible
+        ]
+        negatives = [
+            (state, traj, reward)
+            for state, traj, reward, is_feasible in zip(
+                states, trajectories, rewards_list, feasible
+            )
+            if not is_feasible
+        ]
+
+        if positives:
+            pos_states, pos_trajs, pos_rewards = zip(*positives)
+            self.buffer.add(
+                list(pos_states),
+                list(pos_trajs),
+                list(pos_rewards),
+                self.it,
+                buffer="replay",
+                criterion="greater",
+            )
+        if negatives:
+            neg_states, neg_trajs, neg_rewards = zip(*negatives)
+            self.negative_buffer.add(
+                list(neg_states),
+                list(neg_trajs),
+                list(neg_rewards),
+                self.it,
+                buffer="replay",
+                criterion="fifo",
+            )
 
     @torch.no_grad()
     def log_train_iteration(self, pbar: tqdm, losses: List, batch: Batch, times: dict):
@@ -1080,13 +1247,22 @@ class GFlowNetAgent:
             )
 
         # Update replay buffer
-        self.buffer.add(
-            states_term,
-            actions_trajectories,
-            rewards,
-            self.it,
-            buffer="replay",
-        )
+        if self.negative_buffer is None:
+            self.buffer.add(
+                states_term,
+                actions_trajectories,
+                rewards,
+                self.it,
+                buffer="replay",
+            )
+        else:
+            feasible = self.env.check_feasibility(states_term)
+            self._add_split_replay(
+                states_term,
+                actions_trajectories,
+                rewards,
+                feasible,
+            )
         t1_buffer = time.time()
         times.update({"buffer": t1_buffer - t0_buffer})
 

--- a/gflownet/losses/__init__.py
+++ b/gflownet/losses/__init__.py
@@ -18,4 +18,10 @@
 
 """
 
-__all__ = ["flowmatching", "trajectorybalance", "detailedbalance", "forwardlooking"]
+__all__ = [
+    "flowmatching",
+    "trajectorybalance",
+    "detailedbalance",
+    "forwardlooking",
+    "s3gfn",
+]

--- a/gflownet/losses/s3gfn.py
+++ b/gflownet/losses/s3gfn.py
@@ -1,0 +1,80 @@
+"""
+S3GFN loss variants.
+"""
+
+import math
+
+import torch
+
+from gflownet.losses.trajectorybalance import TrajectoryBalance
+from gflownet.utils.batch import Batch, compute_logprobs_trajectories
+
+
+class S3TrajectoryBalance(TrajectoryBalance):
+    """
+    Trajectory Balance with an S3GFN contrastive auxiliary loss.
+    """
+
+    uses_s3gfn_aux = True
+
+    def __init__(self, aux_weight: float = 1.0, **kwargs):
+        super().__init__(**kwargs)
+        self.aux_weight = aux_weight
+        self.name = "S3 Trajectory Balance"
+        self.acronym = "S3TB"
+        self.id = "s3gfn"
+
+    def compute(self, batch: Batch, get_sublosses: bool = False):
+        losses = self.compute_losses_of_batch(batch)
+        aggregated = self.aggregate_losses_of_batch(losses, batch)
+        if get_sublosses:
+            return aggregated
+        return aggregated["all"]
+
+    def aggregate_losses_of_batch(self, losses, batch: Batch) -> dict[str, float]:
+        tb_loss = losses.mean()
+        return {
+            "tb": tb_loss,
+            "all": tb_loss,
+        }
+
+    def compute_replay_loss(self, pos_batch: Batch, neg_batch: Batch):
+        zero = torch.zeros((), device=self.device, dtype=self.float)
+        if (
+            pos_batch is None
+            or neg_batch is None
+            or len(pos_batch) == 0
+            or len(neg_batch) == 0
+        ):
+            return {
+                "replay_tb": zero,
+                "aux": zero,
+                "all": zero,
+            }
+
+        replay_tb = self.compute_losses_of_batch(pos_batch).mean()
+        aux_loss = self._compute_aux_loss(pos_batch, neg_batch)
+        return {
+            "replay_tb": replay_tb,
+            "aux": aux_loss,
+            "all": replay_tb + self.aux_weight * aux_loss,
+        }
+
+    def _compute_aux_loss(self, pos_batch: Batch, neg_batch: Batch):
+        seq_logprobs = compute_logprobs_trajectories(
+            pos_batch, forward_policy=self.forward_policy, backward=False
+        )
+        neg_seq_logprobs = compute_logprobs_trajectories(
+            neg_batch, forward_policy=self.forward_policy, backward=False
+        )
+        if seq_logprobs.numel() == 0 or neg_seq_logprobs.numel() == 0:
+            return torch.zeros((), device=self.device, dtype=self.float)
+
+        pos_seq_logprobs = seq_logprobs
+        neg_log_sum = torch.logsumexp(neg_seq_logprobs, dim=0) - math.log(
+            max(neg_seq_logprobs.numel(), 1.0)
+        )
+        aux_loss = -(
+            pos_seq_logprobs - torch.logaddexp(pos_seq_logprobs, neg_log_sum)
+        ).mean()
+        return aux_loss

--- a/gflownet/utils/common.py
+++ b/gflownet/utils/common.py
@@ -290,6 +290,16 @@ def gflownet_from_config(config, env=None):
         proxy=proxy,
         datadir=logger.datadir,
     )
+    negative_buffer = None
+    if config.get("negative_buffer") is not None:
+        negative_datadir = logger.datadir / "negative"
+        negative_datadir.mkdir(parents=True, exist_ok=True)
+        negative_buffer = instantiate(
+            config.negative_buffer,
+            env=env,
+            proxy=proxy,
+            datadir=negative_datadir,
+        )
 
     # The evaluator is used to compute metrics and plots
     evaluator = instantiate(config.evaluator)
@@ -346,6 +356,7 @@ def gflownet_from_config(config, env=None):
         backward_policy=backward_policy,
         state_flow=state_flow,
         buffer=buffer,
+        negative_buffer=negative_buffer,
         logger=logger,
         evaluator=evaluator,
     )

--- a/scripts/s3gfn_toy/run_s3gfn.sh
+++ b/scripts/s3gfn_toy/run_s3gfn.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /network/scratch/k/kimh/projects/gflownet
+
+"${PYTHON:-python3}" train.py +experiments=s3gfn_toy/s3gfn "$@"

--- a/scripts/s3gfn_toy/run_tb_replay.sh
+++ b/scripts/s3gfn_toy/run_tb_replay.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /network/scratch/k/kimh/projects/gflownet
+
+"${PYTHON:-python3}" train.py +experiments=s3gfn_toy/tb_replay "$@"

--- a/train.py
+++ b/train.py
@@ -6,6 +6,7 @@ import os
 import pickle
 import random
 import sys
+from collections import Counter
 from pathlib import Path
 
 import hydra
@@ -40,7 +41,21 @@ def main(config):
     # Sample from trained GFlowNet
     # TODO: move to method in GFlowNet agent, like sample_and_log()
     if config.n_samples > 0 and config.n_samples <= 1e5:
-        batch, times = gflownet.sample_batch(n_forward=config.n_samples, train=False)
+        if config.env.id == "toy":
+            random_action_prob = gflownet.random_action_prob
+            try:
+                gflownet.random_action_prob = 0.0
+                batch, times = gflownet.sample_batch(
+                    n_forward=config.n_samples,
+                    train=True,
+                )
+            finally:
+                gflownet.random_action_prob = random_action_prob
+        else:
+            batch, times = gflownet.sample_batch(
+                n_forward=config.n_samples,
+                train=False,
+            )
         x_sampled = batch.get_terminating_states(proxy=True)
         energies = gflownet.proxy(x_sampled)
         x_sampled = batch.get_terminating_states()
@@ -55,11 +70,9 @@ def main(config):
         df.to_csv(samples_dir / "gfn_samples.csv")
         dct = {"x": x_sampled, "energy": energies}
         pickle.dump(dct, open(samples_dir / "gfn_samples.pkl", "wb"))
-
-    # Print replay buffer
-    if len(gflownet.buffer.replay) > 0:
-        print("\nReplay buffer:")
-        print(gflownet.buffer.replay)
+        if config.env.id == "toy":
+            n_trj = min(len(x_sampled), 100)
+            save_toy_sample_summary(gflownet, x_sampled, batch, n_trj)
 
     # Close logger
     # TODO: make it gflownet.end() - perhaps there are other things to end
@@ -75,6 +88,34 @@ def set_seeds(seed):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
+
+
+def save_toy_sample_summary(gflownet, x_sampled, batch, n_trajectories=20):
+    """
+    Saves a compact readable summary of the final Toy samples.
+    """
+    readable_states = [gflownet.env.state2readable(x) for x in x_sampled]
+    state_counts = Counter(readable_states)
+    lines = []
+    lines.append("Final Toy evaluation samples:")
+    lines.append("Final state counts:")
+    for state, count in sorted(
+        state_counts.items(), key=lambda item: int(item[0].lstrip("s"))
+    ):
+        lines.append(f"  {state}: {count}")
+
+    lines.append(f"First {min(n_trajectories, len(readable_states))} trajectories:")
+    for idx, trajectory in enumerate(
+        batch.get_actions_trajectories()[:n_trajectories], start=1
+    ):
+        lines.append(f"  {idx:02d}: {gflownet.env.traj2readable(trajectory)}")
+
+    summary_path = gflownet.logger.logdir / "toy_final_summary.txt"
+    with open(summary_path, "w") as f:
+        f.write("\n".join(lines))
+        f.write("\n")
+
+    print(f"Saved final Toy evaluation summary to {summary_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# S3GFN Implementation

## S3GFN (New files)

Added `gflownet.losses.s3gfn.S3TrajectoryBalance`, inheriting the existing `TrajectoryBalance` loss.

Behavior:

- Non-S3GFN training keeps the original single merged-batch update logic.
- S3GFN uses a branch in `GFlowNetAgent.train()`:
  - normal TB update samples no replay (`n_replay=0`),
  - replay update is computed separately from positive and negative replay batches.
- The auxiliary sample count reuses `gflownet.optimizer.batch_size.backward_replay`.
- Positive auxiliary replay uses `gflownet.replay_sampling`.
- Negative auxiliary replay always uses `uniform` sampling in code.
- Replay update loss is positive replay TB plus `aux_weight * aux`.
- If either replay side is empty, replay update is skipped as zero losses.
- `config/loss/s3gfn.yaml` exposes only `aux_weight`.

Changed files:
- `gflownet/losses/__init__.py`
- `gflownet/losses/s3gfn.py`
- `config/loss/s3gfn.yaml`


To run experiment, 

- Toy TB + filtered positive buffer experiment:
  - `config/experiments/s3gfn_toy/s3gfn.yaml`
  - `scripts/s3gfn_toy/run_s3gfn.sh`

- Toy TB + filtered positive buffer experiment (baseline):
  - `config/experiments/s3gfn_toy/tb_replay.yaml`
  - `scripts/s3gfn_toy/run_tb_replay.sh`


Results (infeasible states are s3 and s4):

- Final state counts with S3GFN: (s3: 1, s6: 10, s8: 6, s9: 28, s10: 5)
- Final state counts with baseline: (s3: 16, s4: 9, s6: 3, s8: 4, s9: 15, s10: 2)



## Changes in shared logic

### Replay Buffer

Added a FIFO insertion criterion to `BaseBuffer.add(..., criterion="fifo")` and optional `reject_duplicate_trajectories` to skip trajectories already present in replay

Reason:

- S3GFN needs a negative replay buffer later.
- Negative replay should keep recent rejected samples without reward prioritization.
- `reject_duplicate_trajectories` is added since the buffer often contains the same trajectories only, especially with `criterion="greater"` in toy env (there are only few possible trajs)

Behavior:

- Appends replay samples while capacity is available.
- Once full, evicts the oldest replay row before appending the new sample.
- Leaves the existing `criterion="greater"` reward-prioritized replay path unchanged.
- Optional `reject_duplicate_trajectories` skips trajectories already present in replay.
- Duplicate checks run before FIFO eviction and before `greater` reward comparison.

Changed files:

- `gflownet/buffer/base.py`
- `config/buffer/base.yaml` (add `reject_duplicate_trajectories=False` as a defalut)



### Environment Feasibility Interface

Added an environment-owned feasibility hook: `GFlowNetEnv.check_feasibility(states)` in `gflownet/`

Reason:

- S3GFN needs a generic way to label terminal samples as positive or negative.
- Feasibility is environment-specific because each environment owns its state representation.
- Stage 2 intentionally does not affect sampling, replay insertion, rewards, losses, or optimization.

Behavior:

- `GFlowNetEnv.check_feasibility(states)` returns all positives by default.
- The detail logic for feasibility check should be implemented in each env class. For example,
  - `Toy` supports optional infeasible-state constraints such as `["s3", "s4"]`.
  - Toy infeasible-state constraints accept readable ids, numeric ids, and single-element states.
  - If Toy `infeasible_states` is empty, all states are feasible.


Changed files:

- `gflownet/envs/base.py`
- `gflownet/envs/toy.py`
- `config/env/toy.yaml` (add `infeasible_states`)



### Adding a negative buffer if configured

Added opt-in split replay storage using two `BaseBuffer` instances.

Reason:

- Keep `BaseBuffer` generic: each buffer owns one `.replay` dataframe.
- Keep existing replay training unchanged unless a `negative_buffer` is configured.

Behavior:

- `self.negative_buffer.replay` stores infeasible samples for contrastive training.
- Feasible samples are inserted with reward-prioritized `criterion="greater"`.
- Infeasible samples are inserted into the negative buffer with `criterion="fifo"`.
- If `negative_buffer` is not configured, the original single replay insertion path is used.
- Negative replay sampling should be fixed to `uniform` at the negative-replay sampling call site; it does not use `gflownet.replay_sampling` config.


Changed files:

- `gflownet/utils/common.py`
- `gflownet/gflownet.py`



### Feasibility-Aware Density Metrics

Updated discrete evaluator density metrics to account for infeasible states.

Behavior:

- Before computing the true density normalization constant `z_true`, rewards for infeasible states are set to zero using `env.check_feasibility(...)`.
- If all test states are infeasible and `z_true <= 0`, the true density is set to zeros to avoid division by zero.
- Cached `density_true` is reused only when all states are feasible. When feasibility masks out any state, density is recomputed so stale unconstrained cache values are not used.


Changed files:

- `gflownet/evaluator/base.py`



### Logging experimental results

Added logs for toy env for debugging and analysis

Behavior:
- Final sample logging remains under `samples/gfn_samples.csv` and `samples/gfn_samples.pkl`.
- For Toy only, final sampling temporarily sets `gflownet.random_action_prob = 0.0`, samples with `train=True`, then restores the original value.
- For Toy only, writes `toy_final_summary.txt` in the run log directory.
- The Toy summary contains final readable state counts and the first `min(n_samples, 100)` readable trajectories.
- The script prints the Toy summary path after saving.
- Non-Toy environments keep the original final sampling path with `train=False`.

Changed files:

- `train.py`
