### PR TITLE
[Ctorus] Fix bugs for diffusion

### DIFF
--- a/config/env/ctorus.yaml
+++ b/config/env/ctorus.yaml
@@ -11,11 +11,7 @@ policy_encoding_dim_per_angle: null
 length_traj: 3
 vonmises_min_concentration: 1e-3
 # Parameters of the fixed policy output distribution
+distr_type: von_mises
 n_comp: 3
-fixed_distr_params:
-  vonmises_mean: 0.0
-  vonmises_concentration: 1.0
-# Parameters of the random policy output distribution
-random_distr_params:
-  vonmises_mean: 0.0
-  vonmises_concentration: 0.01
+fixed_distr_params: null
+random_distr_params: null

--- a/gflownet/envs/ctorus.py
+++ b/gflownet/envs/ctorus.py
@@ -19,6 +19,7 @@ from torchtyping import TensorType
 from gflownet.envs.base import GFlowNetEnv
 from gflownet.utils.common import copy, tfloat, torch2np
 from gflownet.utils.metrics import angles_allclose
+from gflownet.utils.molecule.distributions import WrappedNormal
 
 
 class ContinuousTorus(GFlowNetEnv):

--- a/gflownet/envs/ctorus.py
+++ b/gflownet/envs/ctorus.py
@@ -793,15 +793,8 @@ class ContinuousTorus(GFlowNetEnv):
             distr_angles = MixtureSameFamily(mix, vonmises)
 
         elif self.distr_type == "diffusion":
-            stds = self.convert_timesteps_to_stds(timesteps, cumulative=False)
-            assert self.n_comp == 1
-            if is_backward == False:
-                # At convergence, score should be equal to grad_logp(x_t)
-                score = policy_outputs.reshape(-1, self.n_dim)
-                # since x_{t+1} = x_t + score * std_t^2 + N(0, std_t^2), the increment
-                # mean is equal to score * std_t^2
-                means = score * torch.pow(stds.unsqueeze(1).repeat(1, 2), 2)
-            else:
+            means, stds = params["means"], params["stds"]
+            if is_backward:
                 # For diffusion models, the backwards policy is fixed and not learned.
                 # Here, we force the backwards variance-exploding policy, i.e. x_{t-1}
                 # = x_t + N(0, std_t^2)

--- a/gflownet/utils/molecule/distributions.py
+++ b/gflownet/utils/molecule/distributions.py
@@ -29,56 +29,60 @@ class WrappedNormal:
 
     See equation (3) in https://arxiv.org/pdf/2206.01729 for the definition.
 
-    Attributes:
-        means (torch.Tensor): Mean of the underlying unwrapped Gaussian,
-            of shape (batch_size, n_dims).
-        stds (torch.Tensor): Standard deviation of the underlying unwrapped
-            Gaussian, of shape (batch_size,). Broadcast across `n_dims` when
-            used in `prob`/`sample`.
-        N (int): Number of wraps considered on each side of the circle when
-            approximating the infinite wrapping sum. The sum runs over
-            `2 * N + 1` shifted Gaussians (from -N to +N).
+    Attributes
+    ----------
+    means : torch.Tensor
+        Mean of the underlying unwrapped Gaussian, of shape ``(batch_size, n_dims)``.
+    stds : torch.Tensor
+        Standard deviation of the underlying unwrapped Gaussian, of shape
+        ``(batch_size,)``. Broadcast across ``n_dims`` when used in ``prob`` /
+        ``sample``.
+    N : int
+        Number of wraps considered on each side of the circle when approximating the
+        infinite wrapping sum. The sum runs over ``2 * N + 1`` shifted Gaussians (from
+        -N to +N).
     """
 
     def __init__(self, means, stds, N=10):
         """
         Parameters
         ----------
-            means (torch.Tensor): Mean of the unwrapped Gaussian,
-                shape (batch_size, n_dims).
-            stds (torch.Tensor): Standard deviation of the unwrapped Gaussian,
-                shape (batch_size,).
-            N (int, optional): Number of times to wrap around the circle in
-                each direction when approximating the wrapped density.
-                Higher values give a more accurate approximation at the cost
-                of more computation. Defaults to 10.
+        means : torch.Tensor
+            Mean of the unwrapped Gaussian, shape ``(batch_size, n_dims)``.
+        stds : torch.Tensor
+            Standard deviation of the unwrapped Gaussian, shape ``(batch_size,)``.
+        N : int, optional
+            Number of times to wrap around the circle in each direction when
+            approximating the wrapped density. Higher values give a more accurate
+            approximation at the cost of more computation. Defaults to 10.
         """
-        self.means = means  # shape : batch_size, n_dims
-        self.stds = stds  # shape : batch_size,
-        self.N = N  # number of times to wrap around the circle
+        self.means = means
+        self.stds = stds
+        self.N = N
 
     def prob(self, actions):
         """
         Compute the (unnormalized) wrapped normal density at `actions`.
 
         Approximates the wrapped normal density by summing the unwrapped
-        Gaussian density over `2 * self.N + 1` copies of `actions`, shifted
+        Gaussian density over ``2 * self.N + 1`` copies of ``actions``, shifted
         by integer multiples of 2*pi.
 
-        Note: The returned value omits the usual `1 / (std * sqrt(2*pi))`
+        Note: The returned value omits the usual ``1 / (std * sqrt(2*pi))``
         normalization constant, so it is proportional to, but not exactly
         equal to, the true probability density.
 
         Parameters
         ----------
-            actions (torch.Tensor): Points at which to evaluate the density,
-                broadcastable against `self.means`.
+        actions : torch.Tensor
+            Points at which to evaluate the density, broadcastable against
+            ``self.means``.
 
         Returns
         -------
-            torch.Tensor: Unnormalized wrapped normal density evaluated at
-            `actions`, same shape as the broadcast of `actions` and
-            `self.means`.
+        torch.Tensor
+            Unnormalized wrapped normal density evaluated at ``actions``, same shape as
+            the broadcast of ``actions`` and ``self.means``.
         """
         # TODO: consider using logsumexp instead and computing everything in logscale
         # TODO: why it is not normalised? figure this out, this might be a bug
@@ -97,12 +101,14 @@ class WrappedNormal:
 
         Parameters
         ----------
-            actions (torch.Tensor): Points at which to evaluate the
-                log-density, broadcastable against `self.means`.
+        actions : torch.Tensor
+            Points at which to evaluate the log-density, broadcastable against
+            ``self.means``.
 
         Returns
         -------
-            torch.Tensor: Log of `self.prob(actions)`.
+        torch.Tensor
+            Log of ``self.prob(actions)``.
         """
         return torch.log(self.prob(actions))
 
@@ -115,14 +121,15 @@ class WrappedNormal:
 
         Parameters
         ----------
-            n_samples (torch.Size or tuple, optional): Sample shape to draw.
-                If None, a single sample matching the shape of `self.means`
-                is returned. Defaults to None.
+        n_samples : torch.Size or tuple, optional
+            Sample shape to draw.  If None, a single sample matching the shape of
+            ``self.means`` is returned. Defaults to None.
 
         Returns
         -------
-            torch.Tensor: Samples wrapped into `[0, 2*pi)`, with shape
-            determined by `n_samples` (if given) or by `self.means`.
+        torch.Tensor
+            Samples wrapped into ``[0, 2*pi)``, with shape determined by ``n_samples``
+            (if given) or by ``self.means``.
         """
         n_dims = self.means.shape[-1]
         unwrapped_gaussian = Normal(

--- a/gflownet/utils/molecule/distributions.py
+++ b/gflownet/utils/molecule/distributions.py
@@ -18,15 +18,70 @@ def get_mixture_of_projected_normals(weights, concentrations):
 
 class WrappedNormal:
     """
-    a class representing the wrapped normal distribution, see equation (3) in https://arxiv.org/pdf/2206.01729
+    Wrapped normal distribution on the circle.
+
+    The wrapped normal distribution is obtained by taking a standard (unwrapped)
+    Gaussian random variable defined on the real line and "wrapping" it around
+    the circle of circumference 2*pi, i.e. mapping x -> x mod 2*pi. Its density
+    is given by summing the ordinary Gaussian density over all integer shifts of
+    2*pi, which is approximated here by truncating the (infinite) sum to `N`
+    terms in each direction.
+
+    See equation (3) in https://arxiv.org/pdf/2206.01729 for the definition.
+
+    Attributes:
+        means (torch.Tensor): Mean of the underlying unwrapped Gaussian,
+            of shape (batch_size, n_dims).
+        stds (torch.Tensor): Standard deviation of the underlying unwrapped
+            Gaussian, of shape (batch_size,). Broadcast across `n_dims` when
+            used in `prob`/`sample`.
+        N (int): Number of wraps considered on each side of the circle when
+            approximating the infinite wrapping sum. The sum runs over
+            `2 * N + 1` shifted Gaussians (from -N to +N).
     """
 
     def __init__(self, means, stds, N=10):
+        """
+        Parameters
+        ----------
+            means (torch.Tensor): Mean of the unwrapped Gaussian,
+                shape (batch_size, n_dims).
+            stds (torch.Tensor): Standard deviation of the unwrapped Gaussian,
+                shape (batch_size,).
+            N (int, optional): Number of times to wrap around the circle in
+                each direction when approximating the wrapped density.
+                Higher values give a more accurate approximation at the cost
+                of more computation. Defaults to 10.
+        """
         self.means = means  # shape : batch_size, n_dims
-        self.stds = stds  # shape : batch_size, n_dims
+        self.stds = stds  # shape : batch_size,
         self.N = N  # number of times to wrap around the circle
 
     def prob(self, actions):
+        """
+        Compute the (unnormalized) wrapped normal density at `actions`.
+
+        Approximates the wrapped normal density by summing the unwrapped
+        Gaussian density over `2 * self.N + 1` copies of `actions`, shifted
+        by integer multiples of 2*pi.
+
+        Note: The returned value omits the usual `1 / (std * sqrt(2*pi))`
+        normalization constant, so it is proportional to, but not exactly
+        equal to, the true probability density.
+
+        Parameters
+        ----------
+            actions (torch.Tensor): Points at which to evaluate the density,
+                broadcastable against `self.means`.
+
+        Returns
+        -------
+            torch.Tensor: Unnormalized wrapped normal density evaluated at
+            `actions`, same shape as the broadcast of `actions` and
+            `self.means`.
+        """
+        # TODO: consider using logsumexp instead and computing everything in logscale
+        # TODO: why it is not normalised? figure this out, this might be a bug
         p_ = 0
         for i in range(-self.N, self.N + 1):
             p_ += torch.exp(
@@ -37,9 +92,38 @@ class WrappedNormal:
         return p_
 
     def log_prob(self, actions):
+        """
+        Compute the log of the (unnormalized) wrapped normal density.
+
+        Parameters
+        ----------
+            actions (torch.Tensor): Points at which to evaluate the
+                log-density, broadcastable against `self.means`.
+
+        Returns
+        -------
+            torch.Tensor: Log of `self.prob(actions)`.
+        """
         return torch.log(self.prob(actions))
 
     def sample(self, n_samples=None):
+        """
+        Draw samples from the wrapped normal distribution.
+
+        Samples are drawn from the underlying unwrapped Gaussian and then
+        wrapped onto the circle via `mod 2*pi`.
+
+        Parameters
+        ----------
+            n_samples (torch.Size or tuple, optional): Sample shape to draw.
+                If None, a single sample matching the shape of `self.means`
+                is returned. Defaults to None.
+
+        Returns
+        -------
+            torch.Tensor: Samples wrapped into `[0, 2*pi)`, with shape
+            determined by `n_samples` (if given) or by `self.means`.
+        """
         n_dims = self.means.shape[-1]
         unwrapped_gaussian = Normal(
             self.means, self.stds.unsqueeze(1).repeat(1, n_dims)

--- a/gflownet/utils/molecule/distributions.py
+++ b/gflownet/utils/molecule/distributions.py
@@ -1,4 +1,7 @@
+import numpy as np
+import torch
 from pyro.distributions import ProjectedNormal
+from torch.distributions import Normal
 from torch.distributions.categorical import Categorical
 from torch.distributions.mixture_same_family import MixtureSameFamily
 
@@ -11,3 +14,38 @@ def get_mixture_of_projected_normals(weights, concentrations):
     mix = Categorical(weights)
     comp = ProjectedNormal(concentrations)
     return MixtureSameFamily(mix, comp)
+
+
+class WrappedNormal:
+    """
+    a class representing the wrapped normal distribution, see equation (3) in https://arxiv.org/pdf/2206.01729
+    """
+
+    def __init__(self, means, stds, N=10):
+        self.means = means  # shape : batch_size, n_dims
+        self.stds = stds  # shape : batch_size, n_dims
+        self.N = N  # number of times to wrap around the circle
+
+    def prob(self, actions):
+        p_ = 0
+        for i in range(-self.N, self.N + 1):
+            p_ += torch.exp(
+                -((actions - self.means + 2 * torch.pi * i) ** 2)
+                / 2
+                / (self.stds.unsqueeze(1).repeat(1, 2)) ** 2
+            )
+        return p_
+
+    def log_prob(self, actions):
+        return torch.log(self.prob(actions))
+
+    def sample(self, n_samples=None):
+        n_dims = self.means.shape[-1]
+        unwrapped_gaussian = Normal(
+            self.means, self.stds.unsqueeze(1).repeat(1, n_dims)
+        )
+        if n_samples is None:
+            sample = unwrapped_gaussian.sample() % (2 * torch.pi)
+        else:
+            sample = unwrapped_gaussian.sample(n_samples) % (2 * torch.pi)
+        return sample

--- a/tests/gflownet/envs/test_ctorus.py
+++ b/tests/gflownet/envs/test_ctorus.py
@@ -181,6 +181,7 @@ class TestContinuousTorusBasic(common.BaseTestsContinuous):
         }
         self.n_states = {}  # TODO: Populate.
 
+
 # copypasted from above but wuth env_diff instead of env
 class TestContinuousTorusDiffusion(common.BaseTestsContinuous):
     @pytest.fixture(autouse=True)

--- a/tests/gflownet/envs/test_ctorus.py
+++ b/tests/gflownet/envs/test_ctorus.py
@@ -22,6 +22,11 @@ def env_su():
     return ContinuousTorus(n_dim=2, length_traj=3, start_uniform=True)
 
 
+@pytest.fixture
+def env_diff():
+    return ContinuousTorus(n_dim=2, length_traj=3, distr_type="diffusion", n_copm=1)
+
+
 @pytest.mark.parametrize(
     "action_space",
     [
@@ -54,6 +59,14 @@ def test__get_action_space__returns_expected(env, action_space):
         ("env_su", [1.37, 2.49, 3.0], True, True, (np.inf, np.inf)),
         ("env_su", [0.0, 0.0, 1.0], False, True, (0.0, 0.0)),
         ("env_su", [1.37, 2.49, 1.0], False, True, (1.37, 2.49)),
+        ("env_diff", [0.0, 0.0, 3.0], False, False, (np.inf, np.inf)),
+        ("env_diff", [0.0, 0.0, 3.0], True, False, (np.inf, np.inf)),
+        ("env_diff", [0.0, 0.0, 3.0], True, True, (np.inf, np.inf)),
+        ("env_diff", [1.37, 2.49, 3.0], False, False, (np.inf, np.inf)),
+        ("env_diff", [1.37, 2.49, 3.0], True, False, (np.inf, np.inf)),
+        ("env_diff", [1.37, 2.49, 3.0], True, True, (np.inf, np.inf)),
+        ("env_diff", [0.0, 0.0, 1.0], False, True, (0.0, 0.0)),
+        ("env_diff", [1.37, 2.49, 1.0], False, True, (1.37, 2.49)),
     ],
 )
 def test__sample_actions_batch__special_cases(
@@ -100,6 +113,13 @@ def test__sample_actions_batch__special_cases(
         ("env_su", [0.0, 0.0, 2.0], False, True, (0.0, 0.0)),
         ("env_su", [1.37, 2.49, 2.0], False, True, (1.37, 2.49)),
         ("env_su", [1.37, 2.49, 1.0], False, False, (1.37, 2.49)),
+        ("env_diff", [0.0, 0.0, 2.0], False, False, (np.inf, np.inf)),
+        ("env_diff", [0.0, 0.0, 3.0], False, True, (np.inf, np.inf)),
+        ("env_diff", [1.37, 2.49, 2.0], False, False, (np.inf, np.inf)),
+        ("env_diff", [1.37, 2.49, 2.0], False, True, (np.inf, np.inf)),
+        ("env_diff", [0.0, 0.0, 2.0], False, True, (0.0, 0.0)),
+        ("env_diff", [1.37, 2.49, 2.0], False, True, (1.37, 2.49)),
+        ("env_diff", [1.37, 2.49, 1.0], False, False, (1.37, 2.49)),
     ],
 )
 def test__sample_actions_batch__not_special_cases(
@@ -134,6 +154,38 @@ class TestContinuousTorusBasic(common.BaseTestsContinuous):
     @pytest.fixture(autouse=True)
     def setup(self, env):
         self.env = env
+        self.repeats = {
+            "test__reset__state_is_source": 10,
+            "test__forward_actions_have_nonzero_backward_prob": 10,
+            "test__backward_actions_have_nonzero_forward_prob": 10,
+            "test__trajectories_are_reversible": 10,
+            "test__step_random__does_not_sample_invalid_actions_forward": 10,
+            "test__step_random__does_not_sample_invalid_actions_backward": 10,
+            "test__sample_actions__get_logprobs__return_valid_actions_and_logprobs": 10,
+            "test__get_parents_step_get_mask__are_compatible": 10,
+            "test__sample_backwards_reaches_source": 10,
+            "test__state2readable__is_reversible": 20,
+            "test__gflownet_minimal_runs": 3,
+        }
+        self.n_states = {
+            "test__backward_actions_have_nonzero_forward_prob": 10,
+            "test__sample_backwards_reaches_source": 10,
+            "test__get_logprobs__all_finite_in_random_forward_transitions": 10,
+            "test__get_logprobs__all_finite_in_random_backward_transitions": 10,
+        }
+        self.batch_size = {
+            "test__sample_actions__get_logprobs__batched_forward_trajectories": 10,
+            "test__sample_actions__get_logprobs__batched_backward_trajectories": 10,
+            "test__get_logprobs__all_finite_in_accumulated_forward_trajectories": 10,
+            "test__gflownet_minimal_runs": 10,
+        }
+        self.n_states = {}  # TODO: Populate.
+
+# copypasted from above but wuth env_diff instead of env
+class TestContinuousTorusDiffusion(common.BaseTestsContinuous):
+    @pytest.fixture(autouse=True)
+    def setup(self, env_diff):
+        self.env = env_diff
         self.repeats = {
             "test__reset__state_is_source": 10,
             "test__forward_actions_have_nonzero_backward_prob": 10,
@@ -255,6 +307,7 @@ def test__get_logprobs_start_uniform(env_su):
     [
         "env",
         "env_su",
+        "env_diff",
     ],
 )
 def test__backward_logprob(env_local, request):
@@ -266,11 +319,7 @@ def test__backward_logprob(env_local, request):
         mask = torch.unsqueeze(
             tbool(env.get_mask_invalid_actions_backward(), device=env.device), 0
         )
-        distr_params = {
-            "vonmises_mean": 0.0,
-            "vonmises_concentration": 8.0,
-        }
-        policy_output = env.get_policy_output(distr_params).unsqueeze(0)
+        policy_output = env.get_policy_output(env.fixed_distr_params).unsqueeze(0)
         actions = torch.tensor([angles])
         logprobs = env.get_logprobs(
             policy_output, actions, mask, [state], is_backward=True


### PR DESCRIPTION
In the #416 the diffusion distribution was added but some things were missing to be able to run it. This PR adds these missing pieces

Important notes about Wrapped normal distribution for the future:
1. In the current implementation there's no normalisation constant, we may need to add it.
2. Maybe we want to keep logprobs computation in the logscale

Comparing diffusion run in this branch with the conformer branch in dev: https://wandb.ai/alexandra-volokhova/gfn_sanity_checks/reports/-31-July-26-Ctorus-fixing-diffusion-bugs--VmlldzoxNzYzMTY5Nw 